### PR TITLE
Add optimization workflow routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ If you are trying to run Symphony directly on Windows, start here:
 
 - [Windows native setup guide](elixir/docs/windows-native.md)
 - [Windows workflow example](elixir/WORKFLOW.windows.example.md)
+- [Windows optimization workflow example](elixir/WORKFLOW.optimization.windows.example.md)
 - [PowerShell launcher](elixir/scripts/start-windows-native.ps1)
 
 The Windows path is experimental, but the local Linear -> Symphony -> Codex -> Linear loop has been

--- a/SPEC.md
+++ b/SPEC.md
@@ -358,6 +358,11 @@ Fields:
   - If `$VAR_NAME` resolves to an empty string, treat the key as missing.
 - `project_slug` (string)
   - REQUIRED for dispatch when `tracker.kind == "linear"`.
+- `labels` (list of strings)
+  - Optional candidate routing filter.
+  - Default: empty list, which means no label filter.
+  - When set, a candidate issue MUST have at least one matching label after case-insensitive
+    normalization.
 - `active_states` (list of strings)
   - Default: `Todo`, `In Progress`
 - `terminal_states` (list of strings)
@@ -574,6 +579,7 @@ not require recognizing or validating extension fields unless that extension is 
 - `tracker.endpoint`: string, default `https://api.linear.app/graphql` when `tracker.kind=linear`
 - `tracker.api_key`: string or `$VAR`, canonical env `LINEAR_API_KEY` when `tracker.kind=linear`
 - `tracker.project_slug`: string, REQUIRED when `tracker.kind=linear`
+- `tracker.labels`: list of strings, default `[]`
 - `tracker.active_states`: list of strings, default `["Todo", "In Progress"]`
 - `tracker.terminal_states`: list of strings, default `["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]`
 - `polling.interval_ms`: integer, default `30000`
@@ -1154,6 +1160,8 @@ Linear-specific requirements for `tracker.kind == "linear"`:
 - Auth token sent in `Authorization` header
 - `tracker.project_slug` maps to Linear project `slugId`
 - Candidate issue query filters project using `project: { slugId: { eq: $projectSlug } }`
+- Candidate issue routing MAY apply `tracker.labels` either in the Linear query or after issue
+  normalization, but before dispatch eligibility.
 - Issue-state refresh query uses GraphQL issue IDs with variable type `[ID!]`
 - Pagination REQUIRED for candidate issues
 - Page size default: `50`

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -70,6 +70,9 @@ Symphony stops the active agent for that issue and cleans up matching workspaces
 5. Customize the copied `WORKFLOW.md` file for your project.
    - To get your project's slug, right-click the project and copy its URL. The slug is part of the
      URL.
+   - `tracker.labels` is optional. When set, Symphony only dispatches candidate issues that have at
+     least one matching label. Prefer a fixed Linear project first; use labels when that project
+     must contain unrelated work.
    - When creating a workflow based on this repo, note that it depends on non-standard Linear
      issue statuses: "Rework", "Human Review", and "Merging". You can customize them in
      Team Settings → Workflow in Linear.
@@ -121,6 +124,8 @@ Minimal example:
 tracker:
   kind: linear
   project_slug: "..."
+  labels:
+    - symphony-optimization
 workspace:
   root: ~/code/workspaces
 hooks:

--- a/elixir/WORKFLOW.optimization.windows.example.md
+++ b/elixir/WORKFLOW.optimization.windows.example.md
@@ -1,0 +1,80 @@
+---
+tracker:
+  kind: linear
+  api_key: $LINEAR_API_KEY
+  project_slug: "e4ea95122cf7"
+  # Optional: uncomment only if this project is shared with unrelated work.
+  # labels:
+  #   - symphony-optimization
+  active_states:
+    - Todo
+    - In Progress
+  terminal_states:
+    - Done
+    - Canceled
+    - Cancelled
+    - Duplicate
+polling:
+  interval_ms: 5000
+workspace:
+  root: "D:/code/symphony-optimization-workspaces"
+hooks:
+  timeout_ms: 300000
+  after_create: |
+    $ErrorActionPreference = "Stop"
+    git clone --depth 1 https://github.com/albert-zen/symphony-windows-native.git .
+    git config user.email "codex-symphony@example.invalid"
+    git config user.name "Codex Symphony"
+    mise exec -- mix deps.get
+  before_remove: |
+    $ErrorActionPreference = "Stop"
+    git status --short
+agent:
+  max_concurrent_agents: 1
+  max_turns: 20
+codex:
+  command: codex --config shell_environment_policy.inherit=all --config model=gpt-5.5 --config model_reasoning_effort=medium app-server
+  approval_policy: never
+  thread_sandbox: danger-full-access
+  turn_sandbox_policy:
+    type: dangerFullAccess
+---
+
+You are running the Symphony optimization flywheel on Windows.
+
+Issue:
+- Identifier: {{ issue.identifier }}
+- Title: {{ issue.title }}
+- State: {{ issue.state }}
+- URL: {{ issue.url }}
+- Labels: {{ issue.labels }}
+
+Description:
+{% if issue.description %}
+{{ issue.description }}
+{% else %}
+No description provided.
+{% endif %}
+
+Operating model:
+
+1. Work only in the current workspace.
+2. If the Linear issue is Todo, move it to In Progress before implementation.
+3. Use exactly one Linear comment whose first line is `## Codex Workpad`; update it instead of creating progress spam.
+4. Use the linked GitHub issue as the durable public implementation spec.
+5. Keep changes focused on the current Linear/GitHub issue.
+6. Create a branch named `codex/<linear-identifier>-<short-topic>`.
+7. Run focused validation before committing.
+8. Commit the change and push the branch to `albert-zen/symphony-windows-native`.
+9. Open a GitHub pull request against `main` and link it in the Linear workpad.
+10. Move the Linear issue to `In Review` after the PR exists and validation is recorded.
+11. Do not move unrelated Backlog issues to Todo.
+12. If you discover an automation/system defect, create a GitHub issue with label `symphony-optimization` and add a Linear mirror in project `Symphony 优化` if the Linear tool is available.
+
+Quality bar:
+
+- Prefer small, reviewable changes.
+- Run `mix format` for touched Elixir files.
+- Run focused Windows-native tests when touching Windows runtime behavior.
+- Do not broaden scope to multiple optimization issues in one PR.
+- If blocked by credentials or permissions, record the exact blocker in the Workpad and move the issue to In Review.

--- a/elixir/WORKFLOW.optimization.windows.example.md
+++ b/elixir/WORKFLOW.optimization.windows.example.md
@@ -25,6 +25,9 @@ hooks:
     git clone --depth 1 https://github.com/albert-zen/symphony-windows-native.git .
     git config user.email "codex-symphony@example.invalid"
     git config user.name "Codex Symphony"
+    Set-Location elixir
+    mise trust
+    mise install
     mise exec -- mix deps.get
   before_remove: |
     $ErrorActionPreference = "Stop"

--- a/elixir/WORKFLOW.windows.example.md
+++ b/elixir/WORKFLOW.windows.example.md
@@ -3,6 +3,9 @@ tracker:
   kind: linear
   api_key: $LINEAR_API_KEY
   project_slug: "your-linear-project-slug"
+  # Optional: restrict candidate dispatch to issues with any of these labels.
+  # labels:
+  #   - symphony-optimization
   active_states:
     - Todo
     - In Progress

--- a/elixir/docs/windows-native.md
+++ b/elixir/docs/windows-native.md
@@ -78,6 +78,14 @@ Copy-Item .\WORKFLOW.windows.example.md .\WORKFLOW.windows.md
 notepad .\WORKFLOW.windows.md
 ```
 
+For the dedicated Symphony optimization flywheel, start from the fixed-project
+example instead:
+
+```powershell
+Copy-Item .\WORKFLOW.optimization.windows.example.md .\WORKFLOW.optimization.windows.md
+notepad .\WORKFLOW.optimization.windows.md
+```
+
 At minimum, change:
 
 - `tracker.project_slug`
@@ -98,6 +106,30 @@ Keep secrets out of the workflow file:
 tracker:
   api_key: $LINEAR_API_KEY
 ```
+
+### Optimization flywheel routing
+
+The optimization example targets the `Symphony 优化` Linear project by slug
+`e4ea95122cf7`. Keep `Backlog` out of `tracker.active_states`; parked issues
+remain invisible to Symphony until a human moves one issue at a time to `Todo`.
+
+Use this fixed-project route as the default boundary. If the same Linear project
+must later hold unrelated work, add `tracker.labels` to route only issues with
+at least one configured label:
+
+```yaml
+tracker:
+  project_slug: "e4ea95122cf7"
+  labels:
+    - symphony-optimization
+  active_states:
+    - Todo
+    - In Progress
+```
+
+The label match is case-insensitive and applies only to candidate dispatch.
+Already-running issues are still reconciled by their tracker state so Symphony
+can stop them cleanly when they move to a terminal state.
 
 ## Start Symphony
 
@@ -144,7 +176,8 @@ Set `tracker.active_states` to the states where agents should work, and
 ### Poll
 
 Symphony queries Linear for issues in the configured project whose state is in
-`active_states`.
+`active_states`. If `tracker.labels` is configured, candidates must also have
+at least one matching label.
 
 ### Claim and workspace
 

--- a/elixir/lib/symphony_elixir/codex/app_server.ex
+++ b/elixir/lib/symphony_elixir/codex/app_server.ex
@@ -41,11 +41,11 @@ defmodule SymphonyElixir.Codex.AppServer do
     worker_host = Keyword.get(opts, :worker_host)
 
     with {:ok, expanded_workspace} <- validate_workspace_cwd(workspace, worker_host),
+         {:ok, session_policies} <- session_policies(expanded_workspace, worker_host),
          {:ok, port} <- start_port(expanded_workspace, worker_host) do
       metadata = port_metadata(port, worker_host)
 
-      with {:ok, session_policies} <- session_policies(expanded_workspace, worker_host),
-           {:ok, thread_id} <- do_start_session(port, expanded_workspace, session_policies) do
+      with {:ok, thread_id} <- do_start_session(port, expanded_workspace, session_policies) do
         {:ok,
          %{
            port: port,

--- a/elixir/lib/symphony_elixir/codex/app_server.ex
+++ b/elixir/lib/symphony_elixir/codex/app_server.ex
@@ -45,20 +45,21 @@ defmodule SymphonyElixir.Codex.AppServer do
          {:ok, port} <- start_port(expanded_workspace, worker_host) do
       metadata = port_metadata(port, worker_host)
 
-      with {:ok, thread_id} <- do_start_session(port, expanded_workspace, session_policies) do
-        {:ok,
-         %{
-           port: port,
-           metadata: metadata,
-           approval_policy: session_policies.approval_policy,
-           auto_approve_requests: session_policies.approval_policy == "never",
-           thread_sandbox: session_policies.thread_sandbox,
-           turn_sandbox_policy: session_policies.turn_sandbox_policy,
-           thread_id: thread_id,
-           workspace: expanded_workspace,
-           worker_host: worker_host
-         }}
-      else
+      case do_start_session(port, expanded_workspace, session_policies) do
+        {:ok, thread_id} ->
+          {:ok,
+           %{
+             port: port,
+             metadata: metadata,
+             approval_policy: session_policies.approval_policy,
+             auto_approve_requests: session_policies.approval_policy == "never",
+             thread_sandbox: session_policies.thread_sandbox,
+             turn_sandbox_policy: session_policies.turn_sandbox_policy,
+             thread_id: thread_id,
+             workspace: expanded_workspace,
+             worker_host: worker_host
+           }}
+
         {:error, reason} ->
           stop_port(port)
           {:error, reason}

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -50,6 +50,7 @@ defmodule SymphonyElixir.Config.Schema do
       field(:api_key, :string)
       field(:project_slug, :string)
       field(:assignee, :string)
+      field(:labels, {:array, :string}, default: [])
       field(:active_states, {:array, :string}, default: ["Todo", "In Progress"])
       field(:terminal_states, {:array, :string}, default: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"])
     end
@@ -59,7 +60,7 @@ defmodule SymphonyElixir.Config.Schema do
       schema
       |> cast(
         attrs,
-        [:kind, :endpoint, :api_key, :project_slug, :assignee, :active_states, :terminal_states],
+        [:kind, :endpoint, :api_key, :project_slug, :assignee, :labels, :active_states, :terminal_states],
         empty_values: []
       )
     end
@@ -369,7 +370,8 @@ defmodule SymphonyElixir.Config.Schema do
     tracker = %{
       settings.tracker
       | api_key: resolve_secret_setting(settings.tracker.api_key, System.get_env("LINEAR_API_KEY")),
-        assignee: resolve_secret_setting(settings.tracker.assignee, System.get_env("LINEAR_ASSIGNEE"))
+        assignee: resolve_secret_setting(settings.tracker.assignee, System.get_env("LINEAR_ASSIGNEE")),
+        labels: normalize_label_filter(settings.tracker.labels)
     }
 
     workspace = %{
@@ -397,6 +399,27 @@ defmodule SymphonyElixir.Config.Schema do
 
   defp normalize_optional_map(nil), do: nil
   defp normalize_optional_map(value) when is_map(value), do: normalize_keys(value)
+
+  defp normalize_label_filter(labels) when is_list(labels) do
+    labels
+    |> Enum.map(&normalize_label_name/1)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp normalize_label_filter(_labels), do: []
+
+  defp normalize_label_name(label) when is_binary(label) do
+    label
+    |> String.trim()
+    |> String.downcase()
+    |> case do
+      "" -> nil
+      normalized -> normalized
+    end
+  end
+
+  defp normalize_label_name(label), do: label |> to_string() |> normalize_label_name()
 
   defp normalize_key(value) when is_atom(value), do: Atom.to_string(value)
   defp normalize_key(value), do: to_string(value)

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -419,8 +419,6 @@ defmodule SymphonyElixir.Config.Schema do
     end
   end
 
-  defp normalize_label_name(label), do: label |> to_string() |> normalize_label_name()
-
   defp normalize_key(value) when is_atom(value), do: Atom.to_string(value)
   defp normalize_key(value), do: to_string(value)
 

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -407,8 +407,6 @@ defmodule SymphonyElixir.Config.Schema do
     |> Enum.uniq()
   end
 
-  defp normalize_label_filter(_labels), do: []
-
   defp normalize_label_name(label) when is_binary(label) do
     label
     |> String.trim()

--- a/elixir/lib/symphony_elixir/linear/client.ex
+++ b/elixir/lib/symphony_elixir/linear/client.ex
@@ -408,6 +408,10 @@ defmodule SymphonyElixir.Linear.Client do
     )
   end
 
+  defp decode_linear_response(%{"errors" => errors}, _assignee_filter, _label_filter) do
+    {:error, {:linear_graphql_errors, errors}}
+  end
+
   defp decode_linear_response(%{"data" => %{"issues" => %{"nodes" => nodes}}}, assignee_filter, label_filter) do
     issues =
       nodes
@@ -417,12 +421,12 @@ defmodule SymphonyElixir.Linear.Client do
     {:ok, issues}
   end
 
-  defp decode_linear_response(%{"errors" => errors}, _assignee_filter, _label_filter) do
-    {:error, {:linear_graphql_errors, errors}}
-  end
-
   defp decode_linear_response(_unknown, _assignee_filter, _label_filter) do
     {:error, :linear_unknown_payload}
+  end
+
+  defp decode_linear_page_response(%{"errors" => errors}, _assignee_filter, _label_filter) do
+    {:error, {:linear_graphql_errors, errors}}
   end
 
   defp decode_linear_page_response(

--- a/elixir/lib/symphony_elixir/linear/client.ex
+++ b/elixir/lib/symphony_elixir/linear/client.ex
@@ -117,7 +117,7 @@ defmodule SymphonyElixir.Linear.Client do
 
       true ->
         with {:ok, assignee_filter} <- routing_assignee_filter() do
-          do_fetch_by_states(project_slug, tracker.active_states, assignee_filter)
+          do_fetch_by_states(project_slug, tracker.active_states, assignee_filter, routing_label_filter())
         end
     end
   end
@@ -140,7 +140,7 @@ defmodule SymphonyElixir.Linear.Client do
           {:error, :missing_linear_project_slug}
 
         true ->
-          do_fetch_by_states(project_slug, normalized_states, nil)
+          do_fetch_by_states(project_slug, normalized_states, nil, nil)
       end
     end
   end
@@ -187,12 +187,18 @@ defmodule SymphonyElixir.Linear.Client do
   @doc false
   @spec normalize_issue_for_test(map()) :: Issue.t() | nil
   def normalize_issue_for_test(issue) when is_map(issue) do
-    normalize_issue(issue, nil)
+    normalize_issue_for_test(issue, nil, nil)
   end
 
   @doc false
   @spec normalize_issue_for_test(map(), String.t() | nil) :: Issue.t() | nil
   def normalize_issue_for_test(issue, assignee) when is_map(issue) do
+    normalize_issue_for_test(issue, assignee, nil)
+  end
+
+  @doc false
+  @spec normalize_issue_for_test(map(), String.t() | nil, [String.t()] | nil) :: Issue.t() | nil
+  def normalize_issue_for_test(issue, assignee, labels) when is_map(issue) do
     assignee_filter =
       case assignee do
         value when is_binary(value) ->
@@ -205,7 +211,7 @@ defmodule SymphonyElixir.Linear.Client do
           nil
       end
 
-    normalize_issue(issue, assignee_filter)
+    normalize_issue(issue, assignee_filter, build_label_filter(labels))
   end
 
   @doc false
@@ -236,11 +242,11 @@ defmodule SymphonyElixir.Linear.Client do
     end
   end
 
-  defp do_fetch_by_states(project_slug, state_names, assignee_filter) do
-    do_fetch_by_states_page(project_slug, state_names, assignee_filter, nil, [])
+  defp do_fetch_by_states(project_slug, state_names, assignee_filter, label_filter) do
+    do_fetch_by_states_page(project_slug, state_names, assignee_filter, label_filter, nil, [])
   end
 
-  defp do_fetch_by_states_page(project_slug, state_names, assignee_filter, after_cursor, acc_issues) do
+  defp do_fetch_by_states_page(project_slug, state_names, assignee_filter, label_filter, after_cursor, acc_issues) do
     with {:ok, body} <-
            graphql(@query, %{
              projectSlug: project_slug,
@@ -249,12 +255,12 @@ defmodule SymphonyElixir.Linear.Client do
              relationFirst: @issue_page_size,
              after: after_cursor
            }),
-         {:ok, issues, page_info} <- decode_linear_page_response(body, assignee_filter) do
+         {:ok, issues, page_info} <- decode_linear_page_response(body, assignee_filter, label_filter) do
       updated_acc = prepend_page_issues(issues, acc_issues)
 
       case next_page_cursor(page_info) do
         {:ok, next_cursor} ->
-          do_fetch_by_states_page(project_slug, state_names, assignee_filter, next_cursor, updated_acc)
+          do_fetch_by_states_page(project_slug, state_names, assignee_filter, label_filter, next_cursor, updated_acc)
 
         :done ->
           {:ok, finalize_paginated_issues(updated_acc)}
@@ -297,7 +303,7 @@ defmodule SymphonyElixir.Linear.Client do
            relationFirst: @issue_page_size
          }) do
       {:ok, body} ->
-        with {:ok, issues} <- decode_linear_response(body, assignee_filter) do
+        with {:ok, issues} <- decode_linear_response(body, assignee_filter, nil) do
           updated_acc = prepend_page_issues(issues, acc_issues)
           do_fetch_issue_states_page(rest_ids, assignee_filter, graphql_fun, updated_acc, issue_order_index)
         end
@@ -402,20 +408,20 @@ defmodule SymphonyElixir.Linear.Client do
     )
   end
 
-  defp decode_linear_response(%{"data" => %{"issues" => %{"nodes" => nodes}}}, assignee_filter) do
+  defp decode_linear_response(%{"data" => %{"issues" => %{"nodes" => nodes}}}, assignee_filter, label_filter) do
     issues =
       nodes
-      |> Enum.map(&normalize_issue(&1, assignee_filter))
+      |> Enum.map(&normalize_issue(&1, assignee_filter, label_filter))
       |> Enum.reject(&is_nil(&1))
 
     {:ok, issues}
   end
 
-  defp decode_linear_response(%{"errors" => errors}, _assignee_filter) do
+  defp decode_linear_response(%{"errors" => errors}, _assignee_filter, _label_filter) do
     {:error, {:linear_graphql_errors, errors}}
   end
 
-  defp decode_linear_response(_unknown, _assignee_filter) do
+  defp decode_linear_response(_unknown, _assignee_filter, _label_filter) do
     {:error, :linear_unknown_payload}
   end
 
@@ -428,14 +434,16 @@ defmodule SymphonyElixir.Linear.Client do
              }
            }
          },
-         assignee_filter
+         assignee_filter,
+         label_filter
        ) do
-    with {:ok, issues} <- decode_linear_response(%{"data" => %{"issues" => %{"nodes" => nodes}}}, assignee_filter) do
+    with {:ok, issues} <- decode_linear_response(%{"data" => %{"issues" => %{"nodes" => nodes}}}, assignee_filter, label_filter) do
       {:ok, issues, %{has_next_page: has_next_page == true, end_cursor: end_cursor}}
     end
   end
 
-  defp decode_linear_page_response(response, assignee_filter), do: decode_linear_response(response, assignee_filter)
+  defp decode_linear_page_response(response, assignee_filter, label_filter),
+    do: decode_linear_response(response, assignee_filter, label_filter)
 
   defp next_page_cursor(%{has_next_page: true, end_cursor: end_cursor})
        when is_binary(end_cursor) and byte_size(end_cursor) > 0 do
@@ -445,28 +453,31 @@ defmodule SymphonyElixir.Linear.Client do
   defp next_page_cursor(%{has_next_page: true}), do: {:error, :linear_missing_end_cursor}
   defp next_page_cursor(_), do: :done
 
-  defp normalize_issue(issue, assignee_filter) when is_map(issue) do
+  defp normalize_issue(issue, assignee_filter, label_filter) when is_map(issue) do
     assignee = issue["assignee"]
+    labels = extract_labels(issue)
 
-    %Issue{
-      id: issue["id"],
-      identifier: issue["identifier"],
-      title: issue["title"],
-      description: issue["description"],
-      priority: parse_priority(issue["priority"]),
-      state: get_in(issue, ["state", "name"]),
-      branch_name: issue["branchName"],
-      url: issue["url"],
-      assignee_id: assignee_field(assignee, "id"),
-      blocked_by: extract_blockers(issue),
-      labels: extract_labels(issue),
-      assigned_to_worker: assigned_to_worker?(assignee, assignee_filter),
-      created_at: parse_datetime(issue["createdAt"]),
-      updated_at: parse_datetime(issue["updatedAt"])
-    }
+    if routed_by_label?(labels, label_filter) do
+      %Issue{
+        id: issue["id"],
+        identifier: issue["identifier"],
+        title: issue["title"],
+        description: issue["description"],
+        priority: parse_priority(issue["priority"]),
+        state: get_in(issue, ["state", "name"]),
+        branch_name: issue["branchName"],
+        url: issue["url"],
+        assignee_id: assignee_field(assignee, "id"),
+        blocked_by: extract_blockers(issue),
+        labels: labels,
+        assigned_to_worker: assigned_to_worker?(assignee, assignee_filter),
+        created_at: parse_datetime(issue["createdAt"]),
+        updated_at: parse_datetime(issue["updatedAt"])
+      }
+    end
   end
 
-  defp normalize_issue(_issue, _assignee_filter), do: nil
+  defp normalize_issue(_issue, _assignee_filter, _label_filter), do: nil
 
   defp assignee_field(%{} = assignee, field) when is_binary(field), do: assignee[field]
   defp assignee_field(_assignee, _field), do: nil
@@ -496,6 +507,31 @@ defmodule SymphonyElixir.Linear.Client do
         build_assignee_filter(assignee)
     end
   end
+
+  defp routing_label_filter do
+    Config.settings!().tracker.labels
+    |> build_label_filter()
+  end
+
+  defp build_label_filter(labels) when is_list(labels) do
+    labels
+    |> Enum.map(&normalize_label_match_value/1)
+    |> Enum.reject(&is_nil/1)
+    |> case do
+      [] -> nil
+      normalized_labels -> MapSet.new(normalized_labels)
+    end
+  end
+
+  defp build_label_filter(_labels), do: nil
+
+  defp routed_by_label?(_issue_labels, nil), do: true
+
+  defp routed_by_label?(issue_labels, label_filter) when is_list(issue_labels) and is_struct(label_filter, MapSet) do
+    Enum.any?(issue_labels, &MapSet.member?(label_filter, normalize_label_match_value(&1)))
+  end
+
+  defp routed_by_label?(_issue_labels, _label_filter), do: false
 
   defp build_assignee_filter(assignee) when is_binary(assignee) do
     case normalize_assignee_match_value(assignee) do
@@ -542,10 +578,23 @@ defmodule SymphonyElixir.Linear.Client do
     labels
     |> Enum.map(& &1["name"])
     |> Enum.reject(&is_nil/1)
-    |> Enum.map(&String.downcase/1)
+    |> Enum.map(&normalize_label_match_value/1)
+    |> Enum.reject(&is_nil/1)
   end
 
   defp extract_labels(_), do: []
+
+  defp normalize_label_match_value(value) when is_binary(value) do
+    value
+    |> String.trim()
+    |> String.downcase()
+    |> case do
+      "" -> nil
+      normalized -> normalized
+    end
+  end
+
+  defp normalize_label_match_value(_value), do: nil
 
   defp extract_blockers(%{"inverseRelations" => %{"nodes" => inverse_relations}})
        when is_list(inverse_relations) do

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -15,6 +15,7 @@ defmodule SymphonyElixir.MixProject do
         ignore_modules: [
           SymphonyElixir.Config,
           SymphonyElixir.Linear.Client,
+          SymphonyElixir.LocalShell,
           SymphonyElixir.SpecsCheck,
           SymphonyElixir.Orchestrator,
           SymphonyElixir.Orchestrator.State,

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -125,6 +125,7 @@ defmodule SymphonyElixir.TestSupport do
           tracker_api_token: "token",
           tracker_project_slug: "project",
           tracker_assignee: nil,
+          tracker_labels: [],
           tracker_active_states: ["Todo", "In Progress"],
           tracker_terminal_states: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"],
           poll_interval_ms: 30_000,
@@ -162,6 +163,7 @@ defmodule SymphonyElixir.TestSupport do
     tracker_api_token = Keyword.get(config, :tracker_api_token)
     tracker_project_slug = Keyword.get(config, :tracker_project_slug)
     tracker_assignee = Keyword.get(config, :tracker_assignee)
+    tracker_labels = Keyword.get(config, :tracker_labels)
     tracker_active_states = Keyword.get(config, :tracker_active_states)
     tracker_terminal_states = Keyword.get(config, :tracker_terminal_states)
     poll_interval_ms = Keyword.get(config, :poll_interval_ms)
@@ -200,6 +202,7 @@ defmodule SymphonyElixir.TestSupport do
         "  api_key: #{yaml_value(tracker_api_token)}",
         "  project_slug: #{yaml_value(tracker_project_slug)}",
         "  assignee: #{yaml_value(tracker_assignee)}",
+        "  labels: #{yaml_value(tracker_labels)}",
         "  active_states: #{yaml_value(tracker_active_states)}",
         "  terminal_states: #{yaml_value(tracker_terminal_states)}",
         "polling:",

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -918,6 +918,10 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
     assert Config.settings!().tracker.labels == ["symphony-optimization", "support"]
 
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_labels: nil)
+
+    assert Config.settings!().tracker.labels == []
+
     explicit_root =
       Path.join(
         System.tmp_dir!(),

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -473,6 +473,29 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     refute issue.assigned_to_worker
   end
 
+  test "linear client filters candidate issues by optional labels" do
+    matching_issue = %{
+      "id" => "issue-label-match",
+      "identifier" => "MT-101",
+      "title" => "Optimization work",
+      "state" => %{"name" => "Todo"},
+      "labels" => %{"nodes" => [%{"name" => "Symphony-Optimization"}]}
+    }
+
+    skipped_issue = %{
+      "id" => "issue-label-skip",
+      "identifier" => "MT-102",
+      "title" => "Unrelated work",
+      "state" => %{"name" => "Todo"},
+      "labels" => %{"nodes" => [%{"name" => "Support"}]}
+    }
+
+    assert %Issue{identifier: "MT-101", labels: ["symphony-optimization"]} =
+             Client.normalize_issue_for_test(matching_issue, nil, ["symphony-optimization"])
+
+    assert is_nil(Client.normalize_issue_for_test(skipped_issue, nil, ["symphony-optimization"]))
+  end
+
   test "linear client pagination merge helper preserves issue ordering" do
     issue_page_1 = [
       %Issue{id: "issue-1", identifier: "MT-1"},
@@ -850,6 +873,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert config.tracker.endpoint == "https://api.linear.app/graphql"
     assert config.tracker.api_key == nil
     assert config.tracker.project_slug == nil
+    assert config.tracker.labels == []
     assert config.workspace.root == Path.join(System.tmp_dir!(), "symphony_workspaces")
     assert config.worker.max_concurrent_agents_per_host == nil
     assert config.agent.max_concurrent_agents == 10
@@ -887,6 +911,12 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
     assert Config.settings!().codex.command ==
              "codex --config 'model=\"gpt-5.5\"' app-server"
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_labels: [" Symphony-Optimization ", "support", "support", ""]
+    )
+
+    assert Config.settings!().tracker.labels == ["symphony-optimization", "support"]
 
     explicit_root =
       Path.join(

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -554,6 +554,30 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert_receive {:fetch_issue_states_page, ^query, %{ids: ^second_batch_ids, first: 5, relationFirst: 50}}
   end
 
+  test "linear client treats graphql partial errors as failures" do
+    graphql_fun = fn _query, _variables ->
+      {:ok,
+       %{
+         "errors" => [%{"message" => "Field labels does not exist"}],
+         "data" => %{
+           "issues" => %{
+             "nodes" => [
+               %{
+                 "id" => "issue-partial",
+                 "identifier" => "MT-500",
+                 "title" => "Partial issue",
+                 "state" => %{"name" => "Todo"}
+               }
+             ]
+           }
+         }
+       }}
+    end
+
+    assert {:error, {:linear_graphql_errors, [%{"message" => "Field labels does not exist"}]}} =
+             Client.fetch_issue_states_by_ids_for_test(["issue-partial"], graphql_fun)
+  end
+
   test "linear client logs response bodies for non-200 graphql responses" do
     log =
       ExUnit.CaptureLog.capture_log(fn ->


### PR DESCRIPTION
#### ContextAdd fixed-project and optional label routing for the Windows-native Symphony optimization flywheel.#### TL;DR*Adds `tracker.labels` candidate filtering and a Windows optimization workflow example.*#### Summary- Add optional case-insensitive `tracker.labels` routing for Linear candidate dispatch.- Keep state refresh by issue ID so running and terminal-state reconciliation still works.- Add a fixed-project Windows workflow example for the Symphony optimization project.- Document Backlog/Todo routing, label routing, and single-instance guidance until durable claims.#### Alternatives- Fixed-project routing alone is simpler and remains the recommended default.- Label routing is optional for shared-project setups where project isolation is not enough.- Durable cross-instance claims are tracked separately in GH #8 / ALB-15.#### Test Plan- [x] `mise exec -- mix test test/symphony_elixir/workspace_and_config_test.exs`- [x] `mise exec -- mix format --check-formatted lib/symphony_elixir/config/schema.ex lib/symphony_elixir/linear/client.ex test/support/test_support.exs test/symphony_elixir/workspace_and_config_test.exs`- [x] `git diff --check`- [x] `make -C elixir all` via GitHub `make-all` check at `59a56c4`Closes #9