### PR TITLE
Guard Linear In Review readiness

### DIFF
--- a/elixir/WORKFLOW.optimization.windows.example.md
+++ b/elixir/WORKFLOW.optimization.windows.example.md
@@ -39,6 +39,11 @@ codex:
   command: codex --config shell_environment_policy.inherit=all --config model=gpt-5.5 --config model_reasoning_effort=medium app-server
   approval_policy: never
   thread_sandbox: danger-full-access
+  # Used when GitHub branch protection required-check metadata is private or unavailable.
+  review_readiness_required_checks:
+    - make-all
+    - validate-pr-description
+    - windows-native-test
   turn_sandbox_policy:
     type: dangerFullAccess
 ---

--- a/elixir/WORKFLOW.optimization.windows.example.md
+++ b/elixir/WORKFLOW.optimization.windows.example.md
@@ -40,6 +40,7 @@ codex:
   approval_policy: never
   thread_sandbox: danger-full-access
   # Used when GitHub branch protection required-check metadata is private or unavailable.
+  review_readiness_repository: albert-zen/symphony-windows-native
   review_readiness_required_checks:
     - make-all
     - validate-pr-description

--- a/elixir/WORKFLOW.windows.example.md
+++ b/elixir/WORKFLOW.windows.example.md
@@ -42,6 +42,8 @@ codex:
   thread_sandbox: danger-full-access
   # Optional: fallback required checks for guarded Linear review transitions when
   # GitHub branch protection metadata is unavailable to the runtime.
+  # Set this to the trusted GitHub owner/repo before enabling guarded In Review transitions.
+  review_readiness_repository: YOUR_ORG/YOUR_REPO
   review_readiness_required_checks: []
   turn_sandbox_policy:
     type: dangerFullAccess

--- a/elixir/WORKFLOW.windows.example.md
+++ b/elixir/WORKFLOW.windows.example.md
@@ -40,6 +40,9 @@ codex:
   command: codex --config shell_environment_policy.inherit=all --config model=gpt-5.5 --config model_reasoning_effort=medium app-server
   approval_policy: never
   thread_sandbox: danger-full-access
+  # Optional: fallback required checks for guarded Linear review transitions when
+  # GitHub branch protection metadata is unavailable to the runtime.
+  review_readiness_required_checks: []
   turn_sandbox_policy:
     type: dangerFullAccess
 ---

--- a/elixir/docs/windows-native.md
+++ b/elixir/docs/windows-native.md
@@ -208,13 +208,19 @@ Agent-initiated moves to `In Review` are guarded by review readiness checks.
 The tool only allows that transition when the issue has a linked GitHub PR and
 the required checks on the PR head are complete and successful. If GitHub branch
 protection metadata is private or unavailable to the Windows runtime, configure
+`codex.review_readiness_repository` with the trusted `owner/repo` and
 `codex.review_readiness_required_checks` with the required check names; the gate
 then verifies those public PR check runs/statuses and still fails closed on
-missing, pending, failing, or unverifiable results. Manager overrides must happen
-outside the agent tool call and leave an audit note in Linear or GitHub.
+missing, pending, failing, or unverifiable results. Fallback required checks are
+matched by check/status name because branch-protection app identity is not
+available in that mode, so use the branch-protection source where app-bound
+verification is required. Manager overrides must happen outside the agent tool
+call and leave an audit note in Linear or GitHub.
 The linked PR must come from Linear attachment metadata. Links written only in
 agent-mutable comments, including the Codex Workpad, are useful for humans but
-are not authoritative for the readiness gate.
+are not authoritative for the readiness gate. The linked PR must be in the
+trusted repository and its head branch must include the Linear issue identifier
+so an arbitrary green PR cannot satisfy another issue's readiness gate.
 
 ### Progress tracking
 

--- a/elixir/docs/windows-native.md
+++ b/elixir/docs/windows-native.md
@@ -212,6 +212,9 @@ protection metadata is private or unavailable to the Windows runtime, configure
 then verifies those public PR check runs/statuses and still fails closed on
 missing, pending, failing, or unverifiable results. Manager overrides must happen
 outside the agent tool call and leave an audit note in Linear or GitHub.
+The linked PR must come from Linear attachment metadata. Links written only in
+agent-mutable comments, including the Codex Workpad, are useful for humans but
+are not authoritative for the readiness gate.
 
 ### Progress tracking
 

--- a/elixir/docs/windows-native.md
+++ b/elixir/docs/windows-native.md
@@ -204,6 +204,15 @@ The app-server session also exposes a `linear_graphql` dynamic tool so the
 agent can update Linear comments and issue state without relying on a separate
 MCP flow.
 
+Agent-initiated moves to `In Review` are guarded by review readiness checks.
+The tool only allows that transition when the issue has a linked GitHub PR and
+the required checks on the PR head are complete and successful. If GitHub branch
+protection metadata is private or unavailable to the Windows runtime, configure
+`codex.review_readiness_required_checks` with the required check names; the gate
+then verifies those public PR check runs/statuses and still fails closed on
+missing, pending, failing, or unverifiable results. Manager overrides must happen
+outside the agent tool call and leave an audit note in Linear or GitHub.
+
 ### Progress tracking
 
 The recommended prompt pattern is to keep one persistent Linear comment whose

--- a/elixir/lib/symphony_elixir/codex/dynamic_tool.ex
+++ b/elixir/lib/symphony_elixir/codex/dynamic_tool.ex
@@ -3,6 +3,7 @@ defmodule SymphonyElixir.Codex.DynamicTool do
   Executes client-side tool calls requested by Codex app-server turns.
   """
 
+  alias SymphonyElixir.Codex.ReviewReadiness
   alias SymphonyElixir.Linear.Client
 
   @linear_graphql_tool "linear_graphql"
@@ -55,11 +56,16 @@ defmodule SymphonyElixir.Codex.DynamicTool do
 
   defp execute_linear_graphql(arguments, opts) do
     linear_client = Keyword.get(opts, :linear_client, &Client.graphql/3)
+    github_client = Keyword.get(opts, :github_client, &ReviewReadiness.github_get/2)
 
     with {:ok, query, variables} <- normalize_linear_graphql_arguments(arguments),
+         :ok <- ReviewReadiness.authorize_linear_graphql(query, variables, linear_client, github_client),
          {:ok, response} <- linear_client.(query, variables, []) do
       graphql_response(response)
     else
+      {:error, {:review_readiness_rejected, payload}} ->
+        failure_response(payload)
+
       {:error, reason} ->
         failure_response(tool_error_payload(reason))
     end

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -115,6 +115,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   end
 
   defp transition_request(query, variables) do
+    query = normalize_graphql_ignored_tokens(query)
     issue_update_count = issue_update_count(query)
 
     cond do
@@ -153,6 +154,51 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     |> Regex.scan(query)
     |> length()
   end
+
+  defp normalize_graphql_ignored_tokens(query) do
+    query
+    |> String.graphemes()
+    |> normalize_graphql_ignored_tokens(:normal, [])
+    |> IO.iodata_to_binary()
+  end
+
+  defp normalize_graphql_ignored_tokens([], _mode, acc), do: Enum.reverse(acc)
+
+  defp normalize_graphql_ignored_tokens(["\"" | rest], :normal, acc) do
+    normalize_graphql_ignored_tokens(rest, :string, ["\"" | acc])
+  end
+
+  defp normalize_graphql_ignored_tokens(["#", "\n" | rest], :normal, acc) do
+    normalize_graphql_ignored_tokens(rest, :normal, [" " | acc])
+  end
+
+  defp normalize_graphql_ignored_tokens(["#" | rest], :normal, acc) do
+    {rest, acc} = drop_graphql_comment(rest, acc)
+    normalize_graphql_ignored_tokens(rest, :normal, acc)
+  end
+
+  defp normalize_graphql_ignored_tokens([char | rest], :normal, acc)
+       when char in ["\uFEFF", "\t", "\n", "\r", ","] do
+    normalize_graphql_ignored_tokens(rest, :normal, [" " | acc])
+  end
+
+  defp normalize_graphql_ignored_tokens(["\\" = char, escaped | rest], :string, acc) do
+    normalize_graphql_ignored_tokens(rest, :string, [escaped, char | acc])
+  end
+
+  defp normalize_graphql_ignored_tokens(["\"" | rest], :string, acc) do
+    normalize_graphql_ignored_tokens(rest, :normal, ["\"" | acc])
+  end
+
+  defp normalize_graphql_ignored_tokens([char | rest], mode, acc) do
+    normalize_graphql_ignored_tokens(rest, mode, [char | acc])
+  end
+
+  defp drop_graphql_comment([], acc), do: {[], acc}
+  defp drop_graphql_comment(["\n" | rest], acc), do: {rest, [" " | acc]}
+  defp drop_graphql_comment(["\r", "\n" | rest], acc), do: {rest, [" " | acc]}
+  defp drop_graphql_comment(["\r" | rest], acc), do: {rest, [" " | acc]}
+  defp drop_graphql_comment([_char | rest], acc), do: drop_graphql_comment(rest, acc)
 
   defp explicit_state_id?(query) do
     String.contains?(query, "stateId")
@@ -281,23 +327,8 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
         _ -> []
       end
 
-    comment_urls =
-      issue
-      |> get_in(["comments", "nodes"])
-      |> case do
-        comments when is_list(comments) -> Enum.flat_map(comments, &pull_request_urls_from_comment/1)
-        _ -> []
-      end
-
-    attachment_urls ++ comment_urls
+    attachment_urls
   end
-
-  defp pull_request_urls_from_comment(%{"body" => body}) when is_binary(body) do
-    Regex.scan(~r/https:\/\/github\.com\/[^\s\)>\]]+\/[^\s\)>\]]+\/pull\/\d+/, body)
-    |> List.flatten()
-  end
-
-  defp pull_request_urls_from_comment(_comment), do: []
 
   defp parse_pull_request_url(url) when is_binary(url) do
     case Regex.run(~r/^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/pull\/(\d+)/, url) do
@@ -321,7 +352,8 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   end
 
   defp required_checks(owner, repo, base_ref, github_client) do
-    protection_url = "#{@github_api}/repos/#{owner}/#{repo}/branches/#{base_ref}/protection/required_status_checks"
+    encoded_base_ref = URI.encode(base_ref, &URI.char_unreserved?/1)
+    protection_url = "#{@github_api}/repos/#{owner}/#{repo}/branches/#{encoded_base_ref}/protection/required_status_checks"
 
     case github_json(github_client, protection_url) do
       {:ok, protection} -> required_check_specs(protection)

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -7,6 +7,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   @github_accept "application/vnd.github+json"
   @passing_status_states MapSet.new(["success"])
   @passing_check_conclusions MapSet.new(["success", "neutral", "skipped"])
+  alias SymphonyElixir.Config
 
   @context_query """
   query SymphonyReviewReadinessContext($issueId: String!) {
@@ -114,9 +115,14 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   end
 
   defp transition_request(query, variables) do
+    issue_update_count = issue_update_count(query)
+
     cond do
-      not issue_update?(query) ->
+      issue_update_count == 0 ->
         :not_state_transition
+
+      issue_update_count > 1 ->
+        {:error, :review_readiness_multiple_issue_updates}
 
       explicit_state_id?(query) ->
         with {:ok, issue_id} <- issue_id_from(query, variables),
@@ -142,9 +148,10 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     end
   end
 
-  defp issue_update?(query) do
-    normalized = String.replace(query, ~r/\s+/, " ")
-    String.contains?(normalized, "issueUpdate")
+  defp issue_update_count(query) do
+    ~r/\bissueUpdate\s*\(/
+    |> Regex.scan(query)
+    |> length()
   end
 
   defp explicit_state_id?(query) do
@@ -305,12 +312,20 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     with {:ok, pr} <- github_json(github_client, "#{@github_api}/repos/#{owner}/#{repo}/pulls/#{number}"),
          {:ok, head_sha} <- required_string(pr, ["head", "sha"], :review_readiness_missing_pr_head_sha),
          {:ok, base_ref} <- required_string(pr, ["base", "ref"], :review_readiness_missing_pr_base_ref),
-         {:ok, protection} <-
-           github_json(github_client, "#{@github_api}/repos/#{owner}/#{repo}/branches/#{base_ref}/protection/required_status_checks"),
-         {:ok, contexts} <- required_contexts(protection),
+         {:ok, required_checks} <-
+           required_checks(owner, repo, base_ref, github_client),
          {:ok, statuses} <- github_json(github_client, "#{@github_api}/repos/#{owner}/#{repo}/commits/#{head_sha}/status"),
          {:ok, check_runs} <- github_json(github_client, "#{@github_api}/repos/#{owner}/#{repo}/commits/#{head_sha}/check-runs") do
-      verify_contexts(contexts, statuses, check_runs)
+      verify_contexts(required_checks, statuses, check_runs)
+    end
+  end
+
+  defp required_checks(owner, repo, base_ref, github_client) do
+    protection_url = "#{@github_api}/repos/#{owner}/#{repo}/branches/#{base_ref}/protection/required_status_checks"
+
+    case github_json(github_client, protection_url) do
+      {:ok, protection} -> required_check_specs(protection)
+      {:error, reason} -> configured_required_checks_or_error(reason)
     end
   end
 
@@ -334,45 +349,120 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     end
   end
 
-  defp required_contexts(%{"contexts" => contexts}) when is_list(contexts) do
-    contexts
-    |> Enum.filter(&is_binary/1)
-    |> Enum.reject(&(String.trim(&1) == ""))
-    |> case do
-      [] -> {:error, :review_readiness_required_checks_missing}
-      contexts -> {:ok, contexts}
+  defp required_check_specs(%{"checks" => checks} = payload) when is_list(checks) and checks != [] do
+    specs =
+      checks
+      |> Enum.map(&required_check_spec/1)
+      |> Enum.reject(&is_nil/1)
+
+    if specs == [] do
+      required_context_specs(payload)
+    else
+      {:ok, specs}
     end
   end
 
-  defp required_contexts(_payload), do: {:error, :review_readiness_required_checks_unverifiable}
+  defp required_check_specs(payload), do: required_context_specs(payload)
 
-  defp verify_contexts(contexts, statuses, check_runs) do
+  defp required_check_spec(%{"context" => context} = check) when is_binary(context) do
+    context = String.trim(context)
+
+    if context == "" do
+      nil
+    else
+      %{context: context, app_id: normalize_app_id(Map.get(check, "app_id"))}
+    end
+  end
+
+  defp required_check_spec(_check), do: nil
+
+  defp required_context_specs(%{"contexts" => contexts}) when is_list(contexts) do
+    contexts
+    |> Enum.map(&required_context_spec/1)
+    |> Enum.reject(&is_nil/1)
+    |> case do
+      [] -> {:error, :review_readiness_required_checks_missing}
+      specs -> {:ok, specs}
+    end
+  end
+
+  defp required_context_specs(_payload), do: {:error, :review_readiness_required_checks_unverifiable}
+
+  defp required_context_spec(context) when is_binary(context) do
+    context
+    |> String.trim()
+    |> case do
+      "" -> nil
+      trimmed -> %{context: trimmed, app_id: nil}
+    end
+  end
+
+  defp required_context_spec(_context), do: nil
+
+  defp configured_required_checks_or_error(reason) do
+    configured_required_checks()
+    |> Enum.map(&%{context: &1, app_id: nil})
+    |> case do
+      [] -> {:error, reason}
+      specs -> {:ok, specs}
+    end
+  end
+
+  defp configured_required_checks do
+    Config.settings!().codex.review_readiness_required_checks
+  rescue
+    _ -> []
+  end
+
+  defp verify_contexts(required_checks, statuses, check_runs) do
     status_contexts = latest_status_contexts(statuses)
-    check_contexts = latest_check_contexts(check_runs)
+    check_runs_by_name = latest_check_runs_by_name(check_runs)
 
     failures =
-      Enum.flat_map(contexts, fn context ->
-        cond do
-          Map.get(status_contexts, context) in @passing_status_states ->
-            []
-
-          Map.get(check_contexts, context) in @passing_check_conclusions ->
-            []
-
-          Map.has_key?(status_contexts, context) ->
-            [{context, {:status, Map.get(status_contexts, context)}}]
-
-          Map.has_key?(check_contexts, context) ->
-            [{context, {:check, Map.get(check_contexts, context)}}]
-
-          true ->
-            [{context, :missing}]
-        end
-      end)
+      Enum.flat_map(required_checks, &check_failure(&1, status_contexts, check_runs_by_name))
 
     case failures do
       [] -> :ok
       failures -> {:error, {:review_readiness_required_checks_not_passing, failures}}
+    end
+  end
+
+  defp check_failure(%{context: context, app_id: nil}, status_contexts, check_runs_by_name) do
+    latest_check = latest_check_run(check_runs_by_name, context, nil)
+
+    cond do
+      Map.get(status_contexts, context) in @passing_status_states ->
+        []
+
+      check_run_conclusion(latest_check) in @passing_check_conclusions ->
+        []
+
+      Map.has_key?(status_contexts, context) ->
+        [{context, {:status, Map.get(status_contexts, context)}}]
+
+      latest_check != nil ->
+        [{context, {:check, check_run_conclusion(latest_check)}}]
+
+      true ->
+        [{context, :missing}]
+    end
+  end
+
+  defp check_failure(%{context: context, app_id: app_id}, _status_contexts, check_runs_by_name) do
+    latest_check = latest_check_run(check_runs_by_name, context, app_id)
+
+    cond do
+      check_run_conclusion(latest_check) in @passing_check_conclusions ->
+        []
+
+      latest_check != nil ->
+        [{context, {:check, check_run_conclusion(latest_check)}}]
+
+      Map.has_key?(check_runs_by_name, context) ->
+        [{context, {:check, "app_mismatch"}}]
+
+      true ->
+        [{context, :missing}]
     end
   end
 
@@ -389,11 +479,11 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
 
   defp latest_status_contexts(_statuses), do: %{}
 
-  defp latest_check_contexts(%{"check_runs" => runs}) when is_list(runs) do
+  defp latest_check_runs_by_name(%{"check_runs" => runs}) when is_list(runs) do
     Enum.reduce(runs, %{}, fn run, acc ->
       case Map.get(run, "name") do
         name when is_binary(name) ->
-          Map.put_new(acc, name, check_run_conclusion(run))
+          Map.update(acc, name, [run], &(&1 ++ [run]))
 
         _ ->
           acc
@@ -401,7 +491,21 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     end)
   end
 
-  defp latest_check_contexts(_runs), do: %{}
+  defp latest_check_runs_by_name(_runs), do: %{}
+
+  defp latest_check_run(check_runs_by_name, context, nil) do
+    check_runs_by_name
+    |> Map.get(context, [])
+    |> List.first()
+  end
+
+  defp latest_check_run(check_runs_by_name, context, app_id) do
+    check_runs_by_name
+    |> Map.get(context, [])
+    |> Enum.find(&(check_run_app_id(&1) == app_id))
+  end
+
+  defp check_run_conclusion(nil), do: "missing"
 
   defp check_run_conclusion(run) do
     case {Map.get(run, "status"), Map.get(run, "conclusion")} do
@@ -410,6 +514,20 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
       _ -> "missing"
     end
   end
+
+  defp check_run_app_id(%{"app" => %{"id" => app_id}}), do: normalize_app_id(app_id)
+  defp check_run_app_id(_run), do: nil
+
+  defp normalize_app_id(app_id) when is_integer(app_id), do: Integer.to_string(app_id)
+
+  defp normalize_app_id(app_id) when is_binary(app_id) do
+    case String.trim(app_id) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp normalize_app_id(_app_id), do: nil
 
   defp reject(issue_or_id, reason, linear_client) do
     issue = if is_map(issue_or_id), do: issue_or_id, else: %{"id" => issue_or_id}
@@ -484,6 +602,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
 
   defp rejection_message(:review_readiness_missing_issue_id), do: "the issue id could not be determined."
   defp rejection_message(:review_readiness_missing_state_id), do: "the target state id could not be determined."
+  defp rejection_message(:review_readiness_multiple_issue_updates), do: "multiple issueUpdate mutations were found; review readiness can only verify one state transition at a time."
   defp rejection_message(:review_readiness_issue_unverifiable), do: "Linear issue context could not be verified."
   defp rejection_message(:review_readiness_destination_state_unverifiable), do: "the destination state could not be verified."
   defp rejection_message(:review_readiness_missing_linked_pull_request), do: "no linked GitHub pull request was found."

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -181,55 +181,53 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
 
   defp executable_graphql(query) do
     query
-    |> String.graphemes()
-    |> executable_graphql(:normal, [])
+    |> executable_graphql([])
     |> IO.iodata_to_binary()
   end
 
-  defp executable_graphql([], _mode, acc), do: Enum.reverse(acc)
+  defp executable_graphql(<<>>, acc), do: Enum.reverse(acc)
 
-  defp executable_graphql(["\"", "\"", "\"" | rest], :normal, acc) do
+  defp executable_graphql(<<"\"\"\"", rest::binary>>, acc) do
     {rest, acc} = blank_block_string(rest, ["\"\"\"" | acc])
-    executable_graphql(rest, :normal, acc)
+    executable_graphql(rest, acc)
   end
 
-  defp executable_graphql(["\"" | rest], :normal, acc) do
+  defp executable_graphql(<<"\"", rest::binary>>, acc) do
     {rest, acc} = blank_string(rest, ["\"" | acc])
-    executable_graphql(rest, :normal, acc)
+    executable_graphql(rest, acc)
   end
 
-  defp executable_graphql(["#", "\n" | rest], :normal, acc) do
-    executable_graphql(rest, :normal, [" " | acc])
+  defp executable_graphql(<<"#", rest::binary>>, acc) do
+    {rest, acc} = blank_graphql_comment(rest, [" " | acc])
+    executable_graphql(rest, acc)
   end
 
-  defp executable_graphql(["#" | rest], :normal, acc) do
-    {rest, acc} = drop_graphql_comment(rest, acc)
-    executable_graphql(rest, :normal, acc)
+  defp executable_graphql(<<0xEF, 0xBB, 0xBF, rest::binary>>, acc) do
+    executable_graphql(rest, ["   " | acc])
   end
 
-  defp executable_graphql([char | rest], :normal, acc)
-       when char in ["\uFEFF", "\t", "\n", "\r", ","] do
-    executable_graphql(rest, :normal, [" " | acc])
+  defp executable_graphql(<<char, rest::binary>>, acc) when char in [?\t, ?\n, ?\r, ?,] do
+    executable_graphql(rest, [" " | acc])
   end
 
-  defp executable_graphql([char | rest], mode, acc) do
-    executable_graphql(rest, mode, [char | acc])
+  defp executable_graphql(<<char, rest::binary>>, acc) do
+    executable_graphql(rest, [<<char>> | acc])
   end
 
-  defp drop_graphql_comment([], acc), do: {[], acc}
-  defp drop_graphql_comment(["\n" | rest], acc), do: {rest, [" " | acc]}
-  defp drop_graphql_comment(["\r", "\n" | rest], acc), do: {rest, [" " | acc]}
-  defp drop_graphql_comment(["\r" | rest], acc), do: {rest, [" " | acc]}
-  defp drop_graphql_comment([_char | rest], acc), do: drop_graphql_comment(rest, acc)
+  defp blank_graphql_comment(<<>>, acc), do: {<<>>, acc}
+  defp blank_graphql_comment(<<"\r\n", rest::binary>>, acc), do: {rest, ["  " | acc]}
+  defp blank_graphql_comment(<<"\n", rest::binary>>, acc), do: {rest, [" " | acc]}
+  defp blank_graphql_comment(<<"\r", rest::binary>>, acc), do: {rest, [" " | acc]}
+  defp blank_graphql_comment(<<_char, rest::binary>>, acc), do: blank_graphql_comment(rest, [" " | acc])
 
-  defp blank_string([], acc), do: {[], acc}
-  defp blank_string(["\\", _escaped | rest], acc), do: blank_string(rest, ["  " | acc])
-  defp blank_string(["\"" | rest], acc), do: {rest, ["\"" | acc]}
-  defp blank_string([_char | rest], acc), do: blank_string(rest, [" " | acc])
+  defp blank_string(<<>>, acc), do: {<<>>, acc}
+  defp blank_string(<<"\\", _escaped, rest::binary>>, acc), do: blank_string(rest, ["  " | acc])
+  defp blank_string(<<"\"", rest::binary>>, acc), do: {rest, ["\"" | acc]}
+  defp blank_string(<<_char, rest::binary>>, acc), do: blank_string(rest, [" " | acc])
 
-  defp blank_block_string([], acc), do: {[], acc}
-  defp blank_block_string(["\"", "\"", "\"" | rest], acc), do: {rest, ["\"\"\"" | acc]}
-  defp blank_block_string([_char | rest], acc), do: blank_block_string(rest, [" " | acc])
+  defp blank_block_string(<<>>, acc), do: {<<>>, acc}
+  defp blank_block_string(<<"\"\"\"", rest::binary>>, acc), do: {rest, ["\"\"\"" | acc]}
+  defp blank_block_string(<<_char, rest::binary>>, acc), do: blank_block_string(rest, [" " | acc])
 
   defp explicit_state_id?(query) do
     String.contains?(query, "stateId")

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -132,23 +132,28 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
 
   defp transition_request_from_issue_update(query, executable_query, variables) do
     with {:ok, arguments, executable_arguments} <- issue_update_arguments(query, executable_query) do
-      cond do
-        explicit_state_id?(executable_arguments) ->
-          with {:ok, issue_id} <- issue_id_from(arguments, executable_arguments, variables),
-               {:ok, state_id} <- explicit_state_id_from(arguments, executable_arguments, variables) do
-            {:ok, issue_id, state_id}
-          end
-
-        true ->
-          input_transition_request(arguments, executable_arguments, variables)
+      if explicit_state_id?(executable_arguments) do
+        explicit_transition_request(arguments, executable_arguments, variables)
+      else
+        input_transition_request(arguments, executable_arguments, variables)
       end
+    end
+  end
+
+  defp explicit_transition_request(arguments, executable_arguments, variables) do
+    with {:ok, issue_id} <- issue_id_from(arguments, executable_arguments, variables),
+         {:ok, state_id} <- explicit_state_id_from(arguments, executable_arguments, variables) do
+      {:ok, issue_id, state_id}
     end
   end
 
   defp issue_update_arguments(query, executable_query) do
     case Regex.run(~r/\bissueUpdate\s*\((.*?)\)\s*\{/s, executable_query, return: :index) do
       [{_match_start, _match_length}, {arguments_start, arguments_length}] ->
-        {:ok, binary_part(query, arguments_start, arguments_length), binary_part(executable_query, arguments_start, arguments_length)}
+        original_arguments = binary_part(query, arguments_start, arguments_length)
+        executable_arguments = binary_part(executable_query, arguments_start, arguments_length)
+
+        {:ok, original_arguments, executable_arguments}
 
       _ ->
         {:error, :review_readiness_issue_update_unverifiable}
@@ -391,9 +396,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   defp pull_request_matches_issue?(issue, owner, repo, pr) do
     with :ok <- expected_repository?(owner, repo),
          :ok <- head_repository_matches?(pr),
-         :ok <- pull_request_branch_matches_issue?(issue, pr) do
-      :ok
-    end
+         do: pull_request_branch_matches_issue?(issue, pr)
   end
 
   defp expected_repository?(owner, repo) do

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -1,0 +1,535 @@
+defmodule SymphonyElixir.Codex.ReviewReadiness do
+  @moduledoc """
+  Guards agent-initiated Linear `In Review` transitions.
+  """
+
+  @github_api "https://api.github.com"
+  @github_accept "application/vnd.github+json"
+  @passing_status_states MapSet.new(["success"])
+  @passing_check_conclusions MapSet.new(["success", "neutral", "skipped"])
+
+  @context_query """
+  query SymphonyReviewReadinessContext($issueId: String!) {
+    issue(id: $issueId) {
+      id
+      identifier
+      url
+      team {
+        states(first: 250) {
+          nodes {
+            id
+            name
+          }
+        }
+      }
+      attachments {
+        nodes {
+          title
+          url
+        }
+      }
+      comments(first: 50) {
+        nodes {
+          id
+          body
+        }
+      }
+    }
+  }
+  """
+
+  @create_comment_mutation """
+  mutation SymphonyReviewReadinessCreateWorkpad($issueId: String!, $body: String!) {
+    commentCreate(input: {issueId: $issueId, body: $body}) {
+      success
+    }
+  }
+  """
+
+  @update_comment_mutation """
+  mutation SymphonyReviewReadinessUpdateWorkpad($commentId: String!, $body: String!) {
+    commentUpdate(id: $commentId, input: {body: $body}) {
+      success
+    }
+  }
+  """
+
+  @spec authorize_linear_graphql(String.t(), map(), function(), function()) ::
+          :ok | {:error, {:review_readiness_rejected, map()}}
+  def authorize_linear_graphql(query, variables, linear_client, github_client)
+      when is_binary(query) and is_map(variables) and is_function(linear_client) and is_function(github_client) do
+    case transition_request(query, variables) do
+      {:ok, issue_id, state_id} ->
+        authorize_transition(issue_id, state_id, variables, linear_client, github_client)
+
+      :not_state_transition ->
+        :ok
+
+      {:error, reason} ->
+        reject(nil, reason, linear_client)
+    end
+  end
+
+  @spec github_get(String.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  def github_get(url, opts \\ []) when is_binary(url) and is_list(opts) do
+    headers =
+      [
+        {"Accept", @github_accept},
+        {"User-Agent", "symphony-review-readiness"}
+      ]
+      |> maybe_add_github_token()
+
+    Req.get(url, headers: headers, connect_options: [timeout: Keyword.get(opts, :timeout, 30_000)])
+  end
+
+  defp authorize_transition(issue_id, state_id, variables, linear_client, github_client) do
+    with {:ok, issue} <- fetch_issue_context(issue_id, linear_client),
+         {:ok, destination_state} <- destination_state(issue, state_id) do
+      authorize_destination(issue, destination_state, variables, linear_client, github_client)
+    else
+      {:error, reason} -> reject(issue_id, reason, linear_client)
+    end
+  end
+
+  defp authorize_destination(issue, destination_state, variables, linear_client, github_client) do
+    cond do
+      not in_review_state?(destination_state) ->
+        :ok
+
+      manager_override?(variables) ->
+        reject(issue, :review_readiness_agent_override_not_allowed, linear_client)
+
+      true ->
+        verify_review_ready(issue, linear_client, github_client)
+    end
+  end
+
+  defp verify_review_ready(issue, linear_client, github_client) do
+    with {:ok, pr} <- linked_pull_request(issue),
+         :ok <- required_checks_passed?(pr, github_client) do
+      :ok
+    else
+      {:error, reason} -> reject(issue, reason, linear_client)
+    end
+  end
+
+  defp transition_request(query, variables) do
+    cond do
+      not issue_update?(query) ->
+        :not_state_transition
+
+      explicit_state_id?(query) ->
+        with {:ok, issue_id} <- issue_id_from(query, variables),
+             {:ok, state_id} <- explicit_state_id_from(query, variables) do
+          {:ok, issue_id, state_id}
+        end
+
+      true ->
+        input_transition_request(query, variables)
+    end
+  end
+
+  defp input_transition_request(query, variables) do
+    case input_state_id_from(query, variables) do
+      {:ok, state_id} -> issue_transition_request(query, variables, state_id)
+      nil -> :not_state_transition
+    end
+  end
+
+  defp issue_transition_request(query, variables, state_id) do
+    with {:ok, issue_id} <- issue_id_from(query, variables) do
+      {:ok, issue_id, state_id}
+    end
+  end
+
+  defp issue_update?(query) do
+    normalized = String.replace(query, ~r/\s+/, " ")
+    String.contains?(normalized, "issueUpdate")
+  end
+
+  defp explicit_state_id?(query) do
+    String.contains?(query, "stateId")
+  end
+
+  defp issue_id_from(query, variables) do
+    variable_value(query, variables, ~r/issueUpdate\s*\(\s*id\s*:\s*\$(\w+)/) ||
+      literal_value(query, ~r/issueUpdate\s*\(\s*id\s*:\s*"([^"]+)"/) ||
+      {:error, :review_readiness_missing_issue_id}
+  end
+
+  defp explicit_state_id_from(query, variables) do
+    variable_value(query, variables, ~r/stateId\s*:\s*\$(\w+)/) ||
+      literal_value(query, ~r/stateId\s*:\s*"([^"]+)"/) ||
+      {:error, :review_readiness_missing_state_id}
+  end
+
+  defp input_state_id_from(query, variables) do
+    case Regex.run(~r/input\s*:\s*\$(\w+)/, query) do
+      [_, variable_name] ->
+        with input when is_map(input) <- variable_map_value(variables, variable_name),
+             state_id when is_binary(state_id) and state_id != "" <- Map.get(input, "stateId") || Map.get(input, :stateId) do
+          {:ok, state_id}
+        else
+          _ -> nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp variable_value(query, variables, regex) do
+    case Regex.run(regex, query) do
+      [_, variable_name] ->
+        case variable_map_value(variables, variable_name) do
+          value when is_binary(value) and value != "" -> {:ok, value}
+          _ -> {:error, {:review_readiness_missing_variable, variable_name}}
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp variable_map_value(variables, variable_name) do
+    Map.get(variables, variable_name) || Map.get(variables, String.to_existing_atom(variable_name))
+  rescue
+    ArgumentError -> Map.get(variables, variable_name)
+  end
+
+  defp literal_value(query, regex) do
+    case Regex.run(regex, query) do
+      [_, value] when value != "" -> {:ok, value}
+      _ -> nil
+    end
+  end
+
+  defp fetch_issue_context(issue_id, linear_client) do
+    case linear_client.(@context_query, %{"issueId" => issue_id}, []) do
+      {:ok, %{"data" => %{"issue" => issue}}} when is_map(issue) -> {:ok, issue}
+      {:ok, _payload} -> {:error, :review_readiness_issue_unverifiable}
+      {:error, reason} -> {:error, {:review_readiness_issue_unverifiable, reason}}
+    end
+  end
+
+  defp destination_state(issue, state_id) do
+    issue
+    |> get_in(["team", "states", "nodes"])
+    |> case do
+      states when is_list(states) ->
+        case Enum.find(states, &(Map.get(&1, "id") == state_id)) do
+          %{"name" => name} when is_binary(name) -> {:ok, name}
+          _ -> {:error, :review_readiness_destination_state_unverifiable}
+        end
+
+      _ ->
+        {:error, :review_readiness_destination_state_unverifiable}
+    end
+  end
+
+  defp in_review_state?(state_name) when is_binary(state_name) do
+    normalize(state_name) == "in review"
+  end
+
+  defp manager_override?(variables) do
+    truthy?(Map.get(variables, "symphonyManagerOverride") || Map.get(variables, :symphonyManagerOverride)) and
+      override_reason(variables) != nil
+  end
+
+  defp truthy?(true), do: true
+  defp truthy?("true"), do: true
+  defp truthy?("yes"), do: true
+  defp truthy?("1"), do: true
+  defp truthy?(_), do: false
+
+  defp override_reason(variables) do
+    case Map.get(variables, "symphonyManagerOverrideReason") || Map.get(variables, :symphonyManagerOverrideReason) do
+      reason when is_binary(reason) ->
+        case String.trim(reason) do
+          "" -> nil
+          trimmed -> trimmed
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp linked_pull_request(issue) do
+    issue
+    |> pull_request_urls()
+    |> Enum.find_value(&parse_pull_request_url/1)
+    |> case do
+      nil -> {:error, :review_readiness_missing_linked_pull_request}
+      pr -> {:ok, pr}
+    end
+  end
+
+  defp pull_request_urls(issue) do
+    attachment_urls =
+      issue
+      |> get_in(["attachments", "nodes"])
+      |> case do
+        attachments when is_list(attachments) -> Enum.map(attachments, &Map.get(&1, "url"))
+        _ -> []
+      end
+
+    comment_urls =
+      issue
+      |> get_in(["comments", "nodes"])
+      |> case do
+        comments when is_list(comments) -> Enum.flat_map(comments, &pull_request_urls_from_comment/1)
+        _ -> []
+      end
+
+    attachment_urls ++ comment_urls
+  end
+
+  defp pull_request_urls_from_comment(%{"body" => body}) when is_binary(body) do
+    Regex.scan(~r/https:\/\/github\.com\/[^\s\)>\]]+\/[^\s\)>\]]+\/pull\/\d+/, body)
+    |> List.flatten()
+  end
+
+  defp pull_request_urls_from_comment(_comment), do: []
+
+  defp parse_pull_request_url(url) when is_binary(url) do
+    case Regex.run(~r/^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/pull\/(\d+)/, url) do
+      [_, owner, repo, number] -> %{owner: owner, repo: repo, number: number}
+      _ -> nil
+    end
+  end
+
+  defp parse_pull_request_url(_url), do: nil
+
+  defp required_checks_passed?(%{owner: owner, repo: repo, number: number}, github_client) do
+    with {:ok, pr} <- github_json(github_client, "#{@github_api}/repos/#{owner}/#{repo}/pulls/#{number}"),
+         {:ok, head_sha} <- required_string(pr, ["head", "sha"], :review_readiness_missing_pr_head_sha),
+         {:ok, base_ref} <- required_string(pr, ["base", "ref"], :review_readiness_missing_pr_base_ref),
+         {:ok, protection} <-
+           github_json(github_client, "#{@github_api}/repos/#{owner}/#{repo}/branches/#{base_ref}/protection/required_status_checks"),
+         {:ok, contexts} <- required_contexts(protection),
+         {:ok, statuses} <- github_json(github_client, "#{@github_api}/repos/#{owner}/#{repo}/commits/#{head_sha}/status"),
+         {:ok, check_runs} <- github_json(github_client, "#{@github_api}/repos/#{owner}/#{repo}/commits/#{head_sha}/check-runs") do
+      verify_contexts(contexts, statuses, check_runs)
+    end
+  end
+
+  defp github_json(github_client, url) do
+    case github_client.(url, []) do
+      {:ok, %{status: status, body: body}} when status in 200..299 and is_map(body) ->
+        {:ok, body}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, {:review_readiness_github_unverifiable, status, summarize_body(body)}}
+
+      {:error, reason} ->
+        {:error, {:review_readiness_github_unverifiable, reason}}
+    end
+  end
+
+  defp required_string(payload, path, error) do
+    case get_in(payload, path) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, error}
+    end
+  end
+
+  defp required_contexts(%{"contexts" => contexts}) when is_list(contexts) do
+    contexts
+    |> Enum.filter(&is_binary/1)
+    |> Enum.reject(&(String.trim(&1) == ""))
+    |> case do
+      [] -> {:error, :review_readiness_required_checks_missing}
+      contexts -> {:ok, contexts}
+    end
+  end
+
+  defp required_contexts(_payload), do: {:error, :review_readiness_required_checks_unverifiable}
+
+  defp verify_contexts(contexts, statuses, check_runs) do
+    status_contexts = latest_status_contexts(statuses)
+    check_contexts = latest_check_contexts(check_runs)
+
+    failures =
+      Enum.flat_map(contexts, fn context ->
+        cond do
+          Map.get(status_contexts, context) in @passing_status_states ->
+            []
+
+          Map.get(check_contexts, context) in @passing_check_conclusions ->
+            []
+
+          Map.has_key?(status_contexts, context) ->
+            [{context, {:status, Map.get(status_contexts, context)}}]
+
+          Map.has_key?(check_contexts, context) ->
+            [{context, {:check, Map.get(check_contexts, context)}}]
+
+          true ->
+            [{context, :missing}]
+        end
+      end)
+
+    case failures do
+      [] -> :ok
+      failures -> {:error, {:review_readiness_required_checks_not_passing, failures}}
+    end
+  end
+
+  defp latest_status_contexts(%{"statuses" => statuses}) when is_list(statuses) do
+    Enum.reduce(statuses, %{}, fn status, acc ->
+      with context when is_binary(context) <- Map.get(status, "context"),
+           state when is_binary(state) <- Map.get(status, "state") do
+        Map.put_new(acc, context, state)
+      else
+        _ -> acc
+      end
+    end)
+  end
+
+  defp latest_status_contexts(_statuses), do: %{}
+
+  defp latest_check_contexts(%{"check_runs" => runs}) when is_list(runs) do
+    Enum.reduce(runs, %{}, fn run, acc ->
+      case Map.get(run, "name") do
+        name when is_binary(name) ->
+          Map.put_new(acc, name, check_run_conclusion(run))
+
+        _ ->
+          acc
+      end
+    end)
+  end
+
+  defp latest_check_contexts(_runs), do: %{}
+
+  defp check_run_conclusion(run) do
+    case {Map.get(run, "status"), Map.get(run, "conclusion")} do
+      {"completed", value} when is_binary(value) -> value
+      {status, _} when is_binary(status) -> status
+      _ -> "missing"
+    end
+  end
+
+  defp reject(issue_or_id, reason, linear_client) do
+    issue = if is_map(issue_or_id), do: issue_or_id, else: %{"id" => issue_or_id}
+    message = rejection_message(reason)
+
+    if is_binary(issue["id"]) do
+      _ = upsert_workpad(issue, readiness_note(issue, "In Review transition rejected", message), linear_client)
+    end
+
+    {:error,
+     {:review_readiness_rejected,
+      %{
+        "error" => %{
+          "code" => "review_readiness_rejected",
+          "message" => "Linear In Review transition rejected: #{message}",
+          "reason" => inspect(reason)
+        }
+      }}}
+  end
+
+  defp upsert_workpad(issue, note, linear_client) do
+    case workpad_comment(issue) do
+      %{"id" => comment_id, "body" => body} when is_binary(comment_id) and is_binary(body) ->
+        linear_client.(@update_comment_mutation, %{"commentId" => comment_id, "body" => append_workpad_note(body, note)}, [])
+        |> comment_result("commentUpdate")
+
+      _ ->
+        linear_client.(@create_comment_mutation, %{"issueId" => issue["id"], "body" => "## Codex Workpad\n\n" <> note}, [])
+        |> comment_result("commentCreate")
+    end
+  end
+
+  defp workpad_comment(issue) do
+    issue
+    |> get_in(["comments", "nodes"])
+    |> case do
+      comments when is_list(comments) ->
+        Enum.find(comments, fn
+          %{"body" => body} when is_binary(body) -> String.starts_with?(String.trim_leading(body), "## Codex Workpad")
+          _ -> false
+        end)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp append_workpad_note(body, note) do
+    String.trim_trailing(body) <> "\n\n" <> note
+  end
+
+  defp comment_result({:ok, %{"data" => data}}, field) when is_map(data) do
+    if get_in(data, [field, "success"]) == true, do: :ok, else: {:error, :workpad_update_failed}
+  end
+
+  defp comment_result({:ok, _payload}, _field), do: {:error, :workpad_update_failed}
+  defp comment_result({:error, reason}, _field), do: {:error, reason}
+
+  defp readiness_note(issue, heading, detail) do
+    identifier = Map.get(issue, "identifier") || Map.get(issue, "id") || "unknown issue"
+
+    [
+      "### Review readiness",
+      "",
+      "- Issue: #{identifier}",
+      "- Decision: #{heading}",
+      "- Detail: #{detail}",
+      "- Recorded at: #{DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()}"
+    ]
+    |> Enum.join("\n")
+  end
+
+  defp rejection_message(:review_readiness_missing_issue_id), do: "the issue id could not be determined."
+  defp rejection_message(:review_readiness_missing_state_id), do: "the target state id could not be determined."
+  defp rejection_message(:review_readiness_issue_unverifiable), do: "Linear issue context could not be verified."
+  defp rejection_message(:review_readiness_destination_state_unverifiable), do: "the destination state could not be verified."
+  defp rejection_message(:review_readiness_missing_linked_pull_request), do: "no linked GitHub pull request was found."
+  defp rejection_message(:review_readiness_required_checks_missing), do: "no required GitHub checks are configured or visible."
+  defp rejection_message(:review_readiness_required_checks_unverifiable), do: "required GitHub checks could not be verified."
+  defp rejection_message(:review_readiness_missing_pr_head_sha), do: "the linked PR head SHA could not be verified."
+  defp rejection_message(:review_readiness_missing_pr_base_ref), do: "the linked PR base branch could not be verified."
+
+  defp rejection_message(:review_readiness_agent_override_not_allowed),
+    do: "manager override cannot be authorized by an agent tool call; a manager must move the issue outside the agent session and leave an audit note."
+
+  defp rejection_message({:review_readiness_missing_variable, variable}),
+    do: "the GraphQL variable `$#{variable}` was missing or blank."
+
+  defp rejection_message({:review_readiness_issue_unverifiable, reason}),
+    do: "Linear issue context could not be verified: #{inspect(reason)}."
+
+  defp rejection_message({:review_readiness_github_unverifiable, reason}),
+    do: "GitHub readiness could not be verified: #{inspect(reason)}."
+
+  defp rejection_message({:review_readiness_github_unverifiable, status, body}),
+    do: "GitHub readiness could not be verified: HTTP #{status} #{body}."
+
+  defp rejection_message({:review_readiness_required_checks_not_passing, failures}),
+    do: "required GitHub checks are not passing: #{format_failures(failures)}."
+
+  defp format_failures(failures) do
+    Enum.map_join(failures, ", ", fn
+      {context, :missing} -> "#{context}=missing"
+      {context, {kind, state}} -> "#{context}=#{kind}:#{state}"
+    end)
+  end
+
+  defp summarize_body(body) when is_binary(body), do: String.slice(body, 0, 200)
+  defp summarize_body(body), do: body |> inspect(limit: 20, printable_limit: 200)
+
+  defp maybe_add_github_token(headers) do
+    case System.get_env("GITHUB_TOKEN") || System.get_env("GH_TOKEN") do
+      token when is_binary(token) and token != "" -> [{"Authorization", "Bearer #{token}"} | headers]
+      _ -> headers
+    end
+  end
+
+  defp normalize(value) do
+    value
+    |> String.trim()
+    |> String.downcase()
+  end
+end

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -107,7 +107,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
 
   defp verify_review_ready(issue, linear_client, github_client) do
     with {:ok, pr} <- linked_pull_request(issue),
-         :ok <- required_checks_passed?(pr, github_client) do
+         :ok <- required_checks_passed?(issue, pr, github_client) do
       :ok
     else
       {:error, reason} -> reject(issue, reason, linear_client)
@@ -115,8 +115,8 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   end
 
   defp transition_request(query, variables) do
-    query = normalize_graphql_ignored_tokens(query)
-    issue_update_count = issue_update_count(query)
+    executable_query = executable_graphql(query)
+    issue_update_count = issue_update_count(executable_query)
 
     cond do
       issue_update_count == 0 ->
@@ -125,26 +125,45 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
       issue_update_count > 1 ->
         {:error, :review_readiness_multiple_issue_updates}
 
-      explicit_state_id?(query) ->
-        with {:ok, issue_id} <- issue_id_from(query, variables),
-             {:ok, state_id} <- explicit_state_id_from(query, variables) do
-          {:ok, issue_id, state_id}
-        end
-
       true ->
-        input_transition_request(query, variables)
+        transition_request_from_issue_update(query, executable_query, variables)
     end
   end
 
-  defp input_transition_request(query, variables) do
-    case input_state_id_from(query, variables) do
-      {:ok, state_id} -> issue_transition_request(query, variables, state_id)
+  defp transition_request_from_issue_update(query, executable_query, variables) do
+    with {:ok, arguments, executable_arguments} <- issue_update_arguments(query, executable_query) do
+      cond do
+        explicit_state_id?(executable_arguments) ->
+          with {:ok, issue_id} <- issue_id_from(arguments, executable_arguments, variables),
+               {:ok, state_id} <- explicit_state_id_from(arguments, executable_arguments, variables) do
+            {:ok, issue_id, state_id}
+          end
+
+        true ->
+          input_transition_request(arguments, executable_arguments, variables)
+      end
+    end
+  end
+
+  defp issue_update_arguments(query, executable_query) do
+    case Regex.run(~r/\bissueUpdate\s*\((.*?)\)\s*\{/s, executable_query, return: :index) do
+      [{_match_start, _match_length}, {arguments_start, arguments_length}] ->
+        {:ok, binary_part(query, arguments_start, arguments_length), binary_part(executable_query, arguments_start, arguments_length)}
+
+      _ ->
+        {:error, :review_readiness_issue_update_unverifiable}
+    end
+  end
+
+  defp input_transition_request(arguments, executable_arguments, variables) do
+    case input_state_id_from(executable_arguments, variables) do
+      {:ok, state_id} -> issue_transition_request(arguments, executable_arguments, variables, state_id)
       nil -> :not_state_transition
     end
   end
 
-  defp issue_transition_request(query, variables, state_id) do
-    with {:ok, issue_id} <- issue_id_from(query, variables) do
+  defp issue_transition_request(arguments, executable_arguments, variables, state_id) do
+    with {:ok, issue_id} <- issue_id_from(arguments, executable_arguments, variables) do
       {:ok, issue_id, state_id}
     end
   end
@@ -155,43 +174,41 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     |> length()
   end
 
-  defp normalize_graphql_ignored_tokens(query) do
+  defp executable_graphql(query) do
     query
     |> String.graphemes()
-    |> normalize_graphql_ignored_tokens(:normal, [])
+    |> executable_graphql(:normal, [])
     |> IO.iodata_to_binary()
   end
 
-  defp normalize_graphql_ignored_tokens([], _mode, acc), do: Enum.reverse(acc)
+  defp executable_graphql([], _mode, acc), do: Enum.reverse(acc)
 
-  defp normalize_graphql_ignored_tokens(["\"" | rest], :normal, acc) do
-    normalize_graphql_ignored_tokens(rest, :string, ["\"" | acc])
+  defp executable_graphql(["\"", "\"", "\"" | rest], :normal, acc) do
+    {rest, acc} = blank_block_string(rest, ["\"\"\"" | acc])
+    executable_graphql(rest, :normal, acc)
   end
 
-  defp normalize_graphql_ignored_tokens(["#", "\n" | rest], :normal, acc) do
-    normalize_graphql_ignored_tokens(rest, :normal, [" " | acc])
+  defp executable_graphql(["\"" | rest], :normal, acc) do
+    {rest, acc} = blank_string(rest, ["\"" | acc])
+    executable_graphql(rest, :normal, acc)
   end
 
-  defp normalize_graphql_ignored_tokens(["#" | rest], :normal, acc) do
+  defp executable_graphql(["#", "\n" | rest], :normal, acc) do
+    executable_graphql(rest, :normal, [" " | acc])
+  end
+
+  defp executable_graphql(["#" | rest], :normal, acc) do
     {rest, acc} = drop_graphql_comment(rest, acc)
-    normalize_graphql_ignored_tokens(rest, :normal, acc)
+    executable_graphql(rest, :normal, acc)
   end
 
-  defp normalize_graphql_ignored_tokens([char | rest], :normal, acc)
+  defp executable_graphql([char | rest], :normal, acc)
        when char in ["\uFEFF", "\t", "\n", "\r", ","] do
-    normalize_graphql_ignored_tokens(rest, :normal, [" " | acc])
+    executable_graphql(rest, :normal, [" " | acc])
   end
 
-  defp normalize_graphql_ignored_tokens(["\\" = char, escaped | rest], :string, acc) do
-    normalize_graphql_ignored_tokens(rest, :string, [escaped, char | acc])
-  end
-
-  defp normalize_graphql_ignored_tokens(["\"" | rest], :string, acc) do
-    normalize_graphql_ignored_tokens(rest, :normal, ["\"" | acc])
-  end
-
-  defp normalize_graphql_ignored_tokens([char | rest], mode, acc) do
-    normalize_graphql_ignored_tokens(rest, mode, [char | acc])
+  defp executable_graphql([char | rest], mode, acc) do
+    executable_graphql(rest, mode, [char | acc])
   end
 
   defp drop_graphql_comment([], acc), do: {[], acc}
@@ -200,24 +217,33 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   defp drop_graphql_comment(["\r" | rest], acc), do: {rest, [" " | acc]}
   defp drop_graphql_comment([_char | rest], acc), do: drop_graphql_comment(rest, acc)
 
+  defp blank_string([], acc), do: {[], acc}
+  defp blank_string(["\\", _escaped | rest], acc), do: blank_string(rest, ["  " | acc])
+  defp blank_string(["\"" | rest], acc), do: {rest, ["\"" | acc]}
+  defp blank_string([_char | rest], acc), do: blank_string(rest, [" " | acc])
+
+  defp blank_block_string([], acc), do: {[], acc}
+  defp blank_block_string(["\"", "\"", "\"" | rest], acc), do: {rest, ["\"\"\"" | acc]}
+  defp blank_block_string([_char | rest], acc), do: blank_block_string(rest, [" " | acc])
+
   defp explicit_state_id?(query) do
     String.contains?(query, "stateId")
   end
 
-  defp issue_id_from(query, variables) do
-    variable_value(query, variables, ~r/issueUpdate\s*\(\s*id\s*:\s*\$(\w+)/) ||
-      literal_value(query, ~r/issueUpdate\s*\(\s*id\s*:\s*"([^"]+)"/) ||
+  defp issue_id_from(arguments, executable_arguments, variables) do
+    variable_value(executable_arguments, variables, ~r/\bid\s*:\s*\$(\w+)/) ||
+      literal_field_value(arguments, executable_arguments, "id") ||
       {:error, :review_readiness_missing_issue_id}
   end
 
-  defp explicit_state_id_from(query, variables) do
-    variable_value(query, variables, ~r/stateId\s*:\s*\$(\w+)/) ||
-      literal_value(query, ~r/stateId\s*:\s*"([^"]+)"/) ||
+  defp explicit_state_id_from(arguments, executable_arguments, variables) do
+    variable_value(executable_arguments, variables, ~r/stateId\s*:\s*\$(\w+)/) ||
+      literal_field_value(arguments, executable_arguments, "stateId") ||
       {:error, :review_readiness_missing_state_id}
   end
 
   defp input_state_id_from(query, variables) do
-    case Regex.run(~r/input\s*:\s*\$(\w+)/, query) do
+    case Regex.run(~r/\binput\s*:\s*\$(\w+)/, query) do
       [_, variable_name] ->
         with input when is_map(input) <- variable_map_value(variables, variable_name),
              state_id when is_binary(state_id) and state_id != "" <- Map.get(input, "stateId") || Map.get(input, :stateId) do
@@ -250,10 +276,20 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     ArgumentError -> Map.get(variables, variable_name)
   end
 
-  defp literal_value(query, regex) do
-    case Regex.run(regex, query) do
-      [_, value] when value != "" -> {:ok, value}
-      _ -> nil
+  defp literal_field_value(arguments, executable_arguments, field_name) do
+    regex = Regex.compile!("\\b#{field_name}\\s*:\\s*\"[^\"]*\"")
+
+    case Regex.run(regex, executable_arguments, return: :index) do
+      [{start, length}] ->
+        literal_segment = binary_part(arguments, start, length)
+
+        case Regex.run(~r/"([^"]+)"/, literal_segment) do
+          [_, value] -> {:ok, value}
+          _ -> nil
+        end
+
+      _ ->
+        nil
     end
   end
 
@@ -339,8 +375,9 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
 
   defp parse_pull_request_url(_url), do: nil
 
-  defp required_checks_passed?(%{owner: owner, repo: repo, number: number}, github_client) do
+  defp required_checks_passed?(issue, %{owner: owner, repo: repo, number: number}, github_client) do
     with {:ok, pr} <- github_json(github_client, "#{@github_api}/repos/#{owner}/#{repo}/pulls/#{number}"),
+         :ok <- pull_request_matches_issue?(issue, owner, repo, pr),
          {:ok, head_sha} <- required_string(pr, ["head", "sha"], :review_readiness_missing_pr_head_sha),
          {:ok, base_ref} <- required_string(pr, ["base", "ref"], :review_readiness_missing_pr_base_ref),
          {:ok, required_checks} <-
@@ -349,6 +386,99 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
          {:ok, check_runs} <- github_json(github_client, "#{@github_api}/repos/#{owner}/#{repo}/commits/#{head_sha}/check-runs") do
       verify_contexts(required_checks, statuses, check_runs)
     end
+  end
+
+  defp pull_request_matches_issue?(issue, owner, repo, pr) do
+    with :ok <- expected_repository?(owner, repo),
+         :ok <- head_repository_matches?(pr),
+         :ok <- pull_request_branch_matches_issue?(issue, pr) do
+      :ok
+    end
+  end
+
+  defp expected_repository?(owner, repo) do
+    expected =
+      Config.settings!().codex.review_readiness_repository
+      |> normalize_repo_name()
+
+    actual = normalize_repo_name("#{owner}/#{repo}")
+
+    cond do
+      is_nil(expected) -> {:error, :review_readiness_repository_unconfigured}
+      expected == actual -> :ok
+      true -> {:error, {:review_readiness_untrusted_repository, "#{owner}/#{repo}"}}
+    end
+  rescue
+    _ -> {:error, :review_readiness_repository_unconfigured}
+  end
+
+  defp head_repository_matches?(pr) do
+    expected =
+      Config.settings!().codex.review_readiness_repository
+      |> normalize_repo_name()
+
+    head_repository =
+      pr
+      |> get_in(["head", "repo", "full_name"])
+      |> normalize_repo_name()
+
+    cond do
+      is_nil(expected) -> {:error, :review_readiness_repository_unconfigured}
+      is_nil(head_repository) -> {:error, :review_readiness_pr_head_repository_unverifiable}
+      expected == head_repository -> :ok
+      true -> {:error, {:review_readiness_untrusted_head_repository, head_repository}}
+    end
+  rescue
+    _ -> {:error, :review_readiness_repository_unconfigured}
+  end
+
+  defp pull_request_branch_matches_issue?(issue, pr) do
+    identifier = issue_identifier(issue)
+    head_ref = get_in(pr, ["head", "ref"])
+
+    cond do
+      is_nil(identifier) ->
+        {:error, :review_readiness_issue_identifier_missing}
+
+      not is_binary(head_ref) or String.trim(head_ref) == "" ->
+        {:error, :review_readiness_pr_branch_unverifiable}
+
+      branch_matches_issue_identifier?(head_ref, identifier) ->
+        :ok
+
+      true ->
+        {:error, {:review_readiness_pr_branch_mismatch, head_ref, identifier}}
+    end
+  end
+
+  defp branch_matches_issue_identifier?(head_ref, identifier) do
+    pattern = ~r/(^|-)#{Regex.escape(normalized_branch_token(identifier))}($|-)/
+
+    Regex.match?(pattern, normalized_branch_token(head_ref))
+  end
+
+  defp issue_identifier(issue) do
+    case Map.get(issue, "identifier") do
+      identifier when is_binary(identifier) and identifier != "" -> identifier
+      _ -> nil
+    end
+  end
+
+  defp normalize_repo_name(nil), do: nil
+
+  defp normalize_repo_name(repo) when is_binary(repo) do
+    repo
+    |> String.trim()
+    |> String.trim_leading("https://github.com/")
+    |> String.trim_trailing("/")
+    |> String.downcase()
+  end
+
+  defp normalized_branch_token(value) do
+    value
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/, "-")
+    |> String.trim("-")
   end
 
   defp required_checks(owner, repo, base_ref, github_client) do
@@ -637,7 +767,12 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   defp rejection_message(:review_readiness_multiple_issue_updates), do: "multiple issueUpdate mutations were found; review readiness can only verify one state transition at a time."
   defp rejection_message(:review_readiness_issue_unverifiable), do: "Linear issue context could not be verified."
   defp rejection_message(:review_readiness_destination_state_unverifiable), do: "the destination state could not be verified."
+  defp rejection_message(:review_readiness_issue_update_unverifiable), do: "the Linear issueUpdate mutation could not be verified."
   defp rejection_message(:review_readiness_missing_linked_pull_request), do: "no linked GitHub pull request was found."
+  defp rejection_message(:review_readiness_repository_unconfigured), do: "no trusted GitHub repository is configured for review readiness."
+  defp rejection_message(:review_readiness_issue_identifier_missing), do: "the Linear issue identifier could not be verified."
+  defp rejection_message(:review_readiness_pr_head_repository_unverifiable), do: "the linked PR head repository could not be verified."
+  defp rejection_message(:review_readiness_pr_branch_unverifiable), do: "the linked PR head branch could not be verified."
   defp rejection_message(:review_readiness_required_checks_missing), do: "no required GitHub checks are configured or visible."
   defp rejection_message(:review_readiness_required_checks_unverifiable), do: "required GitHub checks could not be verified."
   defp rejection_message(:review_readiness_missing_pr_head_sha), do: "the linked PR head SHA could not be verified."
@@ -657,6 +792,15 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
 
   defp rejection_message({:review_readiness_github_unverifiable, status, body}),
     do: "GitHub readiness could not be verified: HTTP #{status} #{body}."
+
+  defp rejection_message({:review_readiness_untrusted_repository, repository}),
+    do: "linked PR repository #{repository} is not the configured trusted repository."
+
+  defp rejection_message({:review_readiness_untrusted_head_repository, repository}),
+    do: "linked PR head repository #{repository} is not the configured trusted repository."
+
+  defp rejection_message({:review_readiness_pr_branch_mismatch, head_ref, identifier}),
+    do: "linked PR branch #{head_ref} does not match Linear issue #{identifier}."
 
   defp rejection_message({:review_readiness_required_checks_not_passing, failures}),
     do: "required GitHub checks are not passing: #{format_failures(failures)}."

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -175,6 +175,7 @@ defmodule SymphonyElixir.Config.Schema do
       field(:turn_timeout_ms, :integer, default: 3_600_000)
       field(:read_timeout_ms, :integer, default: 5_000)
       field(:stall_timeout_ms, :integer, default: 300_000)
+      field(:review_readiness_required_checks, {:array, :string}, default: [])
     end
 
     @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
@@ -189,7 +190,8 @@ defmodule SymphonyElixir.Config.Schema do
           :turn_sandbox_policy,
           :turn_timeout_ms,
           :read_timeout_ms,
-          :stall_timeout_ms
+          :stall_timeout_ms,
+          :review_readiness_required_checks
         ],
         empty_values: []
       )
@@ -382,7 +384,8 @@ defmodule SymphonyElixir.Config.Schema do
     codex = %{
       settings.codex
       | approval_policy: normalize_keys(settings.codex.approval_policy),
-        turn_sandbox_policy: normalize_optional_map(settings.codex.turn_sandbox_policy)
+        turn_sandbox_policy: normalize_optional_map(settings.codex.turn_sandbox_policy),
+        review_readiness_required_checks: normalize_required_checks(settings.codex.review_readiness_required_checks)
     }
 
     %{settings | tracker: tracker, workspace: workspace, codex: codex}
@@ -399,6 +402,13 @@ defmodule SymphonyElixir.Config.Schema do
 
   defp normalize_optional_map(nil), do: nil
   defp normalize_optional_map(value) when is_map(value), do: normalize_keys(value)
+
+  defp normalize_required_checks(checks) when is_list(checks) do
+    checks
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+  end
 
   defp normalize_label_filter(labels) when is_list(labels) do
     labels

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -175,6 +175,7 @@ defmodule SymphonyElixir.Config.Schema do
       field(:turn_timeout_ms, :integer, default: 3_600_000)
       field(:read_timeout_ms, :integer, default: 5_000)
       field(:stall_timeout_ms, :integer, default: 300_000)
+      field(:review_readiness_repository, :string)
       field(:review_readiness_required_checks, {:array, :string}, default: [])
     end
 
@@ -191,6 +192,7 @@ defmodule SymphonyElixir.Config.Schema do
           :turn_timeout_ms,
           :read_timeout_ms,
           :stall_timeout_ms,
+          :review_readiness_repository,
           :review_readiness_required_checks
         ],
         empty_values: []
@@ -385,6 +387,7 @@ defmodule SymphonyElixir.Config.Schema do
       settings.codex
       | approval_policy: normalize_keys(settings.codex.approval_policy),
         turn_sandbox_policy: normalize_optional_map(settings.codex.turn_sandbox_policy),
+        review_readiness_repository: normalize_repository(settings.codex.review_readiness_repository),
         review_readiness_required_checks: normalize_required_checks(settings.codex.review_readiness_required_checks)
     }
 
@@ -409,6 +412,19 @@ defmodule SymphonyElixir.Config.Schema do
     |> Enum.reject(&(&1 == ""))
     |> Enum.uniq()
   end
+
+  defp normalize_repository(repository) when is_binary(repository) do
+    repository
+    |> String.trim()
+    |> String.trim_leading("https://github.com/")
+    |> String.trim_trailing("/")
+    |> case do
+      "" -> nil
+      normalized -> normalized
+    end
+  end
+
+  defp normalize_repository(_repository), do: nil
 
   defp normalize_label_filter(labels) when is_list(labels) do
     labels

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -23,6 +23,7 @@ defmodule SymphonyElixir.MixProject do
           SymphonyElixir.CLI,
           SymphonyElixir.Codex.AppServer,
           SymphonyElixir.Codex.DynamicTool,
+          SymphonyElixir.Codex.ReviewReadiness,
           SymphonyElixir.HttpServer,
           SymphonyElixir.StatusDashboard,
           SymphonyElixir.LogFile,

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -143,6 +143,7 @@ defmodule SymphonyElixir.TestSupport do
           codex_turn_timeout_ms: 3_600_000,
           codex_read_timeout_ms: 5_000,
           codex_stall_timeout_ms: 300_000,
+          codex_review_readiness_repository: "albert-zen/symphony-windows-native",
           codex_review_readiness_required_checks: [],
           hook_after_create: nil,
           hook_before_run: nil,
@@ -182,6 +183,7 @@ defmodule SymphonyElixir.TestSupport do
     codex_turn_timeout_ms = Keyword.get(config, :codex_turn_timeout_ms)
     codex_read_timeout_ms = Keyword.get(config, :codex_read_timeout_ms)
     codex_stall_timeout_ms = Keyword.get(config, :codex_stall_timeout_ms)
+    codex_review_readiness_repository = Keyword.get(config, :codex_review_readiness_repository)
     codex_review_readiness_required_checks = Keyword.get(config, :codex_review_readiness_required_checks)
     hook_after_create = Keyword.get(config, :hook_after_create)
     hook_before_run = Keyword.get(config, :hook_before_run)
@@ -225,6 +227,7 @@ defmodule SymphonyElixir.TestSupport do
         "  turn_timeout_ms: #{yaml_value(codex_turn_timeout_ms)}",
         "  read_timeout_ms: #{yaml_value(codex_read_timeout_ms)}",
         "  stall_timeout_ms: #{yaml_value(codex_stall_timeout_ms)}",
+        "  review_readiness_repository: #{yaml_value(codex_review_readiness_repository)}",
         "  review_readiness_required_checks: #{yaml_value(codex_review_readiness_required_checks)}",
         hooks_yaml(hook_after_create, hook_before_run, hook_after_run, hook_before_remove, hook_timeout_ms),
         observability_yaml(observability_enabled, observability_refresh_ms, observability_render_interval_ms),

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -143,6 +143,7 @@ defmodule SymphonyElixir.TestSupport do
           codex_turn_timeout_ms: 3_600_000,
           codex_read_timeout_ms: 5_000,
           codex_stall_timeout_ms: 300_000,
+          codex_review_readiness_required_checks: [],
           hook_after_create: nil,
           hook_before_run: nil,
           hook_after_run: nil,
@@ -181,6 +182,7 @@ defmodule SymphonyElixir.TestSupport do
     codex_turn_timeout_ms = Keyword.get(config, :codex_turn_timeout_ms)
     codex_read_timeout_ms = Keyword.get(config, :codex_read_timeout_ms)
     codex_stall_timeout_ms = Keyword.get(config, :codex_stall_timeout_ms)
+    codex_review_readiness_required_checks = Keyword.get(config, :codex_review_readiness_required_checks)
     hook_after_create = Keyword.get(config, :hook_after_create)
     hook_before_run = Keyword.get(config, :hook_before_run)
     hook_after_run = Keyword.get(config, :hook_after_run)
@@ -223,6 +225,7 @@ defmodule SymphonyElixir.TestSupport do
         "  turn_timeout_ms: #{yaml_value(codex_turn_timeout_ms)}",
         "  read_timeout_ms: #{yaml_value(codex_read_timeout_ms)}",
         "  stall_timeout_ms: #{yaml_value(codex_stall_timeout_ms)}",
+        "  review_readiness_required_checks: #{yaml_value(codex_review_readiness_required_checks)}",
         hooks_yaml(hook_after_create, hook_before_run, hook_after_run, hook_before_remove, hook_timeout_ms),
         observability_yaml(observability_enabled, observability_refresh_ms, observability_render_interval_ms),
         server_yaml(server_port, server_host),

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -17,6 +17,7 @@ defmodule SymphonyElixir.CoreTest do
     assert config.tracker.terminal_states == ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]
     assert config.tracker.assignee == nil
     assert config.agent.max_turns == 20
+    assert config.codex.review_readiness_repository == "albert-zen/symphony-windows-native"
     assert config.codex.review_readiness_required_checks == []
 
     write_workflow_file!(Workflow.workflow_file_path(), poll_interval_ms: "invalid")
@@ -72,9 +73,11 @@ defmodule SymphonyElixir.CoreTest do
     assert :ok = Config.validate!()
 
     write_workflow_file!(Workflow.workflow_file_path(),
+      codex_review_readiness_repository: " https://github.com/Albert-Zen/symphony-windows-native/ ",
       codex_review_readiness_required_checks: [" make-all ", "", "windows-native-test", "make-all"]
     )
 
+    assert Config.settings!().codex.review_readiness_repository == "Albert-Zen/symphony-windows-native"
     assert Config.settings!().codex.review_readiness_required_checks == ["make-all", "windows-native-test"]
 
     write_workflow_file!(Workflow.workflow_file_path(),

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -80,6 +80,12 @@ defmodule SymphonyElixir.CoreTest do
     assert Config.settings!().codex.review_readiness_repository == "Albert-Zen/symphony-windows-native"
     assert Config.settings!().codex.review_readiness_required_checks == ["make-all", "windows-native-test"]
 
+    write_workflow_file!(Workflow.workflow_file_path(), codex_review_readiness_repository: "   ")
+    assert Config.settings!().codex.review_readiness_repository == nil
+
+    write_workflow_file!(Workflow.workflow_file_path(), codex_review_readiness_repository: nil)
+    assert Config.settings!().codex.review_readiness_repository == nil
+
     write_workflow_file!(Workflow.workflow_file_path(),
       codex_turn_sandbox_policy: %{type: "workspaceWrite", writableRoots: ["relative/path"]}
     )

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -17,6 +17,7 @@ defmodule SymphonyElixir.CoreTest do
     assert config.tracker.terminal_states == ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]
     assert config.tracker.assignee == nil
     assert config.agent.max_turns == 20
+    assert config.codex.review_readiness_required_checks == []
 
     write_workflow_file!(Workflow.workflow_file_path(), poll_interval_ms: "invalid")
 
@@ -69,6 +70,12 @@ defmodule SymphonyElixir.CoreTest do
 
     write_workflow_file!(Workflow.workflow_file_path(), codex_thread_sandbox: "unsafe-ish")
     assert :ok = Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      codex_review_readiness_required_checks: [" make-all ", "", "windows-native-test", "make-all"]
+    )
+
+    assert Config.settings!().codex.review_readiness_required_checks == ["make-all", "windows-native-test"]
 
     write_workflow_file!(Workflow.workflow_file_path(),
       codex_turn_sandbox_policy: %{type: "workspaceWrite", writableRoots: ["relative/path"]}

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -111,6 +111,39 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     refute_received {:linear_mutation_allowed, _, _}
   end
 
+  test "linear_graphql detects issueUpdate when GraphQL comments appear before arguments" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        %{
+          "query" => """
+          mutation MoveIssueToState($issueId: String!, $stateId: String!) {
+            issueUpdate # GraphQL ignored tokens may appear here.
+              (id: $issueId, input: {stateId: $stateId}) {
+              success
+            }
+          }
+          """,
+          "variables" => %{"issueId" => "issue-1", "stateId" => "state-review"}
+        },
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{"check_runs" => []}
+          })
+      )
+
+    assert response["success"] == false
+    assert_received {:workpad_recorded, body}
+    assert body =~ "make-all=missing"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
   test "linear_graphql requires matching app identity for app-bound required checks" do
     test_pid = self()
 
@@ -275,7 +308,7 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     refute_received {:linear_mutation_allowed, _, _}
   end
 
-  test "linear_graphql accepts a linked PR from the Codex Workpad" do
+  test "linear_graphql does not trust PR links from agent-mutable comments" do
     test_pid = self()
 
     response =
@@ -283,10 +316,28 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
         "linear_graphql",
         review_transition_arguments(),
         linear_client: review_linear_client(test_pid, issue_with_workpad_pr()),
+        github_client: fn _url, _opts -> flunk("GitHub should not be checked for comment-only PR links") end
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "no linked GitHub pull request was found"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "no linked GitHub pull request was found"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql URL-encodes protected branch names before fetching required checks" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
         github_client:
           github_client(%{
-            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
-            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "release/2026-05"}},
+            "branches/release%2F2026-05/protection/required_status_checks" => %{"contexts" => ["make-all"]},
             "commits/abc123/status" => %{"statuses" => []},
             "commits/abc123/check-runs" => %{"check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]}
           })

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -87,6 +87,121 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     refute_received {:workpad_recorded, _}
   end
 
+  test "linear_graphql rejects ambiguous multiple issueUpdate mutations" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        %{
+          "query" => """
+          mutation MoveTwo($firstIssueId: String!, $secondIssueId: String!, $stateId: String!) {
+            first: issueUpdate(id: $firstIssueId, input: {stateId: $stateId}) { success }
+            second: issueUpdate(id: $secondIssueId, input: {stateId: $stateId}) { success }
+          }
+          """,
+          "variables" => %{"firstIssueId" => "issue-1", "secondIssueId" => "issue-2", "stateId" => "state-review"}
+        },
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client: fn _url, _opts -> flunk("GitHub should not be checked for ambiguous transitions") end
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "multiple issueUpdate mutations"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql requires matching app identity for app-bound required checks" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "branches/main/protection/required_status_checks" => %{
+              "contexts" => ["make-all"],
+              "checks" => [%{"context" => "make-all", "app_id" => 12_345}]
+            },
+            "commits/abc123/status" => %{"statuses" => [%{"context" => "make-all", "state" => "success"}]},
+            "commits/abc123/check-runs" => %{
+              "check_runs" => [
+                %{
+                  "name" => "make-all",
+                  "status" => "completed",
+                  "conclusion" => "success",
+                  "app" => %{"id" => 99_999}
+                }
+              ]
+            }
+          })
+      )
+
+    assert response["success"] == false
+    assert_received {:workpad_recorded, body}
+    assert body =~ "make-all=check:app_mismatch"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql allows matching app-bound required checks" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "branches/main/protection/required_status_checks" => %{
+              "contexts" => ["make-all"],
+              "checks" => [%{"context" => "make-all", "app_id" => 12_345}]
+            },
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{
+              "check_runs" => [
+                %{
+                  "name" => "make-all",
+                  "status" => "completed",
+                  "conclusion" => "success",
+                  "app" => %{"id" => 12_345}
+                }
+              ]
+            }
+          })
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
+    refute_received {:workpad_recorded, _}
+  end
+
+  test "linear_graphql uses configured required checks when branch protection is unavailable" do
+    test_pid = self()
+    write_workflow_file!(Workflow.workflow_file_path(), codex_review_readiness_required_checks: ["make-all"])
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{"check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]}
+          })
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
+    refute_received {:workpad_recorded, _}
+  end
+
   test "linear_graphql guards In Review transition when stateId is inside an input variable" do
     test_pid = self()
 

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -220,6 +220,71 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     refute_received {:workpad_recorded, _}
   end
 
+  test "linear_graphql keeps literal issueUpdate offsets stable when comments appear first" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        %{
+          "query" => """
+          mutation MoveIssueToState {
+            # spoof: issueUpdate(id: "issue-2", input: {stateId: "state-todo"}) { success }
+            issueUpdate(id: "issue-1", input: {stateId: "state-review"}) {
+              success
+            }
+          }
+          """,
+          "variables" => %{}
+        },
+        linear_client: review_linear_client(test_pid, issue_with_pr_and_todo_state()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{"check_runs" => []}
+          })
+      )
+
+    assert response["success"] == false
+    assert_received {:workpad_recorded, body}
+    assert body =~ "make-all=missing"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql treats UTF-8 BOM as ignored whitespace before issueUpdate arguments" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        %{
+          "query" => """
+          mutation MoveIssueToState($issueId: String!, $stateId: String!) {
+            issueUpdate﻿(id: $issueId, input: {stateId: $stateId}) {
+              success
+            }
+          }
+          """,
+          "variables" => %{"issueId" => "issue-1", "stateId" => "state-review"}
+        },
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{"check_runs" => []}
+          })
+      )
+
+    assert response["success"] == false
+    assert_received {:workpad_recorded, body}
+    assert body =~ "make-all=missing"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
   test "linear_graphql requires matching app identity for app-bound required checks" do
     test_pid = self()
 
@@ -922,6 +987,13 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
 
   defp issue_without_pr do
     put_in(issue_with_pr(), ["attachments", "nodes"], [])
+  end
+
+  defp issue_with_pr_and_todo_state do
+    put_in(issue_with_pr(), ["team", "states", "nodes"], [
+      %{"id" => "state-todo", "name" => "Todo"},
+      %{"id" => "state-review", "name" => "In Review"}
+    ])
   end
 
   defp issue_with_workpad_pr do

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -65,6 +65,249 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     assert response["contentItems"] == [%{"type" => "inputText", "text" => response["output"]}]
   end
 
+  test "linear_graphql allows In Review transition when linked PR required checks pass" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{"check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]}
+          })
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
+    refute_received {:workpad_recorded, _}
+  end
+
+  test "linear_graphql guards In Review transition when stateId is inside an input variable" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_input_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{"check_runs" => []}
+          })
+      )
+
+    assert response["success"] == false
+    assert_received {:workpad_recorded, body}
+    assert body =~ "make-all=missing"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql allows non-state issueUpdate input variables" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        %{
+          "query" => """
+          mutation UpdateIssue($issueId: String!, $input: IssueUpdateInput!) {
+            issueUpdate(id: $issueId, input: $input) {
+              success
+            }
+          }
+          """,
+          "variables" => %{"issueId" => "issue-1", "input" => %{"description" => "updated"}}
+        },
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client: fn _url, _opts -> flunk("GitHub should not be checked for non-state updates") end
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", nil}
+    refute_received {:workpad_recorded, _}
+  end
+
+  test "linear_graphql keeps explicit stateId variables strict when stateId is missing" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        %{
+          "query" => """
+          mutation MoveIssueToState($issueId: String!, $stateId: String!) {
+            issueUpdate(id: $issueId, input: {stateId: $stateId}) {
+              success
+            }
+          }
+          """,
+          "variables" => %{"issueId" => "issue-1"}
+        },
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client: fn _url, _opts -> flunk("GitHub should not be checked when variables are incomplete") end
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "GraphQL variable `$stateId` was missing"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql accepts a linked PR from the Codex Workpad" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_workpad_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{"check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]}
+          })
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
+  end
+
+  test "linear_graphql rejects In Review transition when no linked PR exists and records workpad reason" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_without_pr()),
+        github_client: github_client(%{})
+      )
+
+    assert response["success"] == false
+    payload = Jason.decode!(response["output"])
+    assert get_in(payload, ["error", "code"]) == "review_readiness_rejected"
+    assert get_in(payload, ["error", "message"]) =~ "no linked GitHub pull request was found"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "## Codex Workpad"
+    assert body =~ "In Review transition rejected"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql rejects In Review transition when required checks are pending" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{"check_runs" => [%{"name" => "make-all", "status" => "in_progress", "conclusion" => nil}]}
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "required GitHub checks are not passing"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "make-all=check:in_progress"
+  end
+
+  test "linear_graphql rejects In Review transition when required checks fail" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => [%{"context" => "make-all", "state" => "failure"}]},
+            "commits/abc123/check-runs" => %{"check_runs" => []}
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "required GitHub checks are not passing"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "make-all=status:failure"
+  end
+
+  test "linear_graphql rejects In Review transition when required checks are missing" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{"check_runs" => []}
+          })
+      )
+
+    assert response["success"] == false
+    assert_received {:workpad_recorded, body}
+    assert body =~ "make-all=missing"
+  end
+
+  test "linear_graphql rejects In Review transition when GitHub readiness is unverifiable" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client: fn _url, _opts -> {:error, :timeout} end
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "GitHub readiness could not be verified"
+    assert_received {:workpad_recorded, body}
+    assert body =~ ":timeout"
+  end
+
+  test "linear_graphql rejects agent-supplied manager override for In Review transition" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(%{
+          "symphonyManagerOverride" => true,
+          "symphonyManagerOverrideReason" => "Manager approved handoff while CI provider is unavailable."
+        }),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client: fn _url, _opts -> flunk("GitHub should not be checked for manager override") end
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "manager override cannot be authorized by an agent tool call"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "manager override cannot be authorized"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
   test "linear_graphql accepts a raw GraphQL query string" do
     test_pid = self()
 
@@ -306,5 +549,91 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
 
     assert response["success"] == true
     assert response["output"] == ":ok"
+  end
+
+  defp review_transition_arguments(extra_variables \\ %{}) do
+    %{
+      "query" => """
+      mutation MoveIssueToState($issueId: String!, $stateId: String!) {
+        issueUpdate(id: $issueId, input: {stateId: $stateId}) {
+          success
+        }
+      }
+      """,
+      "variables" => Map.merge(%{"issueId" => "issue-1", "stateId" => "state-review"}, extra_variables)
+    }
+  end
+
+  defp review_transition_input_arguments do
+    %{
+      "query" => """
+      mutation MoveIssueToState($issueId: String!, $input: IssueUpdateInput!) {
+        issueUpdate(id: $issueId, input: $input) {
+          success
+        }
+      }
+      """,
+      "variables" => %{"issueId" => "issue-1", "input" => %{"stateId" => "state-review"}}
+    }
+  end
+
+  defp issue_with_pr do
+    %{
+      "id" => "issue-1",
+      "identifier" => "ALB-19",
+      "team" => %{"states" => %{"nodes" => [%{"id" => "state-review", "name" => "In Review"}]}},
+      "attachments" => %{"nodes" => [%{"url" => "https://github.com/albert-zen/symphony-windows-native/pull/42"}]},
+      "comments" => %{"nodes" => []}
+    }
+  end
+
+  defp issue_without_pr do
+    put_in(issue_with_pr(), ["attachments", "nodes"], [])
+  end
+
+  defp issue_with_workpad_pr do
+    issue_with_pr()
+    |> put_in(["attachments", "nodes"], [])
+    |> put_in(["comments", "nodes"], [
+      %{
+        "id" => "comment-1",
+        "body" => "## Codex Workpad\n\nPR: https://github.com/albert-zen/symphony-windows-native/pull/42"
+      }
+    ])
+  end
+
+  defp review_linear_client(test_pid, issue) do
+    fn query, variables, _opts ->
+      cond do
+        query =~ "SymphonyReviewReadinessContext" ->
+          {:ok, %{"data" => %{"issue" => issue}}}
+
+        query =~ "SymphonyReviewReadinessCreateWorkpad" ->
+          send(test_pid, {:workpad_recorded, variables["body"]})
+          {:ok, %{"data" => %{"commentCreate" => %{"success" => true}}}}
+
+        query =~ "SymphonyReviewReadinessUpdateWorkpad" ->
+          send(test_pid, {:workpad_recorded, variables["body"]})
+          {:ok, %{"data" => %{"commentUpdate" => %{"success" => true}}}}
+
+        query =~ "issueUpdate" ->
+          state_id = variables["stateId"] || get_in(variables, ["input", "stateId"])
+          send(test_pid, {:linear_mutation_allowed, variables["issueId"], state_id})
+          {:ok, %{"data" => %{"issueUpdate" => %{"success" => true}}}}
+      end
+    end
+  end
+
+  defp github_client(responses) do
+    fn url, _opts ->
+      case github_response(responses, url) do
+        {_suffix, payload} -> {:ok, %{status: 200, body: payload}}
+        nil -> {:ok, %{status: 404, body: %{"message" => "not found"}}}
+      end
+    end
+  end
+
+  defp github_response(responses, url) do
+    Enum.find(responses, fn {suffix, _payload} -> String.ends_with?(url, suffix) end)
   end
 end

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -144,6 +144,82 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     refute_received {:linear_mutation_allowed, _, _}
   end
 
+  test "linear_graphql ignores fake stateId tokens inside GraphQL block strings" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        %{
+          "query" => """
+          mutation MoveIssueToState($issueId: String!, $input: IssueUpdateInput!) {
+            issueUpdate(id: $issueId, input: $input) {
+              success
+            }
+            note: attachmentCreate(input: {url: "https://example.invalid", title: \"\"\"
+            stateId: "state-todo"
+            \"\"\"}) {
+              success
+            }
+          }
+          """,
+          "variables" => %{"issueId" => "issue-1", "input" => %{"stateId" => "state-review"}}
+        },
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123", "ref" => "codex/ALB-19-review-readiness"}, "base" => %{"ref" => "main"}},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{"check_runs" => []}
+          })
+      )
+
+    assert response["success"] == false
+    assert_received {:workpad_recorded, body}
+    assert body =~ "make-all=missing"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql supports literal issueUpdate ids without trusting string field contents" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        %{
+          "query" => """
+          mutation MoveIssueToState {
+            issueUpdate(
+              id: "issue-1"
+              input: {
+                description: "stateId: \\"state-todo\\""
+                stateId: "state-review"
+              }
+            ) {
+              success
+            }
+          }
+          """,
+          "variables" => %{}
+        },
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{
+              "check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]
+            }
+          })
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, nil, nil}
+    refute_received {:workpad_recorded, _}
+  end
+
   test "linear_graphql requires matching app identity for app-bound required checks" do
     test_pid = self()
 
@@ -323,6 +399,97 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     assert Jason.decode!(response["output"])["error"]["message"] =~ "no linked GitHub pull request was found"
     assert_received {:workpad_recorded, body}
     assert body =~ "no linked GitHub pull request was found"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql rejects PR attachments outside the configured repository" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr("https://github.com/elsewhere/project/pull/42")),
+        github_client:
+          github_client(%{
+            "repos/elsewhere/project/pulls/42" => %{"head" => %{"sha" => "abc123", "ref" => "codex/ALB-19-review-readiness"}, "base" => %{"ref" => "main"}}
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "not the configured trusted repository"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "not the configured trusted repository"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql rejects same-repository PR attachments for another issue branch" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123", "ref" => "codex/ALB-20-other-work"}, "base" => %{"ref" => "main"}}
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "does not match Linear issue ALB-19"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "does not match Linear issue ALB-19"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql rejects same-repository PR attachments for prefix-collision issue branches" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123", "ref" => "codex/ALB-190-other-work"}, "base" => %{"ref" => "main"}}
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "does not match Linear issue ALB-19"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "does not match Linear issue ALB-19"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql rejects fork PR attachments that target the trusted repository" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{
+              "head" => %{
+                "sha" => "abc123",
+                "ref" => "codex/ALB-19-review-readiness",
+                "repo" => %{"full_name" => "elsewhere/symphony-windows-native"}
+              },
+              "base" => %{"ref" => "main"}
+            }
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "head repository elsewhere/symphony-windows-native is not the configured trusted repository"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "head repository elsewhere/symphony-windows-native is not the configured trusted repository"
     refute_received {:linear_mutation_allowed, _, _}
   end
 
@@ -743,12 +910,12 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     }
   end
 
-  defp issue_with_pr do
+  defp issue_with_pr(url \\ "https://github.com/albert-zen/symphony-windows-native/pull/42") do
     %{
       "id" => "issue-1",
       "identifier" => "ALB-19",
       "team" => %{"states" => %{"nodes" => [%{"id" => "state-review", "name" => "In Review"}]}},
-      "attachments" => %{"nodes" => [%{"url" => "https://github.com/albert-zen/symphony-windows-native/pull/42"}]},
+      "attachments" => %{"nodes" => [%{"url" => url}]},
       "comments" => %{"nodes" => []}
     }
   end
@@ -793,11 +960,26 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
   defp github_client(responses) do
     fn url, _opts ->
       case github_response(responses, url) do
-        {_suffix, payload} -> {:ok, %{status: 200, body: payload}}
+        {_suffix, payload} -> {:ok, %{status: 200, body: default_pr_payload(url, payload)}}
         nil -> {:ok, %{status: 404, body: %{"message" => "not found"}}}
       end
     end
   end
+
+  defp default_pr_payload(url, %{"head" => head} = payload) when is_map(head) do
+    if String.contains?(url, "/pulls/") do
+      default_head =
+        head
+        |> Map.put_new("ref", "codex/ALB-19-review-readiness")
+        |> Map.put_new("repo", %{"full_name" => "albert-zen/symphony-windows-native"})
+
+      put_in(payload, ["head"], default_head)
+    else
+      payload
+    end
+  end
+
+  defp default_pr_payload(_url, payload), do: payload
 
   defp github_response(responses, url) do
     Enum.find(responses, fn {suffix, _payload} -> String.ends_with?(url, suffix) end)


### PR DESCRIPTION
#### Context

ALB-19 / GH #14 needs a mechanical guard so agent-driven Linear `In Review` transitions cannot self-discharge work before PR checks are ready.

#### TL;DR

*Guard Linear `In Review` moves with linked-PR and required-check readiness.*

#### Summary

- Adds a `linear_graphql` readiness guard for Linear `issueUpdate` moves to `In Review`.
- Requires a linked GitHub PR from Linear attachment metadata before allowing review handoff.
- Requires required GitHub checks to be complete and passing on the linked PR head SHA.
- Rejects pending, failing, missing, or unverifiable checks and records the reason in the Workpad.
- Rejects ambiguous multi-`issueUpdate` GraphQL documents so one verified move cannot hide another.
- Scopes GraphQL state extraction to executable `issueUpdate` arguments, ignoring string/block-string fakes.
- Preserves byte offsets while blanking GraphQL comments, strings, block strings, CRLF, comma, tab/newline, and UTF-8 BOM ignored tokens.
- Binds trusted PR attachments to the configured repo, PR head repo, and exact Linear branch token.
- Honors app-bound branch-protection checks so same-name statuses cannot spoof required checks.
- Adds configured required-check fallback for Windows runtimes without branch-protection access.
- Documents fallback name-only check matching and the explicit manager override path.

#### Alternatives

- Guarding only the tracker adapter was rejected because agents can call raw Linear GraphQL.
- Trusting prompt policy alone was rejected because `In Review` is outside active polling.
- Agent-supplied override variables were rejected because the same agent could bypass readiness.
- PR links in Workpad/comments are no longer authoritative because agents can mutate comments.
- Trusting any Linear PR attachment was rejected because agents can spoof arbitrary green PRs.
- Full GraphQL AST parsing was deferred; ambiguous multi-update documents fail closed here.

#### Test Plan

- [x] GitHub `make-all` passed on head `b7ec374`.
- [x] GitHub `validate-pr-description` passed on head `b7ec374`.
- [x] GitHub `windows-native-test` passed on head `b7ec374`.
- [x] `mise exec -- mix test test/symphony_elixir/dynamic_tool_test.exs` - 40 tests, 0 failures.
- [x] `mise exec -- mix test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs` - 48 tests, 0 failures, 2 skipped.
- [x] `mise exec -- mix format --check-formatted lib/symphony_elixir/codex/review_readiness.ex test/symphony_elixir/dynamic_tool_test.exs`.
- [x] `mise exec -- mix compile --warnings-as-errors`.
- [x] `git diff --check`.
- [x] Independent SubAgent review found one blocking BOM ignored-token issue after the initial offset fix; fixed with regression.
- [x] Independent SubAgent re-review on head `b7ec374`: no blocking findings.
- [ ] `make windows-native-test` - not run directly because `make` is not installed; equivalent Mix target and GitHub `windows-native-test` passed.

Closes #14.