### PR TITLE
Harden durable Linear claim leases

### DIFF
--- a/elixir/lib/symphony_elixir/linear/adapter.ex
+++ b/elixir/lib/symphony_elixir/linear/adapter.ex
@@ -7,10 +7,37 @@ defmodule SymphonyElixir.Linear.Adapter do
 
   alias SymphonyElixir.Linear.Client
 
+  @claim_ttl_seconds 4 * 60 * 60
+  @claim_settle_ms 250
+  @claim_marker "## Symphony Claim Lease"
+  @claim_release_marker "## Symphony Claim Release"
+
   @create_comment_mutation """
   mutation SymphonyCreateComment($issueId: String!, $body: String!) {
     commentCreate(input: {issueId: $issueId, body: $body}) {
       success
+      comment {
+        id
+        createdAt
+      }
+    }
+  }
+  """
+
+  @claim_comments_query """
+  query SymphonyIssueClaimComments($issueId: String!, $after: String) {
+    issue(id: $issueId) {
+      comments(first: 100, after: $after) {
+        nodes {
+          id
+          body
+          createdAt
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
     }
   }
   """
@@ -46,6 +73,47 @@ defmodule SymphonyElixir.Linear.Adapter do
   @spec fetch_issue_states_by_ids([String.t()]) :: {:ok, [term()]} | {:error, term()}
   def fetch_issue_states_by_ids(issue_ids), do: client_module().fetch_issue_states_by_ids(issue_ids)
 
+  @spec acquire_issue_claim(term()) :: {:ok, map()} | {:error, term()}
+  def acquire_issue_claim(%{id: issue_id, identifier: identifier}) when is_binary(issue_id) do
+    now = DateTime.utc_now()
+    expires_at = DateTime.add(now, @claim_ttl_seconds, :second)
+    owner = claim_owner()
+    token = claim_token()
+    body = claim_body(identifier, owner, token, now, expires_at)
+
+    with {:ok, claim} <- create_claim_comment(issue_id, body, owner, token, now, expires_at) do
+      verify_issue_claim(issue_id, claim)
+    end
+  end
+
+  def acquire_issue_claim(_issue), do: {:error, :invalid_issue_claim}
+
+  @spec release_issue_claim(String.t()) :: :ok | {:error, term()}
+  def release_issue_claim(issue_id), do: release_issue_claim(issue_id, nil)
+
+  @spec release_issue_claim(String.t(), map() | nil) :: :ok | {:error, term()}
+  def release_issue_claim(issue_id, nil) when is_binary(issue_id), do: :ok
+
+  def release_issue_claim(issue_id, claim) when is_binary(issue_id) do
+    owner = claim_value(claim, :owner)
+    token = claim_value(claim, :token)
+
+    if is_binary(owner) and is_binary(token) do
+      body = release_body(owner, token, DateTime.utc_now())
+
+      with {:ok, response} <- client_module().graphql(@create_comment_mutation, %{issueId: issue_id, body: body}),
+           true <- get_in(response, ["data", "commentCreate", "success"]) == true do
+        :ok
+      else
+        false -> {:error, :claim_release_failed}
+        {:error, reason} -> {:error, reason}
+        _ -> {:error, :claim_release_failed}
+      end
+    else
+      :ok
+    end
+  end
+
   @spec create_comment(String.t(), String.t()) :: :ok | {:error, term()}
   def create_comment(issue_id, body) when is_binary(issue_id) and is_binary(body) do
     with {:ok, response} <- client_module().graphql(@create_comment_mutation, %{issueId: issue_id, body: body}),
@@ -76,6 +144,245 @@ defmodule SymphonyElixir.Linear.Adapter do
   defp client_module do
     Application.get_env(:symphony_elixir, :linear_client_module, Client)
   end
+
+  defp create_claim_comment(issue_id, body, owner, token, now, expires_at) do
+    with {:ok, response} <- client_module().graphql(@create_comment_mutation, %{issueId: issue_id, body: body}),
+         true <- get_in(response, ["data", "commentCreate", "success"]) == true do
+      comment = get_in(response, ["data", "commentCreate", "comment"]) || %{}
+
+      {:ok,
+       %{
+         id: comment["id"],
+         owner: owner,
+         token: token,
+         claimed_at: parse_datetime(comment["createdAt"]) || now,
+         expires_at: expires_at
+       }}
+    else
+      false -> {:error, :claim_create_failed}
+      {:error, reason} -> {:error, reason}
+      _ -> {:error, :claim_create_failed}
+    end
+  end
+
+  defp wait_for_concurrent_claims do
+    Process.sleep(@claim_settle_ms)
+    :ok
+  end
+
+  defp verify_issue_claim(issue_id, claim) do
+    result =
+      with :ok <- wait_for_concurrent_claims(),
+           {:ok, claims} <- fetch_claim_comments(issue_id),
+           {:ok, winner} <- winning_claim(claims, DateTime.utc_now()) do
+        if same_claim?(winner, claim) do
+          {:ok, winner}
+        else
+          {:error, {:issue_claimed, winner}}
+        end
+      end
+
+    case result do
+      {:ok, winner} ->
+        {:ok, winner}
+
+      {:error, reason} ->
+        _ = release_issue_claim(issue_id, claim)
+        {:error, reason}
+    end
+  end
+
+  defp fetch_claim_comments(issue_id) do
+    fetch_claim_comments_page(issue_id, nil, [])
+  end
+
+  defp fetch_claim_comments_page(issue_id, after_cursor, acc) do
+    with {:ok, response} <- client_module().graphql(@claim_comments_query, %{issueId: issue_id, after: after_cursor}),
+         comments when is_list(comments) <- get_in(response, ["data", "issue", "comments", "nodes"]) do
+      parsed = parse_claim_comments(comments)
+      page_info = get_in(response, ["data", "issue", "comments", "pageInfo"]) || %{}
+
+      if page_info["hasNextPage"] == true and is_binary(page_info["endCursor"]) do
+        fetch_claim_comments_page(issue_id, page_info["endCursor"], parsed ++ acc)
+      else
+        {:ok, parsed ++ acc}
+      end
+    else
+      {:error, reason} -> {:error, reason}
+      _ -> {:error, :claim_comments_fetch_failed}
+    end
+  end
+
+  defp winning_claim(claims, now) when is_list(claims) do
+    releases =
+      claims
+      |> Enum.filter(&(&1.type == :release))
+      |> Enum.group_by(& &1.owner)
+
+    claims
+    |> Enum.filter(&(&1.type == :claim))
+    |> Enum.reject(&(claim_expired?(&1, now) or claim_released?(&1, releases)))
+    |> Enum.sort_by(fn claim ->
+      {DateTime.to_unix(claim.claimed_at, :microsecond), claim.id || "", claim.token || ""}
+    end)
+    |> case do
+      [claim | _] -> {:ok, claim}
+      [] -> {:error, :claim_not_visible}
+    end
+  end
+
+  defp parse_claim_comments(comments) do
+    comments
+    |> Enum.flat_map(&parse_claim_comment/1)
+  end
+
+  defp parse_claim_comment(%{"id" => id, "body" => body, "createdAt" => created_at})
+       when is_binary(body) do
+    fields = claim_fields(body)
+    comment_created_at = parse_datetime(created_at)
+
+    cond do
+      String.starts_with?(body, @claim_marker) ->
+        claim = %{
+          type: :claim,
+          id: id,
+          owner: Map.get(fields, "owner"),
+          token: Map.get(fields, "token"),
+          claimed_at: parse_datetime(Map.get(fields, "claimed_at")) || comment_created_at,
+          expires_at: parse_datetime(Map.get(fields, "expires_at"))
+        }
+
+        if valid_claim?(claim), do: [claim], else: []
+
+      String.starts_with?(body, @claim_release_marker) ->
+        release = %{
+          type: :release,
+          id: id,
+          owner: Map.get(fields, "owner"),
+          token: Map.get(fields, "token"),
+          released_at: parse_datetime(Map.get(fields, "released_at")) || comment_created_at
+        }
+
+        if valid_release?(release), do: [release], else: []
+
+      true ->
+        []
+    end
+  end
+
+  defp parse_claim_comment(_comment), do: []
+
+  defp claim_fields(body) when is_binary(body) do
+    body
+    |> String.split("\n")
+    |> Enum.reduce(%{}, fn line, fields ->
+      case String.split(line, ":", parts: 2) do
+        [key, value] ->
+          Map.put(fields, String.trim(key), String.trim(value))
+
+        _ ->
+          fields
+      end
+    end)
+  end
+
+  defp valid_claim?(%{owner: owner, claimed_at: %DateTime{}, expires_at: %DateTime{}})
+       when is_binary(owner),
+       do: String.trim(owner) != ""
+
+  defp valid_claim?(_claim), do: false
+
+  defp valid_release?(%{owner: owner, token: token, released_at: %DateTime{}})
+       when is_binary(owner) and is_binary(token),
+       do: String.trim(owner) != "" and String.trim(token) != ""
+
+  defp valid_release?(_release), do: false
+
+  defp claim_expired?(%{expires_at: expires_at}, now), do: DateTime.compare(expires_at, now) != :gt
+
+  defp claim_released?(%{owner: owner, token: token, claimed_at: claimed_at}, releases) do
+    releases
+    |> Map.get(owner, [])
+    |> Enum.any?(fn release ->
+      release_token = Map.get(release, :token)
+
+      release_token == token and DateTime.compare(release.released_at, claimed_at) in [:gt, :eq]
+    end)
+  end
+
+  defp same_claim?(claim, expected_claim) do
+    claim_value(claim, :owner) == claim_value(expected_claim, :owner) and
+      claim_value(claim, :token) == claim_value(expected_claim, :token)
+  end
+
+  defp claim_value(claim, key) when is_map(claim), do: Map.get(claim, key) || Map.get(claim, Atom.to_string(key))
+  defp claim_value(_claim, _key), do: nil
+
+  defp claim_body(identifier, owner, token, claimed_at, expires_at) do
+    [
+      @claim_marker,
+      "",
+      "owner: #{owner}",
+      "token: #{token}",
+      "issue: #{identifier || "unknown"}",
+      "claimed_at: #{DateTime.to_iso8601(claimed_at)}",
+      "expires_at: #{DateTime.to_iso8601(expires_at)}",
+      "",
+      "Symphony dispatch lease. A newer worker must not dispatch this issue while this lease is unexpired unless this owner has released it."
+    ]
+    |> Enum.join("\n")
+  end
+
+  defp release_body(owner, token, released_at) do
+    [
+      @claim_release_marker,
+      "",
+      "owner: #{owner}",
+      "token: #{token}",
+      "released_at: #{DateTime.to_iso8601(released_at)}"
+    ]
+    |> Enum.join("\n")
+  end
+
+  defp claim_owner do
+    case Process.get({__MODULE__, :claim_owner}) do
+      owner when is_binary(owner) ->
+        owner
+
+      _ ->
+        owner =
+          [
+            hostname(),
+            System.pid(),
+            inspect(self()),
+            :erlang.unique_integer([:positive, :monotonic])
+          ]
+          |> Enum.join(":")
+
+        Process.put({__MODULE__, :claim_owner}, owner)
+        owner
+    end
+  end
+
+  defp hostname do
+    {:ok, hostname} = :inet.gethostname()
+    List.to_string(hostname)
+  end
+
+  defp claim_token do
+    16
+    |> :crypto.strong_rand_bytes()
+    |> Base.encode16(case: :lower)
+  end
+
+  defp parse_datetime(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, _offset} -> datetime
+      _ -> nil
+    end
+  end
+
+  defp parse_datetime(_value), do: nil
 
   defp resolve_state_id(issue_id, state_name) do
     with {:ok, response} <-

--- a/elixir/lib/symphony_elixir/linear/adapter.ex
+++ b/elixir/lib/symphony_elixir/linear/adapter.ex
@@ -451,8 +451,6 @@ defmodule SymphonyElixir.Linear.Adapter do
     byte_size(left) == byte_size(right) and :crypto.hash_equals(left, right)
   end
 
-  defp secure_compare(_left, _right), do: false
-
   @doc false
   @spec claim_body_for_test(String.t() | nil, String.t(), String.t(), DateTime.t(), DateTime.t()) :: String.t()
   def claim_body_for_test(identifier, owner, token, claimed_at, expires_at) do

--- a/elixir/lib/symphony_elixir/linear/adapter.ex
+++ b/elixir/lib/symphony_elixir/linear/adapter.ex
@@ -5,12 +5,13 @@ defmodule SymphonyElixir.Linear.Adapter do
 
   @behaviour SymphonyElixir.Tracker
 
-  alias SymphonyElixir.Linear.Client
+  alias SymphonyElixir.{Config, Linear.Client}
 
   @claim_ttl_seconds 4 * 60 * 60
   @claim_settle_ms 250
   @claim_marker "## Symphony Claim Lease"
   @claim_release_marker "## Symphony Claim Release"
+  @claim_signature_version "v1"
 
   @create_comment_mutation """
   mutation SymphonyCreateComment($issueId: String!, $body: String!) {
@@ -81,7 +82,8 @@ defmodule SymphonyElixir.Linear.Adapter do
     token = claim_token()
     body = claim_body(identifier, owner, token, now, expires_at)
 
-    with {:ok, claim} <- create_claim_comment(issue_id, body, owner, token, now, expires_at) do
+    with :ok <- preflight_issue_claim(issue_id),
+         {:ok, claim} <- create_claim_comment(issue_id, body, owner, token, now, expires_at) do
       verify_issue_claim(issue_id, claim)
     end
   end
@@ -95,11 +97,12 @@ defmodule SymphonyElixir.Linear.Adapter do
   def release_issue_claim(issue_id, nil) when is_binary(issue_id), do: :ok
 
   def release_issue_claim(issue_id, claim) when is_binary(issue_id) do
+    id = claim_value(claim, :id)
     owner = claim_value(claim, :owner)
     token = claim_value(claim, :token)
 
-    if is_binary(owner) and is_binary(token) do
-      body = release_body(owner, token, DateTime.utc_now())
+    if is_binary(id) and is_binary(owner) and is_binary(token) do
+      body = release_body(id, owner, token, DateTime.utc_now())
 
       with {:ok, response} <- client_module().graphql(@create_comment_mutation, %{issueId: issue_id, body: body}),
            true <- get_in(response, ["data", "commentCreate", "success"]) == true do
@@ -145,18 +148,32 @@ defmodule SymphonyElixir.Linear.Adapter do
     Application.get_env(:symphony_elixir, :linear_client_module, Client)
   end
 
+  defp preflight_issue_claim(issue_id) do
+    case fetch_claim_comments(issue_id) do
+      {:ok, claims} ->
+        case winning_claim(claims, DateTime.utc_now()) do
+          {:ok, winner} -> {:error, {:issue_claimed, winner}}
+          {:error, :claim_not_visible} -> :ok
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
   defp create_claim_comment(issue_id, body, owner, token, now, expires_at) do
     with {:ok, response} <- client_module().graphql(@create_comment_mutation, %{issueId: issue_id, body: body}),
          true <- get_in(response, ["data", "commentCreate", "success"]) == true do
       comment = get_in(response, ["data", "commentCreate", "comment"]) || %{}
+      claimed_at = parse_datetime(comment["createdAt"]) || now
 
       {:ok,
        %{
          id: comment["id"],
          owner: owner,
          token: token,
-         claimed_at: parse_datetime(comment["createdAt"]) || now,
-         expires_at: expires_at
+         claimed_at: claimed_at,
+         expires_at: clamp_expires_at(expires_at, claimed_at)
        }}
     else
       false -> {:error, :claim_create_failed}
@@ -243,27 +260,38 @@ defmodule SymphonyElixir.Linear.Adapter do
 
     cond do
       String.starts_with?(body, @claim_marker) ->
+        claimed_at = trusted_claimed_at(Map.get(fields, "claimed_at"), comment_created_at)
+
         claim = %{
           type: :claim,
           id: id,
           owner: Map.get(fields, "owner"),
           token: Map.get(fields, "token"),
-          claimed_at: parse_datetime(Map.get(fields, "claimed_at")) || comment_created_at,
-          expires_at: parse_datetime(Map.get(fields, "expires_at"))
+          claimed_at: claimed_at,
+          expires_at:
+            fields
+            |> Map.get("expires_at")
+            |> parse_datetime()
+            |> clamp_expires_at(claimed_at),
+          signature: Map.get(fields, "signature")
         }
 
-        if valid_claim?(claim), do: [claim], else: []
+        if valid_claim?(claim) and valid_signature?(:claim, fields), do: [claim], else: []
 
       String.starts_with?(body, @claim_release_marker) ->
+        released_at = comment_created_at || parse_datetime(Map.get(fields, "released_at"))
+
         release = %{
           type: :release,
           id: id,
+          claim_id: Map.get(fields, "claim_id"),
           owner: Map.get(fields, "owner"),
           token: Map.get(fields, "token"),
-          released_at: parse_datetime(Map.get(fields, "released_at")) || comment_created_at
+          released_at: released_at,
+          signature: Map.get(fields, "signature")
         }
 
-        if valid_release?(release), do: [release], else: []
+        if valid_release?(release) and valid_signature?(:release, fields), do: [release], else: []
 
       true ->
         []
@@ -286,27 +314,28 @@ defmodule SymphonyElixir.Linear.Adapter do
     end)
   end
 
-  defp valid_claim?(%{owner: owner, claimed_at: %DateTime{}, expires_at: %DateTime{}})
-       when is_binary(owner),
-       do: String.trim(owner) != ""
+  defp valid_claim?(%{id: id, owner: owner, token: token, claimed_at: %DateTime{}, expires_at: %DateTime{}})
+       when is_binary(id) and is_binary(owner) and is_binary(token),
+       do: String.trim(id) != "" and String.trim(owner) != "" and String.trim(token) != ""
 
   defp valid_claim?(_claim), do: false
 
-  defp valid_release?(%{owner: owner, token: token, released_at: %DateTime{}})
-       when is_binary(owner) and is_binary(token),
-       do: String.trim(owner) != "" and String.trim(token) != ""
+  defp valid_release?(%{claim_id: claim_id, owner: owner, token: token, released_at: %DateTime{}})
+       when is_binary(claim_id) and is_binary(owner) and is_binary(token),
+       do: String.trim(claim_id) != "" and String.trim(owner) != "" and String.trim(token) != ""
 
   defp valid_release?(_release), do: false
 
   defp claim_expired?(%{expires_at: expires_at}, now), do: DateTime.compare(expires_at, now) != :gt
 
-  defp claim_released?(%{owner: owner, token: token, claimed_at: claimed_at}, releases) do
+  defp claim_released?(%{id: claim_id, owner: owner, token: token, claimed_at: claimed_at}, releases) do
     releases
     |> Map.get(owner, [])
     |> Enum.any?(fn release ->
       release_token = Map.get(release, :token)
 
-      release_token == token and DateTime.compare(release.released_at, claimed_at) in [:gt, :eq]
+      release.claim_id == claim_id and
+        release_token == token and DateTime.compare(release.released_at, claimed_at) in [:gt, :eq]
     end)
   end
 
@@ -319,29 +348,121 @@ defmodule SymphonyElixir.Linear.Adapter do
   defp claim_value(_claim, _key), do: nil
 
   defp claim_body(identifier, owner, token, claimed_at, expires_at) do
+    fields = %{
+      "owner" => owner,
+      "token" => token,
+      "issue" => identifier || "unknown",
+      "claimed_at" => DateTime.to_iso8601(claimed_at),
+      "expires_at" => DateTime.to_iso8601(expires_at)
+    }
+
     [
       @claim_marker,
       "",
-      "owner: #{owner}",
-      "token: #{token}",
-      "issue: #{identifier || "unknown"}",
-      "claimed_at: #{DateTime.to_iso8601(claimed_at)}",
-      "expires_at: #{DateTime.to_iso8601(expires_at)}",
+      "version: #{@claim_signature_version}",
+      "owner: #{fields["owner"]}",
+      "token: #{fields["token"]}",
+      "issue: #{fields["issue"]}",
+      "claimed_at: #{fields["claimed_at"]}",
+      "expires_at: #{fields["expires_at"]}",
+      "signature: #{signature_for(:claim, fields)}",
       "",
       "Symphony dispatch lease. A newer worker must not dispatch this issue while this lease is unexpired unless this owner has released it."
     ]
     |> Enum.join("\n")
   end
 
-  defp release_body(owner, token, released_at) do
+  defp release_body(claim_id, owner, token, released_at) do
+    fields = %{
+      "claim_id" => claim_id,
+      "owner" => owner,
+      "token" => token,
+      "released_at" => DateTime.to_iso8601(released_at)
+    }
+
     [
       @claim_release_marker,
       "",
-      "owner: #{owner}",
-      "token: #{token}",
-      "released_at: #{DateTime.to_iso8601(released_at)}"
+      "version: #{@claim_signature_version}",
+      "claim_id: #{fields["claim_id"]}",
+      "owner: #{fields["owner"]}",
+      "token: #{fields["token"]}",
+      "released_at: #{fields["released_at"]}",
+      "signature: #{signature_for(:release, fields)}"
     ]
     |> Enum.join("\n")
+  end
+
+  defp trusted_claimed_at(_raw_claimed_at, %DateTime{} = comment_created_at), do: comment_created_at
+
+  defp trusted_claimed_at(raw_claimed_at, _comment_created_at), do: parse_datetime(raw_claimed_at)
+
+  defp clamp_expires_at(%DateTime{} = expires_at, %DateTime{} = claimed_at) do
+    max_expires_at = DateTime.add(claimed_at, @claim_ttl_seconds, :second)
+
+    if DateTime.compare(expires_at, max_expires_at) == :gt do
+      max_expires_at
+    else
+      expires_at
+    end
+  end
+
+  defp clamp_expires_at(_expires_at, _claimed_at), do: nil
+
+  defp valid_signature?(type, fields) when is_map(fields) do
+    signature = Map.get(fields, "signature")
+
+    is_binary(signature) and secure_compare(signature, signature_for(type, fields))
+  end
+
+  defp signature_for(type, fields) when is_map(fields) do
+    :hmac
+    |> :crypto.mac(:sha256, claim_signing_secret(), canonical_signature_payload(type, fields))
+    |> Base.encode16(case: :lower)
+  end
+
+  defp canonical_signature_payload(type, fields) do
+    keys =
+      case type do
+        :claim -> ["version", "owner", "token", "issue", "claimed_at", "expires_at"]
+        :release -> ["version", "claim_id", "owner", "token", "released_at"]
+      end
+
+    signed_fields =
+      fields
+      |> Map.put_new("version", @claim_signature_version)
+
+    [
+      "symphony-linear-claim",
+      Atom.to_string(type)
+      | Enum.map(keys, fn key -> "#{key}=#{Map.get(signed_fields, key, "")}" end)
+    ]
+    |> Enum.join("\n")
+  end
+
+  defp claim_signing_secret do
+    case Config.settings!().tracker.api_key do
+      token when is_binary(token) and token != "" -> token
+      _ -> "missing-linear-api-token"
+    end
+  end
+
+  defp secure_compare(left, right) when is_binary(left) and is_binary(right) do
+    byte_size(left) == byte_size(right) and :crypto.hash_equals(left, right)
+  end
+
+  defp secure_compare(_left, _right), do: false
+
+  @doc false
+  @spec claim_body_for_test(String.t() | nil, String.t(), String.t(), DateTime.t(), DateTime.t()) :: String.t()
+  def claim_body_for_test(identifier, owner, token, claimed_at, expires_at) do
+    claim_body(identifier, owner, token, claimed_at, expires_at)
+  end
+
+  @doc false
+  @spec release_body_for_test(String.t(), String.t(), String.t(), DateTime.t()) :: String.t()
+  def release_body_for_test(claim_id, owner, token, released_at) do
+    release_body(claim_id, owner, token, released_at)
   end
 
   defp claim_owner do

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -127,6 +127,7 @@ defmodule SymphonyElixir.Orchestrator do
       issue_id ->
         {running_entry, state} = pop_running_entry(state, issue_id)
         state = record_session_completion_totals(state, running_entry)
+        state = release_issue_claim(state, issue_id, Map.get(running_entry, :claim))
         session_id = running_entry_session_id(running_entry)
 
         state =
@@ -433,12 +434,19 @@ defmodule SymphonyElixir.Orchestrator do
           Process.demonitor(ref, [:flush])
         end
 
-        %{
+        state =
+          %{
+            state
+            | running: Map.delete(state.running, issue_id),
+              claimed: MapSet.delete(state.claimed, issue_id),
+              retry_attempts: Map.delete(state.retry_attempts, issue_id)
+          }
+
+        if Map.has_key?(running_entry, :claim) do
+          release_issue_claim(state, issue_id, Map.get(running_entry, :claim))
+        else
           state
-          | running: Map.delete(state.running, issue_id),
-            claimed: MapSet.delete(state.claimed, issue_id),
-            retry_attempts: Map.delete(state.retry_attempts, issue_id)
-        }
+        end
 
       _ ->
         release_issue_claim(state, issue_id)
@@ -680,17 +688,29 @@ defmodule SymphonyElixir.Orchestrator do
   defp do_dispatch_issue(%State{} = state, issue, attempt, preferred_worker_host) do
     recipient = self()
 
-    case select_worker_host(state, preferred_worker_host) do
+    with worker_host when worker_host != :no_worker_capacity <- select_worker_host(state, preferred_worker_host),
+         {:ok, claim} <- acquire_issue_claim(issue) do
+      spawn_issue_on_worker_host(state, issue, attempt, recipient, worker_host, claim)
+    else
+      {:error, {:issue_claimed, claim}} ->
+        Logger.info("Skipping dispatch; durable claim is held for #{issue_context(issue)} owner=#{claim.owner} expires_at=#{DateTime.to_iso8601(claim.expires_at)}")
+        state
+
+      {:error, reason} ->
+        Logger.warning("Skipping dispatch; unable to acquire durable claim for #{issue_context(issue)}: #{inspect(reason)}")
+        state
+
       :no_worker_capacity ->
         Logger.debug("No SSH worker slots available for #{issue_context(issue)} preferred_worker_host=#{inspect(preferred_worker_host)}")
         state
-
-      worker_host ->
-        spawn_issue_on_worker_host(state, issue, attempt, recipient, worker_host)
     end
   end
 
-  defp spawn_issue_on_worker_host(%State{} = state, issue, attempt, recipient, worker_host) do
+  defp acquire_issue_claim(%Issue{} = issue) do
+    Tracker.acquire_issue_claim(issue)
+  end
+
+  defp spawn_issue_on_worker_host(%State{} = state, issue, attempt, recipient, worker_host, claim) do
     case Task.Supervisor.start_child(SymphonyElixir.TaskSupervisor, fn ->
            AgentRunner.run(issue, recipient, attempt: attempt, worker_host: worker_host)
          end) do
@@ -719,6 +739,7 @@ defmodule SymphonyElixir.Orchestrator do
             codex_last_reported_output_tokens: 0,
             codex_last_reported_total_tokens: 0,
             turn_count: 0,
+            claim: claim,
             retry_attempt: normalize_retry_attempt(attempt),
             started_at: DateTime.utc_now()
           })
@@ -734,7 +755,9 @@ defmodule SymphonyElixir.Orchestrator do
         Logger.error("Unable to spawn agent for #{issue_context(issue)}: #{inspect(reason)}")
         next_attempt = if is_integer(attempt), do: attempt + 1, else: nil
 
-        schedule_issue_retry(state, issue.id, next_attempt, %{
+        state
+        |> release_issue_claim(issue.id, claim)
+        |> schedule_issue_retry(issue.id, next_attempt, %{
           identifier: issue.identifier,
           error: "failed to spawn agent: #{inspect(reason)}",
           worker_host: worker_host
@@ -921,7 +944,15 @@ defmodule SymphonyElixir.Orchestrator do
     end
   end
 
-  defp release_issue_claim(%State{} = state, issue_id) do
+  defp release_issue_claim(%State{} = state, issue_id, claim \\ nil) do
+    case Tracker.release_issue_claim(issue_id, claim) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Failed to release durable claim for issue_id=#{issue_id}: #{inspect(reason)}")
+    end
+
     %{state | claimed: MapSet.delete(state.claimed, issue_id)}
   end
 

--- a/elixir/lib/symphony_elixir/tracker.ex
+++ b/elixir/lib/symphony_elixir/tracker.ex
@@ -8,6 +8,8 @@ defmodule SymphonyElixir.Tracker do
   @callback fetch_candidate_issues() :: {:ok, [term()]} | {:error, term()}
   @callback fetch_issues_by_states([String.t()]) :: {:ok, [term()]} | {:error, term()}
   @callback fetch_issue_states_by_ids([String.t()]) :: {:ok, [term()]} | {:error, term()}
+  @callback acquire_issue_claim(term()) :: {:ok, map()} | {:error, term()}
+  @callback release_issue_claim(String.t(), map() | nil) :: :ok | {:error, term()}
   @callback create_comment(String.t(), String.t()) :: :ok | {:error, term()}
   @callback update_issue_state(String.t(), String.t()) :: :ok | {:error, term()}
 
@@ -24,6 +26,19 @@ defmodule SymphonyElixir.Tracker do
   @spec fetch_issue_states_by_ids([String.t()]) :: {:ok, [term()]} | {:error, term()}
   def fetch_issue_states_by_ids(issue_ids) do
     adapter().fetch_issue_states_by_ids(issue_ids)
+  end
+
+  @spec acquire_issue_claim(term()) :: {:ok, map()} | {:error, term()}
+  def acquire_issue_claim(issue) do
+    adapter().acquire_issue_claim(issue)
+  end
+
+  @spec release_issue_claim(String.t()) :: :ok | {:error, term()}
+  def release_issue_claim(issue_id), do: release_issue_claim(issue_id, nil)
+
+  @spec release_issue_claim(String.t(), map() | nil) :: :ok | {:error, term()}
+  def release_issue_claim(issue_id, claim) do
+    adapter().release_issue_claim(issue_id, claim)
   end
 
   @spec create_comment(String.t(), String.t()) :: :ok | {:error, term()}

--- a/elixir/lib/symphony_elixir/tracker/memory.ex
+++ b/elixir/lib/symphony_elixir/tracker/memory.ex
@@ -35,6 +35,30 @@ defmodule SymphonyElixir.Tracker.Memory do
      end)}
   end
 
+  @spec acquire_issue_claim(Issue.t()) :: {:ok, map()} | {:error, term()}
+  def acquire_issue_claim(%Issue{id: issue_id, identifier: identifier}) when is_binary(issue_id) do
+    claim = %{
+      id: "memory-#{issue_id}",
+      owner: "memory",
+      claimed_at: DateTime.utc_now(),
+      expires_at: DateTime.add(DateTime.utc_now(), 4, :hour)
+    }
+
+    send_event({:memory_tracker_claim_acquired, issue_id, identifier, claim})
+    {:ok, claim}
+  end
+
+  def acquire_issue_claim(_issue), do: {:error, :invalid_issue_claim}
+
+  @spec release_issue_claim(String.t()) :: :ok | {:error, term()}
+  def release_issue_claim(issue_id), do: release_issue_claim(issue_id, nil)
+
+  @spec release_issue_claim(String.t(), map() | nil) :: :ok | {:error, term()}
+  def release_issue_claim(issue_id, _claim) when is_binary(issue_id) do
+    send_event({:memory_tracker_claim_released, issue_id})
+    :ok
+  end
+
   @spec create_comment(String.t(), String.t()) :: :ok | {:error, term()}
   def create_comment(issue_id, body) do
     send_event({:memory_tracker_comment, issue_id, body})

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -31,12 +31,19 @@ defmodule SymphonyElixir.ExtensionsTest do
       case Process.get({__MODULE__, :graphql_results}) do
         [result | rest] ->
           Process.put({__MODULE__, :graphql_results}, rest)
-          result
+          resolve_graphql_result(result, query, variables)
 
         _ ->
           Process.get({__MODULE__, :graphql_result})
+          |> resolve_graphql_result(query, variables)
       end
     end
+
+    defp resolve_graphql_result(result, query, variables) when is_function(result, 2) do
+      result.(query, variables)
+    end
+
+    defp resolve_graphql_result(result, _query, _variables), do: result
   end
 
   defmodule SlowOrchestrator do
@@ -192,8 +199,14 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert {:ok, [^issue]} = SymphonyElixir.Tracker.fetch_candidate_issues()
     assert {:ok, [^issue]} = SymphonyElixir.Tracker.fetch_issues_by_states([" in progress ", 42])
     assert {:ok, [^issue]} = SymphonyElixir.Tracker.fetch_issue_states_by_ids(["issue-1"])
+    assert {:ok, %{id: "memory-issue-1", owner: "memory"}} = SymphonyElixir.Tracker.acquire_issue_claim(issue)
+    assert :ok = SymphonyElixir.Tracker.release_issue_claim("issue-1")
+    assert :ok = Memory.release_issue_claim("issue-1")
+    assert {:error, :invalid_issue_claim} = Memory.acquire_issue_claim(%{})
     assert :ok = SymphonyElixir.Tracker.create_comment("issue-1", "comment")
     assert :ok = SymphonyElixir.Tracker.update_issue_state("issue-1", "Done")
+    assert_receive {:memory_tracker_claim_acquired, "issue-1", "MT-1", %{owner: "memory"}}
+    assert_receive {:memory_tracker_claim_released, "issue-1"}
     assert_receive {:memory_tracker_comment, "issue-1", "comment"}
     assert_receive {:memory_tracker_state_update, "issue-1", "Done"}
 
@@ -317,6 +330,376 @@ defmodule SymphonyElixir.ExtensionsTest do
     )
 
     assert {:error, :issue_update_failed} = Adapter.update_issue_state("issue-1", "Odd")
+  end
+
+  test "linear adapter acquires visible claim when this worker owns the oldest active lease" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+    now = ~U[2026-05-02 00:00:00Z]
+
+    Process.put({FakeLinearClient, :graphql_result}, fn query, variables ->
+      cond do
+        String.contains?(query, "commentCreate") ->
+          Process.put(:claim_body, variables.body)
+
+          {:ok,
+           %{
+             "data" => %{
+               "commentCreate" => %{
+                 "success" => true,
+                 "comment" => %{"id" => "claim-own", "createdAt" => DateTime.to_iso8601(now)}
+               }
+             }
+           }}
+
+        String.contains?(query, "SymphonyIssueClaimComments") ->
+          {:ok,
+           %{
+             "data" => %{
+               "issue" => %{
+                 "comments" => %{
+                   "nodes" => [
+                     %{
+                       "id" => "claim-own",
+                       "body" => Process.get(:claim_body),
+                       "createdAt" => DateTime.to_iso8601(now)
+                     }
+                   ]
+                 }
+               }
+             }
+           }}
+      end
+    end)
+
+    assert {:ok, %{id: "claim-own", owner: owner, expires_at: %DateTime{}}} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+
+    assert is_binary(owner)
+  end
+
+  test "linear adapter rejects dispatch when another unexpired lease is older" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+    older = DateTime.add(DateTime.utc_now(), -60, :second)
+    newer = DateTime.add(older, 1, :second)
+    expires_at = DateTime.add(older, 4, :hour)
+
+    Process.put({FakeLinearClient, :graphql_result}, fn query, variables ->
+      cond do
+        String.contains?(query, "commentCreate") ->
+          Process.put(:claim_body, variables.body)
+
+          {:ok,
+           %{
+             "data" => %{
+               "commentCreate" => %{
+                 "success" => true,
+                 "comment" => %{"id" => "claim-own", "createdAt" => DateTime.to_iso8601(newer)}
+               }
+             }
+           }}
+
+        String.contains?(query, "SymphonyIssueClaimComments") ->
+          competitor_body =
+            [
+              "## Symphony Claim Lease",
+              "",
+              "owner: other-worker",
+              "token: older-token",
+              "issue: ALB-CLAIM",
+              "claimed_at: #{DateTime.to_iso8601(older)}",
+              "expires_at: #{DateTime.to_iso8601(expires_at)}"
+            ]
+            |> Enum.join("\n")
+
+          {:ok,
+           %{
+             "data" => %{
+               "issue" => %{
+                 "comments" => %{
+                   "nodes" => [
+                     %{"id" => "claim-other", "body" => competitor_body, "createdAt" => DateTime.to_iso8601(older)},
+                     %{"id" => "claim-own", "body" => Process.get(:claim_body), "createdAt" => DateTime.to_iso8601(newer)}
+                   ]
+                 }
+               }
+             }
+           }}
+      end
+    end)
+
+    assert {:error, {:issue_claimed, %{id: "claim-other", owner: "other-worker"}}} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+  end
+
+  test "linear adapter releases its claim when verification cannot read claim comments" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+    now = DateTime.utc_now()
+
+    Process.put({FakeLinearClient, :graphql_results}, [
+      {:ok,
+       %{
+         "data" => %{
+           "commentCreate" => %{
+             "success" => true,
+             "comment" => %{"id" => "claim-own", "createdAt" => DateTime.to_iso8601(now)}
+           }
+         }
+       }},
+      {:error, :linear_timeout},
+      fn query, variables ->
+        assert String.contains?(query, "commentCreate")
+        assert variables.body =~ "## Symphony Claim Release"
+        assert variables.body =~ "token:"
+
+        {:ok, %{"data" => %{"commentCreate" => %{"success" => true}}}}
+      end
+    ])
+
+    assert {:error, :linear_timeout} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+  end
+
+  test "linear adapter handles claim and release error branches" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+
+    assert {:error, :invalid_issue_claim} = Adapter.acquire_issue_claim(%{})
+    assert :ok = Adapter.release_issue_claim("issue-claim")
+    assert :ok = Adapter.release_issue_claim("issue-claim", %{})
+    assert :ok = Adapter.release_issue_claim("issue-claim", :invalid_claim)
+
+    Process.put(
+      {FakeLinearClient, :graphql_result},
+      {:ok, %{"data" => %{"commentCreate" => %{"success" => false}}}}
+    )
+
+    assert {:error, :claim_release_failed} =
+             Adapter.release_issue_claim("issue-claim", %{owner: "worker", token: "token"})
+
+    Process.put({FakeLinearClient, :graphql_result}, {:error, :release_timeout})
+
+    assert {:error, :release_timeout} =
+             Adapter.release_issue_claim("issue-claim", %{owner: "worker", token: "token"})
+
+    Process.put({FakeLinearClient, :graphql_result}, :unexpected)
+
+    assert {:error, :claim_release_failed} =
+             Adapter.release_issue_claim("issue-claim", %{owner: "worker", token: "token"})
+
+    Process.put(
+      {FakeLinearClient, :graphql_result},
+      {:ok, %{"data" => %{"commentCreate" => %{"success" => false}}}}
+    )
+
+    assert {:error, :claim_create_failed} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+
+    Process.put({FakeLinearClient, :graphql_result}, {:error, :create_timeout})
+
+    assert {:error, :create_timeout} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+
+    Process.put({FakeLinearClient, :graphql_result}, :unexpected)
+
+    assert {:error, :claim_create_failed} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+  end
+
+  test "linear adapter ignores malformed claim comments and releases invisible claims" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+    now = DateTime.utc_now()
+
+    Process.put({FakeLinearClient, :graphql_results}, [
+      {:ok,
+       %{
+         "data" => %{
+           "commentCreate" => %{
+             "success" => true,
+             "comment" => %{"id" => "claim-own", "createdAt" => DateTime.to_iso8601(now)}
+           }
+         }
+       }},
+      {:ok,
+       %{
+         "data" => %{
+           "issue" => %{
+             "comments" => %{
+               "nodes" => [
+                 %{"id" => "noise", "body" => "not a claim", "createdAt" => "not-a-date"},
+                 %{"id" => "bad-claim", "body" => "## Symphony Claim Lease\nowner: \nclaimed_at: nope", "createdAt" => "nope"},
+                 %{"id" => "bad-release", "body" => "## Symphony Claim Release\nowner: worker", "createdAt" => "nope"},
+                 %{}
+               ],
+               "pageInfo" => %{"hasNextPage" => false}
+             }
+           }
+         }
+       }},
+      {:ok, %{"data" => %{"commentCreate" => %{"success" => true}}}}
+    ])
+
+    assert {:error, :claim_not_visible} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+
+    Process.put({FakeLinearClient, :graphql_results}, [
+      {:ok,
+       %{
+         "data" => %{
+           "commentCreate" => %{
+             "success" => true,
+             "comment" => %{"id" => "claim-own", "createdAt" => DateTime.to_iso8601(now)}
+           }
+         }
+       }},
+      :unexpected,
+      {:ok, %{"data" => %{"commentCreate" => %{"success" => true}}}}
+    ])
+
+    assert {:error, :claim_comments_fetch_failed} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+  end
+
+  test "linear adapter scans paginated claim comments before selecting the winner" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+    older = DateTime.add(DateTime.utc_now(), -60, :second)
+    newer = DateTime.add(older, 1, :second)
+    expires_at = DateTime.add(older, 4, :hour)
+
+    Process.put({FakeLinearClient, :graphql_result}, fn query, variables ->
+      cond do
+        String.contains?(query, "commentCreate") ->
+          Process.put(:claim_body, variables.body)
+
+          {:ok,
+           %{
+             "data" => %{
+               "commentCreate" => %{
+                 "success" => true,
+                 "comment" => %{"id" => "claim-own", "createdAt" => DateTime.to_iso8601(newer)}
+               }
+             }
+           }}
+
+        String.contains?(query, "SymphonyIssueClaimComments") and is_nil(variables.after) ->
+          {:ok,
+           %{
+             "data" => %{
+               "issue" => %{
+                 "comments" => %{
+                   "nodes" => [],
+                   "pageInfo" => %{"hasNextPage" => true, "endCursor" => "cursor-1"}
+                 }
+               }
+             }
+           }}
+
+        String.contains?(query, "SymphonyIssueClaimComments") and variables.after == "cursor-1" ->
+          competitor_body =
+            [
+              "## Symphony Claim Lease",
+              "",
+              "owner: other-worker",
+              "token: older-token",
+              "issue: ALB-CLAIM",
+              "claimed_at: #{DateTime.to_iso8601(older)}",
+              "expires_at: #{DateTime.to_iso8601(expires_at)}"
+            ]
+            |> Enum.join("\n")
+
+          {:ok,
+           %{
+             "data" => %{
+               "issue" => %{
+                 "comments" => %{
+                   "nodes" => [
+                     %{"id" => "claim-other", "body" => competitor_body, "createdAt" => DateTime.to_iso8601(older)},
+                     %{"id" => "claim-own", "body" => Process.get(:claim_body), "createdAt" => DateTime.to_iso8601(newer)}
+                   ],
+                   "pageInfo" => %{"hasNextPage" => false, "endCursor" => nil}
+                 }
+               }
+             }
+           }}
+      end
+    end)
+
+    assert {:error, {:issue_claimed, %{id: "claim-other", owner: "other-worker"}}} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+  end
+
+  test "linear adapter ignores released and expired claims when selecting the lease owner" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+    expired_at = ~U[2026-05-02 00:00:00Z]
+    released_at = DateTime.add(expired_at, 10, :second)
+    now = DateTime.add(expired_at, 30, :second)
+
+    Process.put({FakeLinearClient, :graphql_result}, fn query, variables ->
+      cond do
+        String.contains?(query, "commentCreate") ->
+          Process.put(:claim_body, variables.body)
+
+          {:ok,
+           %{
+             "data" => %{
+               "commentCreate" => %{
+                 "success" => true,
+                 "comment" => %{"id" => "claim-own", "createdAt" => DateTime.to_iso8601(now)}
+               }
+             }
+           }}
+
+        String.contains?(query, "SymphonyIssueClaimComments") ->
+          expired_body =
+            [
+              "## Symphony Claim Lease",
+              "",
+              "owner: expired-worker",
+              "token: expired-token",
+              "claimed_at: #{DateTime.to_iso8601(expired_at)}",
+              "expires_at: #{DateTime.to_iso8601(expired_at)}"
+            ]
+            |> Enum.join("\n")
+
+          released_claim_body =
+            [
+              "## Symphony Claim Lease",
+              "",
+              "owner: released-worker",
+              "token: released-token",
+              "claimed_at: #{DateTime.to_iso8601(expired_at)}",
+              "expires_at: #{DateTime.to_iso8601(DateTime.add(expired_at, 4, :hour))}"
+            ]
+            |> Enum.join("\n")
+
+          release_body =
+            [
+              "## Symphony Claim Release",
+              "",
+              "owner: released-worker",
+              "token: released-token",
+              "released_at: #{DateTime.to_iso8601(released_at)}"
+            ]
+            |> Enum.join("\n")
+
+          {:ok,
+           %{
+             "data" => %{
+               "issue" => %{
+                 "comments" => %{
+                   "nodes" => [
+                     %{"id" => "claim-expired", "body" => expired_body, "createdAt" => DateTime.to_iso8601(expired_at)},
+                     %{"id" => "claim-released", "body" => released_claim_body, "createdAt" => DateTime.to_iso8601(expired_at)},
+                     %{"id" => "release-released", "body" => release_body, "createdAt" => DateTime.to_iso8601(released_at)},
+                     %{"id" => "claim-own", "body" => Process.get(:claim_body), "createdAt" => DateTime.to_iso8601(now)}
+                   ]
+                 }
+               }
+             }
+           }}
+      end
+    end)
+
+    assert {:ok, %{id: "claim-own"}} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
   end
 
   test "phoenix observability api preserves state, issue, and refresh responses" do

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -352,18 +352,26 @@ defmodule SymphonyElixir.ExtensionsTest do
            }}
 
         String.contains?(query, "SymphonyIssueClaimComments") ->
+          claim_body = Process.get(:claim_body)
+
           {:ok,
            %{
              "data" => %{
                "issue" => %{
                  "comments" => %{
-                   "nodes" => [
-                     %{
-                       "id" => "claim-own",
-                       "body" => Process.get(:claim_body),
-                       "createdAt" => DateTime.to_iso8601(now)
-                     }
-                   ]
+                   "nodes" =>
+                     if claim_body do
+                       [
+                         %{
+                           "id" => "claim-own",
+                           "body" => claim_body,
+                           "createdAt" => DateTime.to_iso8601(now)
+                         }
+                       ]
+                     else
+                       []
+                     end,
+                   "pageInfo" => %{"hasNextPage" => false}
                  }
                }
              }
@@ -399,17 +407,7 @@ defmodule SymphonyElixir.ExtensionsTest do
            }}
 
         String.contains?(query, "SymphonyIssueClaimComments") ->
-          competitor_body =
-            [
-              "## Symphony Claim Lease",
-              "",
-              "owner: other-worker",
-              "token: older-token",
-              "issue: ALB-CLAIM",
-              "claimed_at: #{DateTime.to_iso8601(older)}",
-              "expires_at: #{DateTime.to_iso8601(expires_at)}"
-            ]
-            |> Enum.join("\n")
+          competitor_body = signed_claim_body("ALB-CLAIM", "other-worker", "older-token", older, expires_at)
 
           {:ok,
            %{
@@ -429,6 +427,109 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     assert {:error, {:issue_claimed, %{id: "claim-other", owner: "other-worker"}}} =
              Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+
+    refute Process.get(:claim_body)
+  end
+
+  test "linear adapter ignores unsigned spoofed claims before dispatch" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+    older = DateTime.add(DateTime.utc_now(), -60, :second)
+    newer = DateTime.add(older, 1, :second)
+    expires_at = DateTime.add(older, 4, :hour)
+
+    Process.put({FakeLinearClient, :graphql_result}, fn query, variables ->
+      cond do
+        String.contains?(query, "commentCreate") ->
+          Process.put(:claim_body, variables.body)
+
+          {:ok,
+           %{
+             "data" => %{
+               "commentCreate" => %{
+                 "success" => true,
+                 "comment" => %{"id" => "claim-own", "createdAt" => DateTime.to_iso8601(newer)}
+               }
+             }
+           }}
+
+        String.contains?(query, "SymphonyIssueClaimComments") ->
+          spoofed_body =
+            [
+              "## Symphony Claim Lease",
+              "",
+              "owner: spoofed-worker",
+              "token: copied-token",
+              "issue: ALB-CLAIM",
+              "claimed_at: #{DateTime.to_iso8601(older)}",
+              "expires_at: #{DateTime.to_iso8601(expires_at)}"
+            ]
+            |> Enum.join("\n")
+
+          claim_body = Process.get(:claim_body)
+
+          {:ok,
+           %{
+             "data" => %{
+               "issue" => %{
+                 "comments" => %{
+                   "nodes" =>
+                     [%{"id" => "claim-spoofed", "body" => spoofed_body, "createdAt" => DateTime.to_iso8601(older)}] ++
+                       if claim_body do
+                         [%{"id" => "claim-own", "body" => claim_body, "createdAt" => DateTime.to_iso8601(newer)}]
+                       else
+                         []
+                       end,
+                   "pageInfo" => %{"hasNextPage" => false}
+                 }
+               }
+             }
+           }}
+      end
+    end)
+
+    assert {:ok, %{id: "claim-own"}} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+  end
+
+  test "linear adapter ignores unsigned spoofed releases for visible tokens" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+    claimed_at = DateTime.add(DateTime.utc_now(), -60, :second)
+    released_at = DateTime.add(claimed_at, 10, :second)
+    expires_at = DateTime.add(claimed_at, 4, :hour)
+    claim_body = signed_claim_body("ALB-CLAIM", "other-worker", "visible-token", claimed_at, expires_at)
+
+    spoofed_release =
+      [
+        "## Symphony Claim Release",
+        "",
+        "claim_id: claim-other",
+        "owner: other-worker",
+        "token: visible-token",
+        "released_at: #{DateTime.to_iso8601(released_at)}"
+      ]
+      |> Enum.join("\n")
+
+    Process.put({FakeLinearClient, :graphql_result}, fn query, _variables ->
+      assert String.contains?(query, "SymphonyIssueClaimComments")
+
+      {:ok,
+       %{
+         "data" => %{
+           "issue" => %{
+             "comments" => %{
+               "nodes" => [
+                 %{"id" => "claim-other", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)},
+                 %{"id" => "release-spoofed", "body" => spoofed_release, "createdAt" => DateTime.to_iso8601(released_at)}
+               ],
+               "pageInfo" => %{"hasNextPage" => false}
+             }
+           }
+         }
+       }}
+    end)
+
+    assert {:error, {:issue_claimed, %{id: "claim-other", owner: "other-worker"}}} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
   end
 
   test "linear adapter releases its claim when verification cannot read claim comments" do
@@ -436,6 +537,7 @@ defmodule SymphonyElixir.ExtensionsTest do
     now = DateTime.utc_now()
 
     Process.put({FakeLinearClient, :graphql_results}, [
+      empty_claim_comments(),
       {:ok,
        %{
          "data" => %{
@@ -473,32 +575,32 @@ defmodule SymphonyElixir.ExtensionsTest do
     )
 
     assert {:error, :claim_release_failed} =
-             Adapter.release_issue_claim("issue-claim", %{owner: "worker", token: "token"})
+             Adapter.release_issue_claim("issue-claim", %{id: "claim-1", owner: "worker", token: "token"})
 
     Process.put({FakeLinearClient, :graphql_result}, {:error, :release_timeout})
 
     assert {:error, :release_timeout} =
-             Adapter.release_issue_claim("issue-claim", %{owner: "worker", token: "token"})
+             Adapter.release_issue_claim("issue-claim", %{id: "claim-1", owner: "worker", token: "token"})
 
     Process.put({FakeLinearClient, :graphql_result}, :unexpected)
 
     assert {:error, :claim_release_failed} =
-             Adapter.release_issue_claim("issue-claim", %{owner: "worker", token: "token"})
+             Adapter.release_issue_claim("issue-claim", %{id: "claim-1", owner: "worker", token: "token"})
 
-    Process.put(
-      {FakeLinearClient, :graphql_result},
+    Process.put({FakeLinearClient, :graphql_results}, [
+      empty_claim_comments(),
       {:ok, %{"data" => %{"commentCreate" => %{"success" => false}}}}
-    )
+    ])
 
     assert {:error, :claim_create_failed} =
              Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
 
-    Process.put({FakeLinearClient, :graphql_result}, {:error, :create_timeout})
+    Process.put({FakeLinearClient, :graphql_results}, [empty_claim_comments(), {:error, :create_timeout}])
 
     assert {:error, :create_timeout} =
              Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
 
-    Process.put({FakeLinearClient, :graphql_result}, :unexpected)
+    Process.put({FakeLinearClient, :graphql_results}, [empty_claim_comments(), :unexpected])
 
     assert {:error, :claim_create_failed} =
              Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
@@ -508,7 +610,10 @@ defmodule SymphonyElixir.ExtensionsTest do
     Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
     now = DateTime.utc_now()
 
+    malformed_comments = malformed_claim_comments()
+
     Process.put({FakeLinearClient, :graphql_results}, [
+      malformed_comments,
       {:ok,
        %{
          "data" => %{
@@ -518,22 +623,7 @@ defmodule SymphonyElixir.ExtensionsTest do
            }
          }
        }},
-      {:ok,
-       %{
-         "data" => %{
-           "issue" => %{
-             "comments" => %{
-               "nodes" => [
-                 %{"id" => "noise", "body" => "not a claim", "createdAt" => "not-a-date"},
-                 %{"id" => "bad-claim", "body" => "## Symphony Claim Lease\nowner: \nclaimed_at: nope", "createdAt" => "nope"},
-                 %{"id" => "bad-release", "body" => "## Symphony Claim Release\nowner: worker", "createdAt" => "nope"},
-                 %{}
-               ],
-               "pageInfo" => %{"hasNextPage" => false}
-             }
-           }
-         }
-       }},
+      malformed_comments,
       {:ok, %{"data" => %{"commentCreate" => %{"success" => true}}}}
     ])
 
@@ -541,6 +631,7 @@ defmodule SymphonyElixir.ExtensionsTest do
              Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
 
     Process.put({FakeLinearClient, :graphql_results}, [
+      empty_claim_comments(),
       {:ok,
        %{
          "data" => %{
@@ -593,17 +684,7 @@ defmodule SymphonyElixir.ExtensionsTest do
            }}
 
         String.contains?(query, "SymphonyIssueClaimComments") and variables.after == "cursor-1" ->
-          competitor_body =
-            [
-              "## Symphony Claim Lease",
-              "",
-              "owner: other-worker",
-              "token: older-token",
-              "issue: ALB-CLAIM",
-              "claimed_at: #{DateTime.to_iso8601(older)}",
-              "expires_at: #{DateTime.to_iso8601(expires_at)}"
-            ]
-            |> Enum.join("\n")
+          competitor_body = signed_claim_body("ALB-CLAIM", "other-worker", "older-token", older, expires_at)
 
           {:ok,
            %{
@@ -624,11 +705,13 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     assert {:error, {:issue_claimed, %{id: "claim-other", owner: "other-worker"}}} =
              Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+
+    refute Process.get(:claim_body)
   end
 
   test "linear adapter ignores released and expired claims when selecting the lease owner" do
     Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
-    expired_at = ~U[2026-05-02 00:00:00Z]
+    expired_at = DateTime.add(DateTime.utc_now(), -30, :second)
     released_at = DateTime.add(expired_at, 10, :second)
     now = DateTime.add(expired_at, 30, :second)
 
@@ -648,49 +731,37 @@ defmodule SymphonyElixir.ExtensionsTest do
            }}
 
         String.contains?(query, "SymphonyIssueClaimComments") ->
-          expired_body =
-            [
-              "## Symphony Claim Lease",
-              "",
-              "owner: expired-worker",
-              "token: expired-token",
-              "claimed_at: #{DateTime.to_iso8601(expired_at)}",
-              "expires_at: #{DateTime.to_iso8601(expired_at)}"
-            ]
-            |> Enum.join("\n")
+          expired_body = signed_claim_body("ALB-CLAIM", "expired-worker", "expired-token", expired_at, expired_at)
 
           released_claim_body =
-            [
-              "## Symphony Claim Lease",
-              "",
-              "owner: released-worker",
-              "token: released-token",
-              "claimed_at: #{DateTime.to_iso8601(expired_at)}",
-              "expires_at: #{DateTime.to_iso8601(DateTime.add(expired_at, 4, :hour))}"
-            ]
-            |> Enum.join("\n")
+            signed_claim_body(
+              "ALB-CLAIM",
+              "released-worker",
+              "released-token",
+              expired_at,
+              DateTime.add(expired_at, 4, :hour)
+            )
 
-          release_body =
-            [
-              "## Symphony Claim Release",
-              "",
-              "owner: released-worker",
-              "token: released-token",
-              "released_at: #{DateTime.to_iso8601(released_at)}"
-            ]
-            |> Enum.join("\n")
+          release_body = signed_release_body("claim-released", "released-worker", "released-token", released_at)
+          claim_body = Process.get(:claim_body)
 
           {:ok,
            %{
              "data" => %{
                "issue" => %{
                  "comments" => %{
-                   "nodes" => [
-                     %{"id" => "claim-expired", "body" => expired_body, "createdAt" => DateTime.to_iso8601(expired_at)},
-                     %{"id" => "claim-released", "body" => released_claim_body, "createdAt" => DateTime.to_iso8601(expired_at)},
-                     %{"id" => "release-released", "body" => release_body, "createdAt" => DateTime.to_iso8601(released_at)},
-                     %{"id" => "claim-own", "body" => Process.get(:claim_body), "createdAt" => DateTime.to_iso8601(now)}
-                   ]
+                   "nodes" =>
+                     [
+                       %{"id" => "claim-expired", "body" => expired_body, "createdAt" => DateTime.to_iso8601(expired_at)},
+                       %{"id" => "claim-released", "body" => released_claim_body, "createdAt" => DateTime.to_iso8601(expired_at)},
+                       %{"id" => "release-released", "body" => release_body, "createdAt" => DateTime.to_iso8601(released_at)}
+                     ] ++
+                       if claim_body do
+                         [%{"id" => "claim-own", "body" => claim_body, "createdAt" => DateTime.to_iso8601(now)}]
+                       else
+                         []
+                       end,
+                   "pageInfo" => %{"hasNextPage" => false}
                  }
                }
              }
@@ -1119,6 +1190,47 @@ defmodule SymphonyElixir.ExtensionsTest do
   end
 
   defp assert_eventually(_fun, 0), do: flunk("condition not met in time")
+
+  defp empty_claim_comments do
+    {:ok,
+     %{
+       "data" => %{
+         "issue" => %{
+           "comments" => %{
+             "nodes" => [],
+             "pageInfo" => %{"hasNextPage" => false}
+           }
+         }
+       }
+     }}
+  end
+
+  defp malformed_claim_comments do
+    {:ok,
+     %{
+       "data" => %{
+         "issue" => %{
+           "comments" => %{
+             "nodes" => [
+               %{"id" => "noise", "body" => "not a claim", "createdAt" => "not-a-date"},
+               %{"id" => "bad-claim", "body" => "## Symphony Claim Lease\nowner: \nclaimed_at: nope", "createdAt" => "nope"},
+               %{"id" => "bad-release", "body" => "## Symphony Claim Release\nowner: worker", "createdAt" => "nope"},
+               %{}
+             ],
+             "pageInfo" => %{"hasNextPage" => false}
+           }
+         }
+       }
+     }}
+  end
+
+  defp signed_claim_body(identifier, owner, token, claimed_at, expires_at) do
+    Adapter.claim_body_for_test(identifier, owner, token, claimed_at, expires_at)
+  end
+
+  defp signed_release_body(claim_id, owner, token, released_at) do
+    Adapter.release_body_for_test(claim_id, owner, token, released_at)
+  end
 
   defp ensure_workflow_store_running do
     if Process.whereis(WorkflowStore) do

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -604,6 +604,26 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     assert {:error, :claim_create_failed} =
              Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+
+    Process.put({FakeLinearClient, :graphql_result}, {:error, :preflight_timeout})
+
+    assert {:error, :preflight_timeout} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+  end
+
+  test "linear adapter can sign test lease bodies without a configured api token" do
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_api_token: nil)
+
+    body =
+      signed_claim_body(
+        "ALB-CLAIM",
+        "worker",
+        "token",
+        ~U[2026-05-02 00:00:00Z],
+        ~U[2026-05-02 04:00:00Z]
+      )
+
+    assert body =~ "signature:"
   end
 
   test "linear adapter ignores malformed claim comments and releases invisible claims" do


### PR DESCRIPTION
#### Context

Multiple Symphony pollers can dispatch the same Linear issue because local claimed sets are process-only.

#### TL;DR

*Use signed Linear comment leases so untrusted comments cannot claim or release work.*

#### Summary

- Add tracker acquire/release callbacks and memory adapter support.
- Store visible Linear claim comments with owner, token, claim time, expiry, and HMAC signature.
- Ignore unsigned or tampered claim/release comments when selecting the active lease.
- Preflight existing active leases before writing a claim to avoid repeated loser comment spam.
- Release leases with signed claim-id, owner, and token comments on completion and failures.
- Cover competing, spoofed, expired, released, failed-read, and paginated lease behavior.

#### Alternatives

- Assignee or state transitions were avoided because they would alter user workflow ownership.
- Labels were avoided because they do not carry an owner token or expiry timestamp cleanly.
- Unsigned visible comment markers were rejected because they are spoofable by issue comments.
- Custom fields were avoided because comments work with the existing Linear API surface.

#### Test Plan

- [x] `mix test test/symphony_elixir/extensions_test.exs`
- [x] `mix test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs`
- [x] `mix lint`
- [x] `mix dialyzer --format short`
- [x] `git diff --check`
- [x] `mix format --check-formatted lib/symphony_elixir/linear/adapter.ex test/symphony_elixir/extensions_test.exs`
- [x] SubAgent review loop on hardened diff found no blocking findings.
- [ ] `make -C elixir all` not run locally: `make` is not installed in this Windows shell.
- [ ] `mix format --check-formatted` for the full tree fails on pre-existing line-ending formatting drift outside this diff.
- [ ] `mix test --cover` is not green in this Windows shell due existing unrelated baseline failures.