### PR TITLE
docs(quality): add agent PR quality flywheel

### DIFF
--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -65,4 +65,8 @@ jobs:
             ${{ runner.os }}-mix-
 
       - name: Verify Windows-native profile
-        run: mix test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get
+          mix test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -64,7 +64,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-
 
-      - name: Verify Windows-native profile
+      - name: Verify Windows shell and workspace profile
         run: |
           mix local.hex --force
           mix local.rebar --force

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
 
       - name: Set up mise tools
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
@@ -35,6 +37,8 @@ jobs:
             ${{ runner.os }}-mix-
 
       - name: Verify make all
+        env:
+          DIFF_RANGE: ${{ github.event_name == 'pull_request' && format('{0}...HEAD', github.event.pull_request.base.sha) || '' }}
         run: make all
 
   windows-native-test:

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -36,3 +36,33 @@ jobs:
 
       - name: Verify make all
         run: make all
+
+  windows-native-test:
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: elixir
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up mise tools
+        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
+        with:
+          install: true
+          cache: true
+          working_directory: elixir
+
+      - name: Cache deps and build
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            elixir/deps
+            elixir/_build
+          key: ${{ runner.os }}-mix-${{ hashFiles('elixir/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+
+      - name: Verify Windows-native profile
+        run: mix test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs

--- a/elixir/AGENTS.md
+++ b/elixir/AGENTS.md
@@ -58,8 +58,8 @@ mix specs.check
 - PR body must follow `../.github/pull_request_template.md` exactly.
 - Agent PR commits should use lightweight Conventional Commits such as
   `fix(app-server): resolve session startup lint`.
-- Do not hand off an agent PR while required GitHub checks are still pending or failing unless the
-  blocker is explicitly recorded in the PR and Linear workpad.
+- Do not hand off an agent PR while required GitHub checks are still pending or failing unless a
+  manager explicitly asks for that state; record blockers in the PR and Linear workpad.
 - Validate PR body locally when needed:
 
 ```bash

--- a/elixir/AGENTS.md
+++ b/elixir/AGENTS.md
@@ -12,6 +12,7 @@ This directory contains the Elixir agent orchestration service that polls Linear
 ## Codebase-Specific Conventions
 
 - Runtime config is loaded from `WORKFLOW.md` front matter via `SymphonyElixir.Workflow` and `SymphonyElixir.Config`.
+- Agent PRs must follow the quality policy in [`docs/agent-quality-flywheel.md`](docs/agent-quality-flywheel.md).
 - Keep the implementation aligned with [`../SPEC.md`](../SPEC.md) where practical.
   - The implementation may be a superset of the spec.
   - The implementation must not conflict with the spec.
@@ -32,6 +33,12 @@ Run targeted tests while iterating, then run full gates before handoff.
 make all
 ```
 
+For Windows-native worker or workflow changes, also run the focused profile:
+
+```bash
+make windows-native-test
+```
+
 ## Required Rules
 
 - Public functions (`def`) in `lib/` must have an adjacent `@spec`.
@@ -49,6 +56,10 @@ mix specs.check
 ## PR Requirements
 
 - PR body must follow `../.github/pull_request_template.md` exactly.
+- Agent PR commits should use lightweight Conventional Commits such as
+  `fix(app-server): resolve session startup lint`.
+- Do not hand off an agent PR while required GitHub checks are still pending or failing unless the
+  blocker is explicitly recorded in the PR and Linear workpad.
 - Validate PR body locally when needed:
 
 ```bash

--- a/elixir/Makefile
+++ b/elixir/Makefile
@@ -1,6 +1,7 @@
 .PHONY: help all setup deps build fmt fmt-check diff-check lint test windows-native-test coverage ci dialyzer e2e
 
 MIX ?= mix
+DIFF_RANGE ?=
 
 help:
 	@echo "Targets: setup, deps, fmt, fmt-check, diff-check, lint, test, windows-native-test, coverage, dialyzer, e2e, ci"
@@ -21,7 +22,11 @@ fmt-check:
 	$(MIX) format --check-formatted
 
 diff-check:
+ifeq ($(strip $(DIFF_RANGE)),)
 	git diff --check
+else
+	git diff --check $(DIFF_RANGE)
+endif
 
 lint:
 	$(MIX) lint

--- a/elixir/Makefile
+++ b/elixir/Makefile
@@ -1,9 +1,9 @@
-.PHONY: help all setup deps build fmt fmt-check lint test coverage ci dialyzer e2e
+.PHONY: help all setup deps build fmt fmt-check lint test windows-native-test coverage ci dialyzer e2e
 
 MIX ?= mix
 
 help:
-	@echo "Targets: setup, deps, fmt, fmt-check, lint, test, coverage, dialyzer, e2e, ci"
+	@echo "Targets: setup, deps, fmt, fmt-check, lint, test, windows-native-test, coverage, dialyzer, e2e, ci"
 
 setup:
 	$(MIX) setup
@@ -28,6 +28,9 @@ coverage:
 
 test:
 	$(MIX) test
+
+windows-native-test:
+	$(MIX) test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs
 
 dialyzer:
 	$(MIX) deps.get

--- a/elixir/Makefile
+++ b/elixir/Makefile
@@ -1,9 +1,9 @@
-.PHONY: help all setup deps build fmt fmt-check lint test windows-native-test coverage ci dialyzer e2e
+.PHONY: help all setup deps build fmt fmt-check diff-check lint test windows-native-test coverage ci dialyzer e2e
 
 MIX ?= mix
 
 help:
-	@echo "Targets: setup, deps, fmt, fmt-check, lint, test, windows-native-test, coverage, dialyzer, e2e, ci"
+	@echo "Targets: setup, deps, fmt, fmt-check, diff-check, lint, test, windows-native-test, coverage, dialyzer, e2e, ci"
 
 setup:
 	$(MIX) setup
@@ -19,6 +19,9 @@ fmt:
 
 fmt-check:
 	$(MIX) format --check-formatted
+
+diff-check:
+	git diff --check
 
 lint:
 	$(MIX) lint
@@ -43,6 +46,7 @@ ci:
 	$(MAKE) setup
 	$(MAKE) build
 	$(MAKE) fmt-check
+	$(MAKE) diff-check
 	$(MAKE) lint
 	$(MAKE) coverage
 	$(MAKE) dialyzer

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -61,6 +61,8 @@ Symphony stops the active agent for that issue and cleans up matching workspaces
 
 1. Make sure your codebase is set up to work well with agents: see
    [Harness engineering](https://openai.com/index/harness-engineering/).
+   For Symphony-managed PRs in this repo, also follow the
+   [agent quality flywheel policy](docs/agent-quality-flywheel.md).
 2. Get a new personal token in Linear via Settings → Security & access → Personal API keys, and
    set it as the `LINEAR_API_KEY` environment variable.
 3. Copy this directory's `WORKFLOW.md` to your repo.
@@ -207,6 +209,13 @@ The observability UI now runs on a minimal Phoenix stack:
 
 ```bash
 make all
+```
+
+For Windows-native worker startup, workflow, or path-handling changes, run the focused Windows
+profile as well:
+
+```bash
+make windows-native-test
 ```
 
 Run the real external end-to-end test only when you want Symphony to create disposable Linear

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -211,7 +211,7 @@ The observability UI now runs on a minimal Phoenix stack:
 make all
 ```
 
-For Windows-native worker startup, workflow, or path-handling changes, run the focused Windows
+For Windows shell, workspace/config, workflow, or path-handling changes, run the focused Windows
 profile as well:
 
 ```bash

--- a/elixir/WORKFLOW.optimization.windows.example.md
+++ b/elixir/WORKFLOW.optimization.windows.example.md
@@ -73,7 +73,8 @@ Operating model:
    `albert-zen/symphony-windows-native`.
 9. Open a GitHub pull request against `main` and link it in the Linear workpad.
 10. Wait for required GitHub checks to complete before moving the Linear issue to `In Review`.
-    If checks cannot be verified, record the exact reason in the workpad and PR.
+    If checks cannot be verified, record the exact reason in the workpad and PR, then keep the
+    issue in `In Progress` or return it to `Todo`; only a manager may explicitly override this.
 11. Do not move unrelated Backlog issues to Todo.
 12. If you discover an automation/system defect, create a GitHub issue with label `symphony-optimization` and add a Linear mirror in project `Symphony 优化` if the Linear tool is available.
 
@@ -83,9 +84,15 @@ Quality bar:
 - Run `mix format` for touched Elixir files.
 - Follow `docs/agent-quality-flywheel.md` for PR quality gates, review loop rules, and defect
   protocol.
-- Run focused Windows-native tests when touching Windows runtime behavior:
+- Run focused Windows shell and workspace/config tests when touching Windows runtime or workflow
+  behavior:
   `make windows-native-test`.
 - Do not move the issue to `In Review` while required checks are pending or failing.
+- For non-trivial changes, request manager/subagent review before handoff and record the review
+  request plus findings in the PR and/or Workpad.
+- If review finds blocking issues, keep the issue in `In Progress` or return it to `Todo` until
+  the findings are addressed and required checks pass.
 - Write CI/runtime failures back to the Linear Workpad or linked GitHub issue before ending.
 - Do not broaden scope to multiple optimization issues in one PR.
-- If blocked by credentials or permissions, record the exact blocker in the Workpad and move the issue to In Review.
+- If blocked by credentials or permissions, record the exact blocker in the Workpad and keep the
+  issue out of `In Review` unless a manager explicitly moves it there.

--- a/elixir/WORKFLOW.optimization.windows.example.md
+++ b/elixir/WORKFLOW.optimization.windows.example.md
@@ -68,9 +68,12 @@ Operating model:
 5. Keep changes focused on the current Linear/GitHub issue.
 6. Create a branch named `codex/<linear-identifier>-<short-topic>`.
 7. Run focused validation before committing.
-8. Commit the change and push the branch to `albert-zen/symphony-windows-native`.
+8. Commit with lightweight Conventional Commits, for example
+   `docs(quality): add agent PR quality policy`, and push the branch to
+   `albert-zen/symphony-windows-native`.
 9. Open a GitHub pull request against `main` and link it in the Linear workpad.
-10. Move the Linear issue to `In Review` after the PR exists and validation is recorded.
+10. Wait for required GitHub checks to complete before moving the Linear issue to `In Review`.
+    If checks cannot be verified, record the exact reason in the workpad and PR.
 11. Do not move unrelated Backlog issues to Todo.
 12. If you discover an automation/system defect, create a GitHub issue with label `symphony-optimization` and add a Linear mirror in project `Symphony 优化` if the Linear tool is available.
 
@@ -78,6 +81,11 @@ Quality bar:
 
 - Prefer small, reviewable changes.
 - Run `mix format` for touched Elixir files.
-- Run focused Windows-native tests when touching Windows runtime behavior.
+- Follow `docs/agent-quality-flywheel.md` for PR quality gates, review loop rules, and defect
+  protocol.
+- Run focused Windows-native tests when touching Windows runtime behavior:
+  `make windows-native-test`.
+- Do not move the issue to `In Review` while required checks are pending or failing.
+- Write CI/runtime failures back to the Linear Workpad or linked GitHub issue before ending.
 - Do not broaden scope to multiple optimization issues in one PR.
 - If blocked by credentials or permissions, record the exact blocker in the Workpad and move the issue to In Review.

--- a/elixir/docs/agent-quality-flywheel.md
+++ b/elixir/docs/agent-quality-flywheel.md
@@ -10,7 +10,9 @@ Every agent PR must record these checks in the PR body and the Linear `## Codex 
 
 - `validate-pr-description`: the PR body follows `.github/pull_request_template.md`.
 - `make-all`: the repository gate runs `make all` from `elixir/`.
-- `diff-check`: the repository gate runs `git diff --check` through `make all`.
+- `diff-check`: the repository gate runs `git diff --check` through `make all`. In CI it
+  must check the committed PR diff with `DIFF_RANGE=<base>...HEAD`; locally, set
+  `DIFF_RANGE` or let the target check uncommitted working-tree changes.
 - `windows-native-test`: Windows CI runs the focused native shell and workspace/config profile.
 - Targeted checks for the changed behavior, such as a single ExUnit file or mix task test.
 

--- a/elixir/docs/agent-quality-flywheel.md
+++ b/elixir/docs/agent-quality-flywheel.md
@@ -1,0 +1,64 @@
+# Agent quality flywheel
+
+This policy defines the minimum review and validation loop for Symphony-managed agent PRs. It is
+intended to be copied into workflow prompts and used by humans when deciding whether an issue can
+leave active work.
+
+## Required gates
+
+Every agent PR must record these checks in the PR body and the Linear `## Codex Workpad`:
+
+- `validate-pr-description`: the PR body follows `.github/pull_request_template.md`.
+- `make-all`: the repository gate runs `make all` from `elixir/`.
+- `windows-native-test`: Windows CI runs the focused native startup/config profile.
+- Targeted checks for the changed behavior, such as a single ExUnit file or mix task test.
+
+Agents should run focused validation before committing. `make all` should run before handoff when
+the local environment can support the full gate. If a gate cannot be run locally, the PR and workpad
+must say why and rely on GitHub checks before review.
+
+## Review loop
+
+Use a manager or subagent review pass for non-trivial changes before merge. A change is non-trivial
+when it touches runtime orchestration, worker startup, Linear state transitions, Codex app-server
+protocol handling, CI, release/merge policy, or more than one subsystem.
+
+The review pass should check:
+
+- The implementation is scoped to the linked Linear/GitHub issue.
+- The validation evidence matches the touched risk.
+- CI failures and runtime defects are written back to GitHub or Linear before state changes.
+- Follow-up work is filed instead of being left only in logs.
+
+Docs-only changes may skip an extra subagent review when they only clarify existing behavior and
+all required documentation checks pass.
+
+## Linear and GitHub state rules
+
+Agents must not move a Linear issue to `In Review` solely because a branch was pushed. They should
+wait until required GitHub checks have completed and passed, or record the exact reason checks could
+not be verified.
+
+If a required gate fails, the agent must summarize the failure in the workpad or linked GitHub issue
+and keep the Linear issue in `In Progress` or return it to `Todo` for repair. Failures discovered by
+automation should create a GitHub issue with the `symphony-optimization` label when they describe a
+system defect outside the current PR.
+
+## Commit and PR conventions
+
+Use lightweight Conventional Commits for agent work:
+
+```text
+<type>(<scope>): <imperative summary>
+```
+
+Accepted types are `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, and `ci`. Scopes should name
+the touched area, such as `windows`, `ci`, `quality`, `tracker`, or `app-server`.
+
+Every PR body must keep the template headings exactly as written and include concrete validation
+results. Recommended branch protection for `main` is:
+
+- Require pull requests before merge.
+- Require `make-all` and `validate-pr-description`.
+- Require `windows-native-test` for Windows runtime or workflow changes.
+- Require at least one review for non-trivial agent PRs.

--- a/elixir/docs/agent-quality-flywheel.md
+++ b/elixir/docs/agent-quality-flywheel.md
@@ -10,18 +10,20 @@ Every agent PR must record these checks in the PR body and the Linear `## Codex 
 
 - `validate-pr-description`: the PR body follows `.github/pull_request_template.md`.
 - `make-all`: the repository gate runs `make all` from `elixir/`.
-- `windows-native-test`: Windows CI runs the focused native startup/config profile.
+- `diff-check`: the repository gate runs `git diff --check` through `make all`.
+- `windows-native-test`: Windows CI runs the focused native shell and workspace/config profile.
 - Targeted checks for the changed behavior, such as a single ExUnit file or mix task test.
 
 Agents should run focused validation before committing. `make all` should run before handoff when
 the local environment can support the full gate. If a gate cannot be run locally, the PR and workpad
-must say why and rely on GitHub checks before review.
+must say why, and the issue must stay out of `In Review` until required GitHub checks pass or a
+manager explicitly moves it.
 
 ## Review loop
 
-Use a manager or subagent review pass for non-trivial changes before merge. A change is non-trivial
-when it touches runtime orchestration, worker startup, Linear state transitions, Codex app-server
-protocol handling, CI, release/merge policy, or more than one subsystem.
+Request a manager or subagent review pass for non-trivial changes before handoff. A change is
+non-trivial when it touches runtime orchestration, worker startup, Linear state transitions, Codex
+app-server protocol handling, CI, release/merge policy, or more than one subsystem.
 
 The review pass should check:
 
@@ -33,11 +35,20 @@ The review pass should check:
 Docs-only changes may skip an extra subagent review when they only clarify existing behavior and
 all required documentation checks pass.
 
+Record the review request and outcome in the PR conversation or Linear workpad. If the review finds
+blocking issues, keep the Linear issue in `In Progress` or return it to `Todo` until the findings are
+addressed and required checks are green.
+
 ## Linear and GitHub state rules
 
-Agents must not move a Linear issue to `In Review` solely because a branch was pushed. They should
-wait until required GitHub checks have completed and passed, or record the exact reason checks could
-not be verified.
+Agents must not move a Linear issue to `In Review` solely because a branch was pushed. `In Review`
+means a PR exists, required checks have completed and passed, and required manager/subagent review
+findings have been addressed, unless a manager explicitly moves the issue there.
+
+Pending, failing, or unverifiable required checks are not review-ready. The agent must write the
+failure or blocker to the workpad and/or linked GitHub issue or PR, then keep the issue in
+`In Progress` or return it to `Todo`. If a `Blocked` state exists, the manager may move the issue
+there.
 
 If a required gate fails, the agent must summarize the failure in the workpad or linked GitHub issue
 and keep the Linear issue in `In Progress` or return it to `Todo` for repair. Failures discovered by
@@ -60,5 +71,5 @@ results. Recommended branch protection for `main` is:
 
 - Require pull requests before merge.
 - Require `make-all` and `validate-pr-description`.
-- Require `windows-native-test` for Windows runtime or workflow changes.
+- Require `windows-native-test` for Windows shell, workspace/config, or workflow changes.
 - Require at least one review for non-trivial agent PRs.

--- a/elixir/docs/windows-native.md
+++ b/elixir/docs/windows-native.md
@@ -241,6 +241,18 @@ The important production path for local Windows workers is:
 - clean JSON-RPC stdio
 - Linear issue state updates through `linear_graphql`
 
+## Quality gates for Windows changes
+
+Windows-native runtime, workflow, or path-handling changes should run the focused native profile:
+
+```powershell
+make windows-native-test
+```
+
+Agent PRs should also follow the [agent quality flywheel](agent-quality-flywheel.md): keep one
+Linear workpad, use Conventional Commits, record validation in the PR body, and wait for required
+GitHub checks before moving the Linear issue to review.
+
 ## Troubleshooting
 
 ### `response_timeout` when starting Codex

--- a/elixir/docs/windows-native.md
+++ b/elixir/docs/windows-native.md
@@ -162,7 +162,8 @@ A practical flow is:
 - `Backlog`: not picked up by Symphony.
 - `Todo`: Symphony can pick this up. The agent should move it to `In Progress`.
 - `In Progress`: the agent implements and validates.
-- `Human Review`: the agent has created or updated a PR and is waiting.
+- `Human Review`: the agent has created or updated a PR, required checks are passing, and review is
+  requested or underway.
 - `Rework`: the agent should handle reviewer feedback.
 - `Merging`: the agent should run the repository's merge/land process.
 - `Done`: terminal. Symphony stops the active agent.
@@ -243,7 +244,8 @@ The important production path for local Windows workers is:
 
 ## Quality gates for Windows changes
 
-Windows-native runtime, workflow, or path-handling changes should run the focused native profile:
+Windows shell, workspace/config, workflow, or path-handling changes should run the focused native
+profile:
 
 ```powershell
 make windows-native-test

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -18,7 +18,40 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     path
     |> Path.expand()
     |> String.replace("\\", "/")
-    |> then(fn expanded -> if windows?(), do: String.downcase(expanded), else: expanded end)
+    |> then(fn expanded ->
+      if windows?() do
+        expanded
+        |> String.downcase()
+        |> normalize_windows_temp_root_for_assertion()
+      else
+        expanded
+      end
+    end)
+  end
+
+  defp normalize_windows_temp_root_for_assertion(path) do
+    windows_temp_roots_for_assertion()
+    |> Enum.reduce(path, fn root, normalized ->
+      String.replace(normalized, root, "<windows-temp-root>")
+    end)
+  end
+
+  defp windows_temp_roots_for_assertion do
+    [
+      System.tmp_dir!(),
+      System.get_env("TEMP"),
+      System.get_env("TMP"),
+      System.get_env("USERPROFILE") && Path.join(System.get_env("USERPROFILE"), "AppData/Local/Temp")
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(fn path ->
+      path
+      |> Path.expand()
+      |> String.replace("\\", "/")
+      |> String.downcase()
+    end)
+    |> Enum.uniq()
+    |> Enum.sort_by(&byte_size/1, :desc)
   end
 
   defp shell_quote(value) when is_binary(value) do
@@ -234,8 +267,14 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
       assert {:ok, canonical_outside_root} = SymphonyElixir.PathSafety.canonicalize(outside_root)
       assert {:ok, canonical_workspace_root} = SymphonyElixir.PathSafety.canonicalize(workspace_root)
 
-      assert {:error, {:workspace_outside_root, ^canonical_outside_root, ^canonical_workspace_root}} =
+      assert {:error, {:workspace_outside_root, outside_path, root_path}} =
                Workspace.create_for_issue("MT-SYM")
+
+      assert normalize_path_for_assertion(outside_path) ==
+               normalize_path_for_assertion(canonical_outside_root)
+
+      assert normalize_path_for_assertion(root_path) ==
+               normalize_path_for_assertion(canonical_workspace_root)
     after
       File.rm_rf(test_root)
     end
@@ -265,7 +304,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
                SymphonyElixir.PathSafety.canonicalize(Path.join(actual_root, "MT-LINK"))
 
       assert {:ok, workspace} = Workspace.create_for_issue("MT-LINK")
-      assert workspace == canonical_workspace
+      assert normalize_path_for_assertion(workspace) == normalize_path_for_assertion(canonical_workspace)
       assert File.dir?(workspace)
     after
       File.rm_rf(test_root)


### PR DESCRIPTION
#### Context

GH #6 / ALB-13 needs durable agent PR guardrails plus explicit Windows-native validation.

#### TL;DR

*Add agent PR policy, strict review gates, committed-diff checking, and focused Windows CI.*

#### Summary

- Add an agent quality flywheel policy for review, CI, failure writeback, and branch protection.
- Add `windows-native-test` and a Windows CI job for shell plus workspace/config tests.
- Add `diff-check` to `make all` so `git diff --check` is mechanically enforced against the committed PR diff in CI.
- Tighten workflow rules so pending, failing, or unverifiable checks stay out of `In Review`.
- Require manager/subagent review requests and review outcomes to be recorded.
- Normalize Windows temp-root path assertions exposed by the new CI gate.
- File the remaining mechanical readiness-guard work as GH #14 / ALB-19.

#### Alternatives

- Keep rules only in issue comments, but prompts would keep relying on transient context.
- Add app-server startup coverage to `windows-native-test`, but this slice narrows the profile name instead.
- Implement a full `In Review` transition gate in this PR, but the current state-change surface is raw Linear GraphQL; GH #14 / ALB-19 tracks a focused enforceable design.

#### Test Plan

- [ ] `make -C elixir all` (not run: `make` is unavailable in this Windows shell)
- [x] `mix format --check-formatted ../.github/workflows/make-all.yml docs/agent-quality-flywheel.md`
- [x] `mix format --check-formatted ../.github/workflows/make-all.yml AGENTS.md README.md WORKFLOW.optimization.windows.example.md docs/agent-quality-flywheel.md docs/windows-native.md`
- [x] `mix test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs`
- [x] `git diff --check 819ea7e...HEAD`
- [x] `mix pr_body.check --file $env:TEMP/ALB-13-pr-body.md`
- [ ] `mix format --check-formatted` full repo (blocked by pre-existing drift in untouched Elixir files)