### PR TITLE
Add worker detail steering UI

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -197,6 +197,12 @@ The observability UI now runs on a minimal Phoenix stack:
 - JSON API for operational debugging under `/api/v1/*`
 - Bandit as the HTTP server
 - Phoenix dependency static assets for the LiveView client bootstrap
+- Worker detail pages at `/workers/<issue_identifier>` with sanitized Codex
+  timelines and session-scoped manager steering.
+
+When binding the server to a non-loopback host, configure
+`observability.steer_token` or `SYMPHONY_STEER_TOKEN`; otherwise steer
+submission is locked while read-only dashboard views remain available.
 
 ## Project Layout
 

--- a/elixir/docs/windows-native.md
+++ b/elixir/docs/windows-native.md
@@ -209,6 +209,22 @@ The app-server session also exposes a `linear_graphql` dynamic tool so the
 agent can update Linear comments and issue state without relying on a separate
 MCP flow.
 
+### Worker detail and steering
+
+The observability dashboard links each running worker row to
+`/workers/<issue-identifier>`. The detail page shows the issue identity, active
+session id, workspace path, token totals, and a bounded timeline of recent Codex
+app-server events. Timeline rows render a human-readable message first and keep
+the raw payload in an expandable JSON panel for diagnosis.
+
+Managers can send a steer message from the detail page while the worker is
+running. Symphony routes the message through the orchestrator to the worker task
+that owns the Codex app-server port. The request is guarded twice: the dashboard
+submits the current session id, and the app-server `turn/steer` request includes
+the active `threadId` plus `expectedTurnId`. Symphony records queued and sent
+steer messages in the worker timeline so later reviewers can see when a human
+intervened.
+
 ### Progress tracking
 
 The recommended prompt pattern is to keep one persistent Linear comment whose

--- a/elixir/docs/windows-native.md
+++ b/elixir/docs/windows-native.md
@@ -215,7 +215,10 @@ The observability dashboard links each running worker row to
 `/workers/<issue-identifier>`. The detail page shows the issue identity, active
 session id, workspace path, token totals, and a bounded timeline of recent Codex
 app-server events. Timeline rows render a human-readable message first and keep
-the raw payload in an expandable JSON panel for diagnosis.
+the sanitized payload in an expandable JSON panel for diagnosis. Symphony
+redacts common secret keys, bearer/basic auth values, credential-bearing URLs,
+and token-like query parameters before storing Codex event payloads in
+orchestrator state or presenting them through the dashboard/API.
 
 Managers can send a steer message from the detail page while the worker is
 running. Symphony routes the message through the orchestrator to the worker task
@@ -224,6 +227,11 @@ submits the current session id, and the app-server `turn/steer` request includes
 the active `threadId` plus `expectedTurnId`. Symphony records queued and sent
 steer messages in the worker timeline so later reviewers can see when a human
 intervened.
+
+If the dashboard is bound to a non-loopback host such as `0.0.0.0`, steering is
+locked unless an operator token is configured with `observability.steer_token` or
+the `SYMPHONY_STEER_TOKEN` environment variable. The token is required only for
+steer submission; read-only dashboard and JSON views remain available.
 
 ### Progress tracking
 

--- a/elixir/lib/symphony_elixir/codex/app_server.ex
+++ b/elixir/lib/symphony_elixir/codex/app_server.ex
@@ -411,81 +411,15 @@ defmodule SymphonyElixir.Codex.AppServer do
        ) do
     payload_string = to_string(data)
 
+    loop_options = %{
+      timeout_ms: timeout_ms,
+      tool_executor: tool_executor,
+      auto_approve_requests: auto_approve_requests
+    }
+
     case Jason.decode(payload_string) do
-      {:ok, %{"method" => "turn/completed"} = payload} ->
-        emit_turn_event(on_message, :turn_completed, payload, payload_string, port, payload)
-        {:ok, :turn_completed}
-
-      {:ok, %{"method" => "turn/failed", "params" => _} = payload} ->
-        emit_turn_event(
-          on_message,
-          :turn_failed,
-          payload,
-          payload_string,
-          port,
-          Map.get(payload, "params")
-        )
-
-        {:error, {:turn_failed, Map.get(payload, "params")}}
-
-      {:ok, %{"method" => "turn/cancelled", "params" => _} = payload} ->
-        emit_turn_event(
-          on_message,
-          :turn_cancelled,
-          payload,
-          payload_string,
-          port,
-          Map.get(payload, "params")
-        )
-
-        {:error, {:turn_cancelled, Map.get(payload, "params")}}
-
-      {:ok, %{"method" => method} = payload}
-      when is_binary(method) ->
-        handle_turn_method(
-          port,
-          on_message,
-          payload,
-          payload_string,
-          method,
-          timeout_ms,
-          tool_executor,
-          auto_approve_requests,
-          turn_context
-        )
-
-      {:ok, %{"id" => response_id} = payload} ->
-        case pop_pending_steer(turn_context, response_id) do
-          {:ok, steer, turn_context} ->
-            emit_steer_response(on_message, payload, payload_string, port, steer, turn_context)
-            receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests, turn_context)
-
-          :not_steer ->
-            emit_message(
-              on_message,
-              :other_message,
-              %{
-                payload: payload,
-                raw: payload_string
-              },
-              metadata_from_message(port, payload)
-            )
-
-            receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests, turn_context)
-        end
-
       {:ok, payload} ->
-        emit_message(
-          on_message,
-          :other_message,
-          %{
-            payload: payload,
-            raw: payload_string
-          },
-          metadata_from_message(port, payload)
-        )
-
-        receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests, turn_context)
+        handle_decoded_payload(port, on_message, payload, payload_string, loop_options, turn_context)
 
       {:error, _reason} ->
         log_non_json_stream_line(payload_string, "turn stream")
@@ -502,8 +436,101 @@ defmodule SymphonyElixir.Codex.AppServer do
           )
         end
 
-        receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests, turn_context)
+        continue_receive_loop(port, on_message, loop_options, turn_context)
     end
+  end
+
+  defp handle_decoded_payload(
+         port,
+         on_message,
+         %{"method" => "turn/completed"} = payload,
+         payload_string,
+         _loop_options,
+         _turn_context
+       ) do
+    emit_turn_event(on_message, :turn_completed, payload, payload_string, port, payload)
+    {:ok, :turn_completed}
+  end
+
+  defp handle_decoded_payload(
+         port,
+         on_message,
+         %{"method" => "turn/failed", "params" => _} = payload,
+         payload_string,
+         _loop_options,
+         _turn_context
+       ) do
+    emit_turn_event(on_message, :turn_failed, payload, payload_string, port, Map.get(payload, "params"))
+    {:error, {:turn_failed, Map.get(payload, "params")}}
+  end
+
+  defp handle_decoded_payload(
+         port,
+         on_message,
+         %{"method" => "turn/cancelled", "params" => _} = payload,
+         payload_string,
+         _loop_options,
+         _turn_context
+       ) do
+    emit_turn_event(on_message, :turn_cancelled, payload, payload_string, port, Map.get(payload, "params"))
+    {:error, {:turn_cancelled, Map.get(payload, "params")}}
+  end
+
+  defp handle_decoded_payload(
+         port,
+         on_message,
+         %{"method" => method} = payload,
+         payload_string,
+         loop_options,
+         turn_context
+       )
+       when is_binary(method) do
+    handle_turn_method(port, on_message, payload, payload_string, method, loop_options, turn_context)
+  end
+
+  defp handle_decoded_payload(
+         port,
+         on_message,
+         %{"id" => response_id} = payload,
+         payload_string,
+         loop_options,
+         turn_context
+       ) do
+    case pop_pending_steer(turn_context, response_id) do
+      {:ok, steer, turn_context} ->
+        emit_steer_response(on_message, payload, payload_string, port, steer, turn_context)
+        continue_receive_loop(port, on_message, loop_options, turn_context)
+
+      :not_steer ->
+        emit_other_message(on_message, payload, payload_string, port)
+        continue_receive_loop(port, on_message, loop_options, turn_context)
+    end
+  end
+
+  defp handle_decoded_payload(port, on_message, payload, payload_string, loop_options, turn_context) do
+    emit_other_message(on_message, payload, payload_string, port)
+    continue_receive_loop(port, on_message, loop_options, turn_context)
+  end
+
+  defp continue_receive_loop(
+         port,
+         on_message,
+         %{timeout_ms: timeout_ms, tool_executor: tool_executor, auto_approve_requests: auto_approve_requests},
+         turn_context
+       ) do
+    receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests, turn_context)
+  end
+
+  defp emit_other_message(on_message, payload, payload_string, port) do
+    emit_message(
+      on_message,
+      :other_message,
+      %{
+        payload: payload,
+        raw: payload_string
+      },
+      metadata_from_message(port, payload)
+    )
   end
 
   defp emit_turn_event(on_message, event, payload, payload_string, port, payload_details) do
@@ -525,12 +552,11 @@ defmodule SymphonyElixir.Codex.AppServer do
          payload,
          payload_string,
          method,
-         timeout_ms,
-         tool_executor,
-         auto_approve_requests,
+         loop_options,
          turn_context
        ) do
     metadata = metadata_from_message(port, payload)
+    %{tool_executor: tool_executor, auto_approve_requests: auto_approve_requests} = loop_options
 
     case maybe_handle_approval_request(
            port,
@@ -553,7 +579,7 @@ defmodule SymphonyElixir.Codex.AppServer do
         {:error, {:turn_input_required, payload}}
 
       :approved ->
-        receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests, turn_context)
+        continue_receive_loop(port, on_message, loop_options, turn_context)
 
       :approval_required ->
         emit_message(
@@ -587,7 +613,7 @@ defmodule SymphonyElixir.Codex.AppServer do
           )
 
           Logger.debug("Codex notification: #{inspect(method)}")
-          receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests, turn_context)
+          continue_receive_loop(port, on_message, loop_options, turn_context)
         end
     end
   end

--- a/elixir/lib/symphony_elixir/codex/app_server.ex
+++ b/elixir/lib/symphony_elixir/codex/app_server.ex
@@ -9,6 +9,7 @@ defmodule SymphonyElixir.Codex.AppServer do
   @initialize_id 1
   @thread_start_id 2
   @turn_start_id 3
+  @steer_start_id 10_000
   @port_line_bytes 1_048_576
   @max_stream_log_bytes 1_000
   @non_interactive_tool_input_answer "This is a non-interactive session. Operator input is unavailable."
@@ -105,7 +106,12 @@ defmodule SymphonyElixir.Codex.AppServer do
           metadata
         )
 
-        case await_turn_completion(port, on_message, tool_executor, auto_approve_requests) do
+        case await_turn_completion(port, on_message, tool_executor, auto_approve_requests, %{
+               session_id: session_id,
+               thread_id: thread_id,
+               turn_id: turn_id,
+               pending_steers: %{}
+             }) do
           {:ok, result} ->
             Logger.info("Codex session completed for #{issue_context(issue)} session_id=#{session_id}")
 
@@ -317,22 +323,40 @@ defmodule SymphonyElixir.Codex.AppServer do
     end
   end
 
-  defp await_turn_completion(port, on_message, tool_executor, auto_approve_requests) do
+  defp await_turn_completion(port, on_message, tool_executor, auto_approve_requests, turn_context) do
     receive_loop(
       port,
       on_message,
       Config.settings!().codex.turn_timeout_ms,
       "",
       tool_executor,
-      auto_approve_requests
+      auto_approve_requests,
+      turn_context
     )
   end
 
-  defp receive_loop(port, on_message, timeout_ms, pending_line, tool_executor, auto_approve_requests) do
+  defp receive_loop(
+         port,
+         on_message,
+         timeout_ms,
+         pending_line,
+         tool_executor,
+         auto_approve_requests,
+         turn_context
+       ) do
     receive do
       {^port, {:data, {:eol, chunk}}} ->
         complete_line = pending_line <> to_string(chunk)
-        handle_incoming(port, on_message, complete_line, timeout_ms, tool_executor, auto_approve_requests)
+
+        handle_incoming(
+          port,
+          on_message,
+          complete_line,
+          timeout_ms,
+          tool_executor,
+          auto_approve_requests,
+          turn_context
+        )
 
       {^port, {:data, {:noeol, chunk}}} ->
         receive_loop(
@@ -341,18 +365,50 @@ defmodule SymphonyElixir.Codex.AppServer do
           timeout_ms,
           pending_line <> to_string(chunk),
           tool_executor,
-          auto_approve_requests
+          auto_approve_requests,
+          turn_context
         )
 
       {^port, {:exit_status, status}} ->
         {:error, {:port_exit, status}}
+
+      {:codex_steer, reply_to, request_ref, expected_session_id, message}
+      when is_binary(expected_session_id) and is_binary(message) ->
+        turn_context =
+          handle_steer_message(
+            port,
+            on_message,
+            reply_to,
+            request_ref,
+            expected_session_id,
+            message,
+            turn_context
+          )
+
+        receive_loop(
+          port,
+          on_message,
+          timeout_ms,
+          pending_line,
+          tool_executor,
+          auto_approve_requests,
+          turn_context
+        )
     after
       timeout_ms ->
         {:error, :turn_timeout}
     end
   end
 
-  defp handle_incoming(port, on_message, data, timeout_ms, tool_executor, auto_approve_requests) do
+  defp handle_incoming(
+         port,
+         on_message,
+         data,
+         timeout_ms,
+         tool_executor,
+         auto_approve_requests,
+         turn_context
+       ) do
     payload_string = to_string(data)
 
     case Jason.decode(payload_string) do
@@ -394,8 +450,29 @@ defmodule SymphonyElixir.Codex.AppServer do
           method,
           timeout_ms,
           tool_executor,
-          auto_approve_requests
+          auto_approve_requests,
+          turn_context
         )
+
+      {:ok, %{"id" => response_id} = payload} ->
+        case pop_pending_steer(turn_context, response_id) do
+          {:ok, steer, turn_context} ->
+            emit_steer_response(on_message, payload, payload_string, port, steer, turn_context)
+            receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests, turn_context)
+
+          :not_steer ->
+            emit_message(
+              on_message,
+              :other_message,
+              %{
+                payload: payload,
+                raw: payload_string
+              },
+              metadata_from_message(port, payload)
+            )
+
+            receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests, turn_context)
+        end
 
       {:ok, payload} ->
         emit_message(
@@ -408,7 +485,7 @@ defmodule SymphonyElixir.Codex.AppServer do
           metadata_from_message(port, payload)
         )
 
-        receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests)
+        receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests, turn_context)
 
       {:error, _reason} ->
         log_non_json_stream_line(payload_string, "turn stream")
@@ -425,7 +502,7 @@ defmodule SymphonyElixir.Codex.AppServer do
           )
         end
 
-        receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests)
+        receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests, turn_context)
     end
   end
 
@@ -450,7 +527,8 @@ defmodule SymphonyElixir.Codex.AppServer do
          method,
          timeout_ms,
          tool_executor,
-         auto_approve_requests
+         auto_approve_requests,
+         turn_context
        ) do
     metadata = metadata_from_message(port, payload)
 
@@ -475,7 +553,7 @@ defmodule SymphonyElixir.Codex.AppServer do
         {:error, {:turn_input_required, payload}}
 
       :approved ->
-        receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests)
+        receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests, turn_context)
 
       :approval_required ->
         emit_message(
@@ -509,9 +587,89 @@ defmodule SymphonyElixir.Codex.AppServer do
           )
 
           Logger.debug("Codex notification: #{inspect(method)}")
-          receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests)
+          receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests, turn_context)
         end
     end
+  end
+
+  defp handle_steer_message(
+         port,
+         on_message,
+         reply_to,
+         request_ref,
+         expected_session_id,
+         message,
+         %{session_id: session_id, thread_id: thread_id, turn_id: turn_id} = turn_context
+       ) do
+    trimmed_message = String.trim(message)
+
+    cond do
+      trimmed_message == "" ->
+        emit_message(
+          on_message,
+          :manager_steer_rejected,
+          Map.merge(turn_context, %{reason: :blank_message}),
+          metadata_from_message(port, %{})
+        )
+
+        reply_steer_request(reply_to, request_ref, {:error, :blank_message})
+        turn_context
+
+      expected_session_id != session_id ->
+        emit_message(
+          on_message,
+          :manager_steer_rejected,
+          Map.merge(turn_context, %{reason: :session_mismatch, expected_session_id: expected_session_id}),
+          metadata_from_message(port, %{})
+        )
+
+        reply_steer_request(reply_to, request_ref, {:error, :session_mismatch})
+        turn_context
+
+      true ->
+        case send_turn_steer(port, thread_id, turn_id, trimmed_message) do
+          {:ok, request_id} ->
+            reply_steer_request(reply_to, request_ref, {:ok, session_id})
+
+            emit_message(
+              on_message,
+              :manager_steer_submitted,
+              Map.merge(turn_context, %{message: trimmed_message, request_id: request_id}),
+              metadata_from_message(port, %{})
+            )
+
+            put_pending_steer(turn_context, request_id, %{
+              message: trimmed_message,
+              request_id: request_id,
+              session_id: session_id,
+              thread_id: thread_id,
+              turn_id: turn_id
+            })
+
+          {:error, reason} ->
+            emit_message(
+              on_message,
+              :manager_steer_failed,
+              Map.merge(turn_context, %{message: trimmed_message, reason: reason}),
+              metadata_from_message(port, %{})
+            )
+
+            reply_steer_request(reply_to, request_ref, {:error, reason})
+            turn_context
+        end
+    end
+  end
+
+  defp handle_steer_message(port, on_message, reply_to, request_ref, _expected_session_id, _message, turn_context) do
+    emit_message(
+      on_message,
+      :manager_steer_failed,
+      Map.merge(turn_context, %{reason: :missing_turn_context}),
+      metadata_from_message(port, %{})
+    )
+
+    reply_steer_request(reply_to, request_ref, {:error, :missing_turn_context})
+    turn_context
   end
 
   defp maybe_handle_approval_request(
@@ -1048,6 +1206,84 @@ defmodule SymphonyElixir.Codex.AppServer do
   defp send_message(port, message) do
     line = Jason.encode!(message) <> "\n"
     Port.command(port, line)
+  end
+
+  defp send_turn_steer(port, thread_id, turn_id, message) do
+    request_id = System.unique_integer([:positive]) + @steer_start_id
+
+    if send_message(port, %{
+         "method" => "turn/steer",
+         "id" => request_id,
+         "params" => %{
+           "threadId" => thread_id,
+           "expectedTurnId" => turn_id,
+           "input" => [
+             %{
+               "type" => "text",
+               "text" => message
+             }
+           ]
+         }
+       }) do
+      {:ok, request_id}
+    else
+      {:error, :port_unavailable}
+    end
+  end
+
+  defp reply_steer_request(reply_to, request_ref, result) when is_pid(reply_to) and is_reference(request_ref) do
+    send(reply_to, {:codex_steer_request_result, request_ref, result})
+    :ok
+  end
+
+  defp reply_steer_request(_reply_to, _request_ref, _result), do: :ok
+
+  defp put_pending_steer(turn_context, request_id, steer) do
+    pending_steers =
+      turn_context
+      |> Map.get(:pending_steers, %{})
+      |> Map.put(request_id, steer)
+
+    Map.put(turn_context, :pending_steers, pending_steers)
+  end
+
+  defp pop_pending_steer(turn_context, response_id) do
+    pending_steers = Map.get(turn_context, :pending_steers, %{})
+
+    case Map.pop(pending_steers, response_id) do
+      {nil, _pending_steers} ->
+        :not_steer
+
+      {steer, pending_steers} ->
+        {:ok, steer, Map.put(turn_context, :pending_steers, pending_steers)}
+    end
+  end
+
+  defp emit_steer_response(on_message, %{"error" => error} = payload, raw, port, steer, turn_context) do
+    emit_message(
+      on_message,
+      :manager_steer_failed,
+      Map.merge(turn_context, %{message: steer.message, request_id: steer.request_id, reason: error, payload: payload, raw: raw}),
+      metadata_from_message(port, payload)
+    )
+  end
+
+  defp emit_steer_response(on_message, %{"result" => result} = payload, raw, port, steer, turn_context) do
+    emit_message(
+      on_message,
+      :manager_steer_delivered,
+      Map.merge(turn_context, %{message: steer.message, request_id: steer.request_id, payload: payload, raw: raw, details: result}),
+      metadata_from_message(port, payload)
+    )
+  end
+
+  defp emit_steer_response(on_message, payload, raw, port, steer, turn_context) do
+    emit_message(
+      on_message,
+      :manager_steer_failed,
+      Map.merge(turn_context, %{message: steer.message, request_id: steer.request_id, reason: :invalid_steer_response, payload: payload, raw: raw}),
+      metadata_from_message(port, payload)
+    )
   end
 
   defp needs_input?(method, payload)

--- a/elixir/lib/symphony_elixir/codex/app_server.ex
+++ b/elixir/lib/symphony_elixir/codex/app_server.ex
@@ -686,18 +686,6 @@ defmodule SymphonyElixir.Codex.AppServer do
     end
   end
 
-  defp handle_steer_message(port, on_message, reply_to, request_ref, _expected_session_id, _message, turn_context) do
-    emit_message(
-      on_message,
-      :manager_steer_failed,
-      Map.merge(turn_context, %{reason: :missing_turn_context}),
-      metadata_from_message(port, %{})
-    )
-
-    reply_steer_request(reply_to, request_ref, {:error, :missing_turn_context})
-    turn_context
-  end
-
   defp maybe_handle_approval_request(
          port,
          "item/commandExecution/requestApproval",
@@ -1237,23 +1225,25 @@ defmodule SymphonyElixir.Codex.AppServer do
   defp send_turn_steer(port, thread_id, turn_id, message) do
     request_id = System.unique_integer([:positive]) + @steer_start_id
 
-    if send_message(port, %{
-         "method" => "turn/steer",
-         "id" => request_id,
-         "params" => %{
-           "threadId" => thread_id,
-           "expectedTurnId" => turn_id,
-           "input" => [
-             %{
-               "type" => "text",
-               "text" => message
-             }
-           ]
-         }
-       }) do
+    try do
+      send_message(port, %{
+        "method" => "turn/steer",
+        "id" => request_id,
+        "params" => %{
+          "threadId" => thread_id,
+          "expectedTurnId" => turn_id,
+          "input" => [
+            %{
+              "type" => "text",
+              "text" => message
+            }
+          ]
+        }
+      })
+
       {:ok, request_id}
-    else
-      {:error, :port_unavailable}
+    rescue
+      error in ArgumentError -> {:error, {:port_command_failed, Exception.message(error)}}
     end
   end
 

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -232,12 +232,13 @@ defmodule SymphonyElixir.Config.Schema do
       field(:dashboard_enabled, :boolean, default: true)
       field(:refresh_ms, :integer, default: 1_000)
       field(:render_interval_ms, :integer, default: 16)
+      field(:steer_token, :string)
     end
 
     @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
     def changeset(schema, attrs) do
       schema
-      |> cast(attrs, [:dashboard_enabled, :refresh_ms, :render_interval_ms], empty_values: [])
+      |> cast(attrs, [:dashboard_enabled, :refresh_ms, :render_interval_ms, :steer_token], empty_values: [])
       |> validate_number(:refresh_ms, greater_than: 0)
       |> validate_number(:render_interval_ms, greater_than: 0)
     end
@@ -385,7 +386,12 @@ defmodule SymphonyElixir.Config.Schema do
         turn_sandbox_policy: normalize_optional_map(settings.codex.turn_sandbox_policy)
     }
 
-    %{settings | tracker: tracker, workspace: workspace, codex: codex}
+    observability = %{
+      settings.observability
+      | steer_token: resolve_secret_setting(settings.observability.steer_token, System.get_env("SYMPHONY_STEER_TOKEN"))
+    }
+
+    %{settings | tracker: tracker, workspace: workspace, codex: codex, observability: observability}
   end
 
   defp normalize_keys(value) when is_map(value) do
@@ -493,7 +499,8 @@ defmodule SymphonyElixir.Config.Schema do
   end
 
   defp normalize_secret_value(value) when is_binary(value) do
-    if value == "", do: nil, else: value
+    trimmed = String.trim(value)
+    if trimmed == "", do: nil, else: trimmed
   end
 
   defp normalize_secret_value(_value), do: nil

--- a/elixir/lib/symphony_elixir/http_server.ex
+++ b/elixir/lib/symphony_elixir/http_server.ex
@@ -23,6 +23,7 @@ defmodule SymphonyElixir.HttpServer do
         host = Keyword.get(opts, :host, Config.settings!().server.host)
         orchestrator = Keyword.get(opts, :orchestrator, Orchestrator)
         snapshot_timeout_ms = Keyword.get(opts, :snapshot_timeout_ms, 15_000)
+        steer_token = Config.settings!().observability.steer_token
 
         with {:ok, ip} <- parse_host(host) do
           endpoint_opts = [
@@ -31,6 +32,8 @@ defmodule SymphonyElixir.HttpServer do
             url: [host: normalize_host(host)],
             orchestrator: orchestrator,
             snapshot_timeout_ms: snapshot_timeout_ms,
+            steer_auth_required: !loopback_ip?(ip),
+            steer_token: steer_token,
             secret_key_base: secret_key_base()
           ]
 
@@ -81,6 +84,10 @@ defmodule SymphonyElixir.HttpServer do
   defp normalize_host(host) when host in ["", nil], do: "127.0.0.1"
   defp normalize_host(host) when is_binary(host), do: host
   defp normalize_host(host), do: to_string(host)
+
+  defp loopback_ip?({127, _, _, _}), do: true
+  defp loopback_ip?({0, 0, 0, 0, 0, 0, 0, 1}), do: true
+  defp loopback_ip?(_ip), do: false
 
   defp secret_key_base do
     Base.encode64(:crypto.strong_rand_bytes(@secret_key_bytes), padding: false)

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -23,6 +23,13 @@ defmodule SymphonyElixir.Orchestrator do
     seconds_running: 0
   }
 
+  @type steer_error ::
+          :unavailable
+          | :worker_not_running
+          | :blank_message
+          | :session_mismatch
+          | :worker_not_accepting_steer
+
   defmodule State do
     @moduledoc """
     Runtime state for the orchestrator polling loop.
@@ -1126,15 +1133,13 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   @spec steer_worker(String.t(), String.t(), String.t() | nil) ::
-          {:ok, map()}
-          | {:error, :unavailable | :worker_not_running | :blank_message | :session_mismatch | :worker_not_accepting_steer}
+          {:ok, map()} | {:error, steer_error()}
   def steer_worker(issue_identifier, message, expected_session_id \\ nil) do
     steer_worker(__MODULE__, issue_identifier, message, expected_session_id)
   end
 
   @spec steer_worker(GenServer.server(), String.t(), String.t(), String.t() | nil) ::
-          {:ok, map()}
-          | {:error, :unavailable | :worker_not_running | :blank_message | :session_mismatch | :worker_not_accepting_steer}
+          {:ok, map()} | {:error, steer_error()}
   def steer_worker(server, issue_identifier, message, expected_session_id)
       when is_binary(issue_identifier) and is_binary(message) do
     if Process.whereis(server) do

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -1345,8 +1345,6 @@ defmodule SymphonyElixir.Orchestrator do
     end
   end
 
-  defp id_for_update(existing, _update, _key), do: existing
-
   defp turn_count_for_update(existing_count, existing_session_id, %{
          event: :session_started,
          session_id: session_id

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -7,7 +7,7 @@ defmodule SymphonyElixir.Orchestrator do
   require Logger
   import Bitwise, only: [<<<: 2]
 
-  alias SymphonyElixir.{AgentRunner, Config, StatusDashboard, Tracker, Workspace}
+  alias SymphonyElixir.{AgentRunner, Config, Redactor, StatusDashboard, Tracker, Workspace}
   alias SymphonyElixir.Linear.Issue
 
   @continuation_retry_delay_ms 1_000
@@ -1289,6 +1289,7 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp integrate_codex_update(running_entry, %{event: event, timestamp: timestamp} = update) do
     token_delta = extract_token_delta(running_entry, update)
+    update = Redactor.redact(update)
     codex_input_tokens = Map.get(running_entry, :codex_input_tokens, 0)
     codex_output_tokens = Map.get(running_entry, :codex_output_tokens, 0)
     codex_total_tokens = Map.get(running_entry, :codex_total_tokens, 0)

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -1574,12 +1574,16 @@ defmodule SymphonyElixir.Orchestrator do
        when is_pid(pid) and is_binary(session_id) do
     cond do
       !Process.alive?(pid) -> {:error, :worker_not_running}
+      !non_blank_binary?(expected_session_id) -> {:error, :session_mismatch}
       is_binary(expected_session_id) and expected_session_id != session_id -> {:error, :session_mismatch}
       true -> {:ok, session_id}
     end
   end
 
   defp validate_running_session(_running_entry, _expected_session_id), do: {:error, :worker_not_running}
+
+  defp non_blank_binary?(value) when is_binary(value), do: String.trim(value) != ""
+  defp non_blank_binary?(_value), do: false
 
   defp schedule_tick(%State{} = state, delay_ms) when is_integer(delay_ms) and delay_ms >= 0 do
     if is_reference(state.tick_timer_ref) do

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -14,6 +14,8 @@ defmodule SymphonyElixir.Orchestrator do
   @failure_retry_base_ms 10_000
   # Slightly above the dashboard render interval so "checking now…" can render.
   @poll_transition_render_delay_ms 20
+  @max_recent_codex_events 80
+  @steer_request_timeout_ms 3_000
   @empty_codex_totals %{
     input_tokens: 0,
     output_tokens: 0,
@@ -37,6 +39,7 @@ defmodule SymphonyElixir.Orchestrator do
       completed: MapSet.new(),
       claimed: MapSet.new(),
       retry_attempts: %{},
+      pending_steer_calls: %{},
       codex_totals: nil,
       codex_rate_limits: nil
     ]
@@ -202,6 +205,48 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   def handle_info({:codex_worker_update, _issue_id, _update}, state), do: {:noreply, state}
+
+  def handle_info({:codex_steer_request_result, request_ref, result}, state) when is_reference(request_ref) do
+    case Map.pop(Map.get(state, :pending_steer_calls, %{}), request_ref) do
+      {nil, _pending_steer_calls} ->
+        {:noreply, state}
+
+      {%{from: from, issue_id: issue_id, audit_update: audit_update}, pending_steer_calls} ->
+        state = %{state | pending_steer_calls: pending_steer_calls}
+
+        case result do
+          {:ok, session_id} ->
+            state = audit_queued_steer(state, issue_id, %{audit_update | session_id: session_id})
+
+            GenServer.reply(from, {
+              :ok,
+              %{
+                issue_identifier: audit_update.issue_identifier,
+                issue_id: issue_id,
+                session_id: session_id,
+                queued_at: audit_update.timestamp
+              }
+            })
+
+            {:noreply, state}
+
+          {:error, reason} ->
+            GenServer.reply(from, {:error, reason})
+            {:noreply, state}
+        end
+    end
+  end
+
+  def handle_info({:steer_request_timeout, request_ref}, state) when is_reference(request_ref) do
+    case Map.pop(Map.get(state, :pending_steer_calls, %{}), request_ref) do
+      {nil, _pending_steer_calls} ->
+        {:noreply, state}
+
+      {%{from: from}, pending_steer_calls} ->
+        GenServer.reply(from, {:error, :worker_not_accepting_steer})
+        {:noreply, %{state | pending_steer_calls: pending_steer_calls}}
+    end
+  end
 
   def handle_info({:retry_issue, issue_id, retry_token}, state) do
     result =
@@ -1080,6 +1125,25 @@ defmodule SymphonyElixir.Orchestrator do
     end
   end
 
+  @spec steer_worker(String.t(), String.t(), String.t() | nil) ::
+          {:ok, map()}
+          | {:error, :unavailable | :worker_not_running | :blank_message | :session_mismatch | :worker_not_accepting_steer}
+  def steer_worker(issue_identifier, message, expected_session_id \\ nil) do
+    steer_worker(__MODULE__, issue_identifier, message, expected_session_id)
+  end
+
+  @spec steer_worker(GenServer.server(), String.t(), String.t(), String.t() | nil) ::
+          {:ok, map()}
+          | {:error, :unavailable | :worker_not_running | :blank_message | :session_mismatch | :worker_not_accepting_steer}
+  def steer_worker(server, issue_identifier, message, expected_session_id)
+      when is_binary(issue_identifier) and is_binary(message) do
+    if Process.whereis(server) do
+      GenServer.call(server, {:steer_worker, issue_identifier, message, expected_session_id})
+    else
+      {:error, :unavailable}
+    end
+  end
+
   @spec snapshot() :: map() | :timeout | :unavailable
   def snapshot, do: snapshot(__MODULE__, 15_000)
 
@@ -1109,10 +1173,14 @@ defmodule SymphonyElixir.Orchestrator do
         %{
           issue_id: issue_id,
           identifier: metadata.identifier,
+          title: metadata.issue.title,
+          url: metadata.issue.url,
           state: metadata.issue.state,
           worker_host: Map.get(metadata, :worker_host),
           workspace_path: Map.get(metadata, :workspace_path),
           session_id: metadata.session_id,
+          thread_id: Map.get(metadata, :thread_id),
+          turn_id: Map.get(metadata, :turn_id),
           codex_app_server_pid: metadata.codex_app_server_pid,
           codex_input_tokens: metadata.codex_input_tokens,
           codex_output_tokens: metadata.codex_output_tokens,
@@ -1122,6 +1190,7 @@ defmodule SymphonyElixir.Orchestrator do
           last_codex_timestamp: metadata.last_codex_timestamp,
           last_codex_message: metadata.last_codex_message,
           last_codex_event: metadata.last_codex_event,
+          recent_codex_events: Map.get(metadata, :recent_codex_events, []),
           runtime_seconds: running_seconds(metadata.started_at, now)
         }
       end)
@@ -1169,6 +1238,50 @@ defmodule SymphonyElixir.Orchestrator do
      }, state}
   end
 
+  def handle_call({:steer_worker, issue_identifier, message, expected_session_id}, from, state) do
+    with {:ok, trimmed_message} <- validate_steer_message(message),
+         {:ok, issue_id, running_entry} <- find_running_entry_by_identifier(state.running, issue_identifier),
+         {:ok, session_id} <- validate_running_session(running_entry, expected_session_id) do
+      request_ref = make_ref()
+
+      audit_update = %{
+        event: :manager_steer_queued,
+        message: trimmed_message,
+        issue_identifier: issue_identifier,
+        session_id: session_id,
+        thread_id: Map.get(running_entry, :thread_id),
+        turn_id: Map.get(running_entry, :turn_id),
+        timestamp: DateTime.utc_now()
+      }
+
+      send(running_entry.pid, {:codex_steer, self(), request_ref, session_id, trimmed_message})
+      Process.send_after(self(), {:steer_request_timeout, request_ref}, @steer_request_timeout_ms)
+
+      pending_steer_calls =
+        Map.put(state.pending_steer_calls, request_ref, %{
+          from: from,
+          issue_id: issue_id,
+          audit_update: audit_update
+        })
+
+      {:noreply, %{state | pending_steer_calls: pending_steer_calls}}
+    else
+      {:error, reason} -> {:reply, {:error, reason}, state}
+    end
+  end
+
+  defp audit_queued_steer(%State{} = state, issue_id, audit_update) do
+    case Map.get(state.running, issue_id) do
+      nil ->
+        state
+
+      running_entry ->
+        {updated_running_entry, _token_delta} = integrate_codex_update(running_entry, audit_update)
+        notify_dashboard()
+        %{state | running: Map.put(state.running, issue_id, updated_running_entry)}
+    end
+  end
+
   defp integrate_codex_update(running_entry, %{event: event, timestamp: timestamp} = update) do
     token_delta = extract_token_delta(running_entry, update)
     codex_input_tokens = Map.get(running_entry, :codex_input_tokens, 0)
@@ -1185,7 +1298,10 @@ defmodule SymphonyElixir.Orchestrator do
         last_codex_timestamp: timestamp,
         last_codex_message: summarize_codex_update(update),
         session_id: session_id_for_update(running_entry.session_id, update),
+        thread_id: id_for_update(Map.get(running_entry, :thread_id), update, :thread_id),
+        turn_id: id_for_update(Map.get(running_entry, :turn_id), update, :turn_id),
         last_codex_event: event,
+        recent_codex_events: recent_codex_events_for_update(running_entry, update),
         codex_app_server_pid: codex_app_server_pid_for_update(codex_app_server_pid, update),
         codex_input_tokens: codex_input_tokens + token_delta.input_tokens,
         codex_output_tokens: codex_output_tokens + token_delta.output_tokens,
@@ -1217,6 +1333,15 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp session_id_for_update(existing, _update), do: existing
 
+  defp id_for_update(existing, update, key) when is_map(update) do
+    case Map.get(update, key) do
+      value when is_binary(value) -> value
+      _ -> existing
+    end
+  end
+
+  defp id_for_update(existing, _update, _key), do: existing
+
   defp turn_count_for_update(existing_count, existing_session_id, %{
          event: :session_started,
          session_id: session_id
@@ -1238,10 +1363,56 @@ defmodule SymphonyElixir.Orchestrator do
   defp summarize_codex_update(update) do
     %{
       event: update[:event],
-      message: update[:payload] || update[:raw],
+      message: update[:message] || update[:payload] || update[:raw],
       timestamp: update[:timestamp]
     }
   end
+
+  defp recent_codex_events_for_update(running_entry, update) do
+    next_event =
+      summarize_codex_update(update)
+      |> Map.put(:raw, update[:raw])
+      |> Map.put(:session_id, update[:session_id] || Map.get(running_entry, :session_id))
+      |> Map.put(:thread_id, update[:thread_id] || Map.get(running_entry, :thread_id))
+      |> Map.put(:turn_id, update[:turn_id] || Map.get(running_entry, :turn_id))
+
+    running_entry
+    |> Map.get(:recent_codex_events, [])
+    |> Kernel.++([next_event])
+    |> Enum.take(-@max_recent_codex_events)
+  end
+
+  defp validate_steer_message(message) when is_binary(message) do
+    case String.trim(message) do
+      "" -> {:error, :blank_message}
+      trimmed -> {:ok, trimmed}
+    end
+  end
+
+  defp validate_steer_message(_message), do: {:error, :blank_message}
+
+  defp find_running_entry_by_identifier(running, issue_identifier) when is_map(running) do
+    running
+    |> Enum.find_value(fn
+      {issue_id, %{identifier: ^issue_identifier} = running_entry} -> {:ok, issue_id, running_entry}
+      _entry -> nil
+    end)
+    |> case do
+      nil -> {:error, :worker_not_running}
+      result -> result
+    end
+  end
+
+  defp validate_running_session(%{pid: pid, session_id: session_id}, expected_session_id)
+       when is_pid(pid) and is_binary(session_id) do
+    cond do
+      !Process.alive?(pid) -> {:error, :worker_not_running}
+      is_binary(expected_session_id) and expected_session_id != session_id -> {:error, :session_mismatch}
+      true -> {:ok, session_id}
+    end
+  end
+
+  defp validate_running_session(_running_entry, _expected_session_id), do: {:error, :worker_not_running}
 
   defp schedule_tick(%State{} = state, delay_ms) when is_integer(delay_ms) and delay_ms >= 0 do
     if is_reference(state.tick_timer_ref) do

--- a/elixir/lib/symphony_elixir/redactor.ex
+++ b/elixir/lib/symphony_elixir/redactor.ex
@@ -1,0 +1,66 @@
+defmodule SymphonyElixir.Redactor do
+  @moduledoc """
+  Redacts credential-like values before runtime event payloads are stored or rendered.
+  """
+
+  @redacted "[REDACTED]"
+
+  @sensitive_key_pattern ~r/(api[_-]?key|authorization|bearer|cookie|credential|password|private[_-]?key|secret|^token$|[_-]token$|token[_-]|access[_-]?token|refresh[_-]?token|session[_-]?token|id[_-]?token)/i
+  @credential_url_pattern ~r{([a-z][a-z0-9+.-]*://)([^/\s:@]+):([^@\s/]+)@}i
+  @sensitive_query_pattern ~r/([?&](?:access_token|api_key|client_secret|code|key|password|secret|token)=)[^&#\s]+/i
+  @authorization_pattern ~r/\b(Bearer|Basic)\s+[A-Za-z0-9._~+\/=-]+/i
+  @assignment_pattern ~r/\b([A-Za-z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY|CREDENTIAL)[A-Za-z0-9_]*)=([^\s]+)/i
+  @json_secret_field_pattern ~r/("(?:api[_-]?key|authorization|cookie|credential|password|private[_-]?key|secret|token|access[_-]?token|refresh[_-]?token|session[_-]?token|id[_-]?token)"\s*:\s*")[^"]*(")/i
+
+  @spec redact(term()) :: term()
+  def redact(value), do: redact_value(value, nil)
+
+  defp redact_value(value, key) when is_struct(value) do
+    if sensitive_key?(key), do: @redacted, else: value
+  end
+
+  defp redact_value(value, key) when is_map(value) do
+    if sensitive_key?(key) do
+      @redacted
+    else
+      Map.new(value, fn {child_key, child_value} ->
+        {child_key, redact_value(child_value, child_key)}
+      end)
+    end
+  end
+
+  defp redact_value(value, key) when is_list(value) do
+    if sensitive_key?(key) do
+      @redacted
+    else
+      Enum.map(value, &redact_value(&1, nil))
+    end
+  end
+
+  defp redact_value(value, key) when is_binary(value) do
+    if sensitive_key?(key), do: @redacted, else: redact_string(value)
+  end
+
+  defp redact_value(value, _key), do: value
+
+  defp sensitive_key?(key) when is_atom(key), do: sensitive_key?(Atom.to_string(key))
+  defp sensitive_key?(key) when is_binary(key), do: Regex.match?(@sensitive_key_pattern, key)
+  defp sensitive_key?(_key), do: false
+
+  defp redact_string(value) do
+    case Jason.decode(value) do
+      {:ok, decoded} when is_map(decoded) or is_list(decoded) ->
+        decoded
+        |> redact_value(nil)
+        |> Jason.encode!()
+
+      _ ->
+        value
+        |> then(&Regex.replace(@json_secret_field_pattern, &1, "\\1[REDACTED]\\2"))
+        |> then(&Regex.replace(@credential_url_pattern, &1, "\\1[REDACTED]:[REDACTED]@"))
+        |> then(&Regex.replace(@sensitive_query_pattern, &1, "\\1[REDACTED]"))
+        |> then(&Regex.replace(@authorization_pattern, &1, "\\1 [REDACTED]"))
+        |> then(&Regex.replace(@assignment_pattern, &1, "\\1=[REDACTED]"))
+    end
+  end
+end

--- a/elixir/lib/symphony_elixir/redactor.ex
+++ b/elixir/lib/symphony_elixir/redactor.ex
@@ -4,13 +4,53 @@ defmodule SymphonyElixir.Redactor do
   """
 
   @redacted "[REDACTED]"
+  @sensitive_name_pattern [
+    "api[_-]?key",
+    "authorization",
+    "bearer",
+    "cookie",
+    "credential",
+    "password",
+    "private[_-]?key",
+    "secret",
+    "token"
+  ]
 
   @sensitive_key_pattern ~r/(api[_-]?key|authorization|bearer|cookie|credential|password|private[_-]?key|secret|^token$|[_-]token$|token[_-]|access[_-]?token|refresh[_-]?token|session[_-]?token|id[_-]?token)/i
   @credential_url_pattern ~r{([a-z][a-z0-9+.-]*://)([^/\s:@]+):([^@\s/]+)@}i
-  @sensitive_query_pattern ~r/([?&](?:access_token|api_key|client_secret|code|key|password|secret|token)=)[^&#\s]+/i
+  @sensitive_query_names [
+    "access[_-]?token",
+    "api[_-]?key",
+    "client[_-]?secret",
+    "code",
+    "id[_-]?token",
+    "key",
+    "password",
+    "refresh[_-]?token",
+    "secret",
+    "session[_-]?token",
+    "token"
+  ]
+  @sensitive_query_pattern Regex.compile!(
+                             "([?&](?:#{Enum.join(@sensitive_query_names, "|")})=).*?(?=(&|#|[[:space:]]|$))",
+                             "i"
+                           )
   @authorization_pattern ~r/\b(Bearer|Basic)\s+[A-Za-z0-9._~+\/=-]+/i
-  @assignment_pattern ~r/\b([A-Za-z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY|CREDENTIAL)[A-Za-z0-9_]*)=([^\s]+)/i
-  @json_secret_field_pattern ~r/("(?:api[_-]?key|authorization|cookie|credential|password|private[_-]?key|secret|token|access[_-]?token|refresh[_-]?token|session[_-]?token|id[_-]?token)"\s*:\s*")[^"]*(")/i
+  @assignment_pattern ~r/\b([A-Za-z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY|CREDENTIAL)[A-Za-z0-9_]*)=([^\s&]+)/i
+  @json_secret_field_pattern Regex.compile!(
+                               ~s/("[^"]*(?:#{Enum.join(@sensitive_name_pattern, "|")})[^"]*"\\s*:\\s*")[^"]*(")/,
+                               "i"
+                             )
+  @standalone_secret_pattern Regex.compile!(
+                               "\\b(?:" <>
+                                 "sk-[A-Za-z0-9_-]{8,}|" <>
+                                 "github_pat_[A-Za-z0-9_]{20,}|" <>
+                                 "gh[opsu]_[A-Za-z0-9_]{20,}|" <>
+                                 "glpat-[A-Za-z0-9_-]{20,}|" <>
+                                 "xox[baprs]-[A-Za-z0-9-]{10,}|" <>
+                                 "AKIA[0-9A-Z]{16}" <>
+                                 ")\\b"
+                             )
 
   @spec redact(term()) :: term()
   def redact(value), do: redact_value(value, nil)
@@ -61,6 +101,7 @@ defmodule SymphonyElixir.Redactor do
         |> then(&Regex.replace(@sensitive_query_pattern, &1, "\\1[REDACTED]"))
         |> then(&Regex.replace(@authorization_pattern, &1, "\\1 [REDACTED]"))
         |> then(&Regex.replace(@assignment_pattern, &1, "\\1=[REDACTED]"))
+        |> then(&Regex.replace(@standalone_secret_pattern, &1, @redacted))
     end
   end
 end

--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -1145,12 +1145,36 @@ defmodule SymphonyElixir.StatusDashboard do
   defp humanize_codex_event(:unsupported_tool_call, _message, payload),
     do: humanize_dynamic_tool_event("unsupported dynamic tool call rejected", payload)
 
+  defp humanize_codex_event(:manager_steer_queued, message, payload),
+    do: "manager steer queued: #{manager_steer_text(message, payload)}"
+
+  defp humanize_codex_event(:manager_steer_submitted, message, payload),
+    do: "manager steer submitted: #{manager_steer_text(message, payload)}"
+
+  defp humanize_codex_event(:manager_steer_delivered, message, payload),
+    do: "manager steer delivered: #{manager_steer_text(message, payload)}"
+
+  defp humanize_codex_event(:manager_steer_rejected, message, _payload),
+    do: "manager steer rejected: #{format_reason(map_value(message, ["reason", :reason]))}"
+
+  defp humanize_codex_event(:manager_steer_failed, message, _payload),
+    do: "manager steer failed: #{format_reason(map_value(message, ["reason", :reason]))}"
+
   defp humanize_codex_event(:turn_ended_with_error, message, _payload), do: "turn ended with error: #{format_reason(message)}"
   defp humanize_codex_event(:startup_failed, message, _payload), do: "startup failed: #{format_reason(message)}"
   defp humanize_codex_event(:turn_failed, _message, payload), do: humanize_codex_method("turn/failed", payload)
   defp humanize_codex_event(:turn_cancelled, _message, _payload), do: "turn cancelled"
   defp humanize_codex_event(:malformed, _message, _payload), do: "malformed JSON event from codex"
   defp humanize_codex_event(_event, _message, _payload), do: nil
+
+  defp manager_steer_text(message, payload) do
+    text =
+      map_value(message, ["message", :message]) ||
+        if(is_binary(payload), do: payload, else: nil) ||
+        ""
+
+    inline_text(text)
+  end
 
   defp unwrap_codex_message_payload(%{} = message) do
     cond do

--- a/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
@@ -515,15 +515,11 @@ defmodule SymphonyElixirWeb.DashboardLive do
   defp steer_locked?(true, false), do: true
   defp steer_locked?(_required, _configured), do: false
 
-  defp completed_runtime_seconds(payload) do
-    payload.codex_totals.seconds_running || 0
-  end
-
   defp total_runtime_seconds(payload, now) do
-    completed_runtime_seconds(payload) +
-      Enum.reduce(payload.running, 0, fn entry, total ->
-        total + runtime_seconds_from_started_at(entry.started_at, now)
-      end)
+    base_seconds = payload.codex_totals.seconds_running || 0
+    active_count = length(payload.running || [])
+
+    base_seconds + active_count * runtime_seconds_since_generated_at(payload.generated_at, now)
   end
 
   defp format_runtime_and_turns(started_at, turn_count, now) when is_integer(turn_count) and turn_count > 0 do
@@ -552,6 +548,15 @@ defmodule SymphonyElixirWeb.DashboardLive do
   end
 
   defp runtime_seconds_from_started_at(_started_at, _now), do: 0
+
+  defp runtime_seconds_since_generated_at(generated_at, %DateTime{} = now) when is_binary(generated_at) do
+    case DateTime.from_iso8601(generated_at) do
+      {:ok, parsed, _offset} -> max(DateTime.diff(now, parsed, :second), 0)
+      _ -> 0
+    end
+  end
+
+  defp runtime_seconds_since_generated_at(_generated_at, _now), do: 0
 
   defp format_int(value) when is_integer(value) do
     value

--- a/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
@@ -16,6 +16,8 @@ defmodule SymphonyElixirWeb.DashboardLive do
       |> assign(:detail_payload, nil)
       |> assign(:detail_error, nil)
       |> assign(:issue_identifier, nil)
+      |> assign(:steer_auth_required, steer_auth_required?())
+      |> assign(:steer_token_configured, steer_token_configured?())
       |> assign(:now, DateTime.utc_now())
 
     if connected?(socket) do
@@ -62,9 +64,22 @@ defmodule SymphonyElixirWeb.DashboardLive do
   end
 
   @impl true
-  def handle_event("steer", %{"steer" => %{"message" => message, "session_id" => session_id}}, socket) do
+  def handle_event("steer", %{"steer" => steer_params}, socket) do
     issue_identifier = socket.assigns.issue_identifier
+    message = Map.get(steer_params, "message", "")
+    session_id = Map.get(steer_params, "session_id")
+    operator_token = Map.get(steer_params, "operator_token")
 
+    case authorize_steer(operator_token) do
+      :ok ->
+        submit_steer(socket, issue_identifier, message, session_id)
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, steer_error_message(reason))}
+    end
+  end
+
+  defp submit_steer(socket, issue_identifier, message, session_id) do
     case Presenter.steer_payload(issue_identifier, message, session_id, orchestrator()) do
       {:ok, _payload} ->
         {:noreply,
@@ -144,7 +159,11 @@ defmodule SymphonyElixirWeb.DashboardLive do
                 <h2 class="section-title">Steer worker</h2>
                 <p class="section-copy">
                   <%= if detail.running do %>
-                    Send an auditable manager message to this exact active session.
+                    <%= if @steer_auth_required and not @steer_token_configured do %>
+                      Steering is locked because this dashboard is exposed without an operator token.
+                    <% else %>
+                      Send an auditable manager message to this exact active session.
+                    <% end %>
                   <% else %>
                     This worker is not running, so steering is disabled.
                   <% end %>
@@ -154,14 +173,27 @@ defmodule SymphonyElixirWeb.DashboardLive do
 
             <.form for={%{}} as={:steer} phx-submit="steer" class="steer-form">
               <input type="hidden" name="steer[session_id]" value={running.session_id || ""} />
+              <%= if @steer_auth_required and @steer_token_configured do %>
+                <input
+                  type="password"
+                  name="steer[operator_token]"
+                  class="steer-token"
+                  placeholder="Operator token"
+                  autocomplete="off"
+                  disabled={is_nil(running.session_id)}
+                />
+              <% end %>
               <textarea
                 name="steer[message]"
                 class="steer-input"
                 rows="4"
                 placeholder="Send a targeted instruction to this running worker"
-                disabled={is_nil(running.session_id)}
+                disabled={is_nil(running.session_id) or steer_locked?(@steer_auth_required, @steer_token_configured)}
               ></textarea>
-              <button type="submit" disabled={is_nil(running.session_id)}>Send steer</button>
+              <button
+                type="submit"
+                disabled={is_nil(running.session_id) or steer_locked?(@steer_auth_required, @steer_token_configured)}
+              >Send steer</button>
             </.form>
           </section>
 
@@ -443,6 +475,46 @@ defmodule SymphonyElixirWeb.DashboardLive do
     Endpoint.config(:snapshot_timeout_ms) || 15_000
   end
 
+  defp steer_auth_required?, do: Endpoint.config(:steer_auth_required) == true
+
+  defp steer_token_configured? do
+    case Endpoint.config(:steer_token) do
+      token when is_binary(token) -> String.trim(token) != ""
+      _ -> false
+    end
+  end
+
+  defp authorize_steer(operator_token) do
+    if steer_auth_required?(), do: authorize_exposed_steer(operator_token), else: :ok
+  end
+
+  defp authorize_exposed_steer(operator_token) do
+    case Endpoint.config(:steer_token) do
+      token when is_binary(token) ->
+        case String.trim(token) do
+          "" -> {:error, :steer_auth_required}
+          expected_token -> compare_steer_token(operator_token, expected_token)
+        end
+
+      _ ->
+        {:error, :steer_auth_required}
+    end
+  end
+
+  defp compare_steer_token(operator_token, expected_token) do
+    submitted_token = String.trim(operator_token || "")
+
+    if byte_size(submitted_token) == byte_size(expected_token) and
+         Plug.Crypto.secure_compare(submitted_token, expected_token) do
+      :ok
+    else
+      {:error, :invalid_steer_token}
+    end
+  end
+
+  defp steer_locked?(true, false), do: true
+  defp steer_locked?(_required, _configured), do: false
+
   defp completed_runtime_seconds(payload) do
     payload.codex_totals.seconds_running || 0
   end
@@ -497,6 +569,8 @@ defmodule SymphonyElixirWeb.DashboardLive do
   defp steer_error_message(:blank_message), do: "Steer message cannot be blank."
   defp steer_error_message(:worker_not_running), do: "Worker is no longer running."
   defp steer_error_message(:session_mismatch), do: "Worker session changed before the steer was sent."
+  defp steer_error_message(:steer_auth_required), do: "Operator token is required before steering exposed workers."
+  defp steer_error_message(:invalid_steer_token), do: "Operator token is invalid."
   defp steer_error_message(reason), do: "Steer failed: #{inspect(reason)}"
 
   defp state_badge_class(state) do

--- a/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
@@ -80,15 +80,19 @@ defmodule SymphonyElixirWeb.DashboardLive do
   end
 
   defp submit_steer(socket, issue_identifier, message, session_id) do
-    case Presenter.steer_payload(issue_identifier, message, session_id, orchestrator()) do
-      {:ok, _payload} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Steer message queued for #{issue_identifier}.")
-         |> assign_detail_payload(issue_identifier)}
+    if non_blank_binary?(session_id) do
+      case Presenter.steer_payload(issue_identifier, message, session_id, orchestrator()) do
+        {:ok, _payload} ->
+          {:noreply,
+           socket
+           |> put_flash(:info, "Steer message queued for #{issue_identifier}.")
+           |> assign_detail_payload(issue_identifier)}
 
-      {:error, reason} ->
-        {:noreply, put_flash(socket, :error, steer_error_message(reason))}
+        {:error, reason} ->
+          {:noreply, put_flash(socket, :error, steer_error_message(reason))}
+      end
+    else
+      {:noreply, put_flash(socket, :error, steer_error_message(:session_mismatch))}
     end
   end
 
@@ -521,6 +525,9 @@ defmodule SymphonyElixirWeb.DashboardLive do
       {:error, :invalid_steer_token}
     end
   end
+
+  defp non_blank_binary?(value) when is_binary(value), do: String.trim(value) != ""
+  defp non_blank_binary?(_value), do: false
 
   defp steer_locked?(true, false), do: true
   defp steer_locked?(_required, _configured), do: false

--- a/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
@@ -13,6 +13,9 @@ defmodule SymphonyElixirWeb.DashboardLive do
     socket =
       socket
       |> assign(:payload, load_payload())
+      |> assign(:detail_payload, nil)
+      |> assign(:detail_error, nil)
+      |> assign(:issue_identifier, nil)
       |> assign(:now, DateTime.utc_now())
 
     if connected?(socket) do
@@ -24,6 +27,19 @@ defmodule SymphonyElixirWeb.DashboardLive do
   end
 
   @impl true
+  def handle_params(%{"issue_identifier" => issue_identifier}, _uri, socket) do
+    {:noreply, assign_detail_payload(socket, issue_identifier)}
+  end
+
+  def handle_params(_params, _uri, socket) do
+    {:noreply,
+     socket
+     |> assign(:detail_payload, nil)
+     |> assign(:detail_error, nil)
+     |> assign(:issue_identifier, nil)}
+  end
+
+  @impl true
   def handle_info(:runtime_tick, socket) do
     schedule_runtime_tick()
     {:noreply, assign(socket, :now, DateTime.utc_now())}
@@ -31,15 +47,163 @@ defmodule SymphonyElixirWeb.DashboardLive do
 
   @impl true
   def handle_info(:observability_updated, socket) do
-    {:noreply,
-     socket
-     |> assign(:payload, load_payload())
-     |> assign(:now, DateTime.utc_now())}
+    socket =
+      socket
+      |> assign(:payload, load_payload())
+      |> assign(:now, DateTime.utc_now())
+
+    socket =
+      case socket.assigns[:issue_identifier] do
+        issue_identifier when is_binary(issue_identifier) -> assign_detail_payload(socket, issue_identifier)
+        _ -> socket
+      end
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("steer", %{"steer" => %{"message" => message, "session_id" => session_id}}, socket) do
+    issue_identifier = socket.assigns.issue_identifier
+
+    case Presenter.steer_payload(issue_identifier, message, session_id, orchestrator()) do
+      {:ok, _payload} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Steer message queued for #{issue_identifier}.")
+         |> assign_detail_payload(issue_identifier)}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, steer_error_message(reason))}
+    end
   end
 
   @impl true
   def render(assigns) do
     ~H"""
+    <%= if @live_action == :worker_detail do %>
+      <section class="dashboard-shell">
+        <header class="hero-card">
+          <div class="hero-grid">
+            <div>
+              <p class="eyebrow">Worker Detail</p>
+              <h1 class="hero-title"><%= @issue_identifier %></h1>
+              <p class="hero-copy">
+                Human-readable Codex session activity, raw event details, and targeted manager steering.
+              </p>
+            </div>
+            <div class="status-stack">
+              <a class="subtle-button" href="/">Dashboard</a>
+            </div>
+          </div>
+        </header>
+
+        <%= if @detail_error do %>
+          <section class="error-card">
+            <h2 class="error-title">Worker unavailable</h2>
+            <p class="error-copy"><%= @detail_error %></p>
+          </section>
+        <% else %>
+          <% detail = @detail_payload %>
+          <% running =
+            detail.running ||
+              %{
+                state: detail.status,
+                session_id: nil,
+                turn_count: 0,
+                tokens: %{input_tokens: nil, output_tokens: nil, total_tokens: nil}
+              } %>
+
+          <section class="metric-grid">
+            <article class="metric-card">
+              <p class="metric-label">State</p>
+              <p class="metric-value"><%= running.state %></p>
+              <p class="metric-detail"><%= detail.title || detail.issue_identifier %></p>
+            </article>
+            <article class="metric-card">
+              <p class="metric-label">Session</p>
+              <p class="metric-value mono detail-session"><%= running.session_id || "n/a" %></p>
+              <p class="metric-detail">Turn <%= running.turn_count %></p>
+            </article>
+            <article class="metric-card">
+              <p class="metric-label">Workspace</p>
+              <p class="metric-value detail-path"><%= detail.workspace.path %></p>
+              <p class="metric-detail"><%= detail.workspace.host || "local" %></p>
+            </article>
+            <article class="metric-card">
+              <p class="metric-label">Tokens</p>
+              <p class="metric-value numeric"><%= format_int(running.tokens.total_tokens) %></p>
+              <p class="metric-detail numeric">
+                In <%= format_int(running.tokens.input_tokens) %> / Out <%= format_int(running.tokens.output_tokens) %>
+              </p>
+            </article>
+          </section>
+
+          <section class="section-card">
+            <div class="section-header">
+              <div>
+                <h2 class="section-title">Steer worker</h2>
+                <p class="section-copy">
+                  <%= if detail.running do %>
+                    Send an auditable manager message to this exact active session.
+                  <% else %>
+                    This worker is not running, so steering is disabled.
+                  <% end %>
+                </p>
+              </div>
+            </div>
+
+            <.form for={%{}} as={:steer} phx-submit="steer" class="steer-form">
+              <input type="hidden" name="steer[session_id]" value={running.session_id || ""} />
+              <textarea
+                name="steer[message]"
+                class="steer-input"
+                rows="4"
+                placeholder="Send a targeted instruction to this running worker"
+                disabled={is_nil(running.session_id)}
+              ></textarea>
+              <button type="submit" disabled={is_nil(running.session_id)}>Send steer</button>
+            </.form>
+          </section>
+
+          <section class="section-card">
+            <div class="section-header">
+              <div>
+                <h2 class="section-title">Timeline</h2>
+                <p class="section-copy">Readable Codex updates with raw JSON preserved per event.</p>
+              </div>
+            </div>
+
+            <%= if detail.timeline == [] do %>
+              <p class="empty-state">No Codex events recorded yet.</p>
+            <% else %>
+              <ol class="timeline-list">
+                <li :for={event <- detail.timeline} class="timeline-item">
+                  <div class="timeline-main">
+                    <span class="timeline-event"><%= event_label(event.event) %></span>
+                    <span class="timeline-time mono"><%= event.at || "pending" %></span>
+                  </div>
+                  <p class="timeline-message"><%= event.message || "n/a" %></p>
+                  <details class="raw-details">
+                    <summary>Raw JSON</summary>
+                    <pre class="code-panel"><%= pretty_value(event.raw) %></pre>
+                  </details>
+                </li>
+              </ol>
+            <% end %>
+          </section>
+
+          <section class="section-card">
+            <div class="section-header">
+              <div>
+                <h2 class="section-title">Raw worker payload</h2>
+                <p class="section-copy">Full JSON projection used by the detail page.</p>
+              </div>
+            </div>
+            <pre class="code-panel"><%= pretty_value(detail) %></pre>
+          </section>
+        <% end %>
+      </section>
+    <% else %>
     <section class="dashboard-shell">
       <header class="hero-card">
         <div class="hero-grid">
@@ -153,6 +317,7 @@ defmodule SymphonyElixirWeb.DashboardLive do
                     <td>
                       <div class="issue-stack">
                         <span class="issue-id"><%= entry.issue_identifier %></span>
+                        <a class="issue-link" href={"/workers/#{entry.issue_identifier}"}>Worker detail</a>
                         <a class="issue-link" href={"/api/v1/#{entry.issue_identifier}"}>JSON details</a>
                       </div>
                     </td>
@@ -246,11 +411,28 @@ defmodule SymphonyElixirWeb.DashboardLive do
         </section>
       <% end %>
     </section>
+    <% end %>
     """
   end
 
   defp load_payload do
     Presenter.state_payload(orchestrator(), snapshot_timeout_ms())
+  end
+
+  defp assign_detail_payload(socket, issue_identifier) do
+    case Presenter.issue_payload(issue_identifier, orchestrator(), snapshot_timeout_ms()) do
+      {:ok, payload} ->
+        socket
+        |> assign(:detail_payload, payload)
+        |> assign(:detail_error, nil)
+        |> assign(:issue_identifier, issue_identifier)
+
+      {:error, :issue_not_found} ->
+        socket
+        |> assign(:detail_payload, nil)
+        |> assign(:detail_error, "No active or retrying worker was found for #{issue_identifier}.")
+        |> assign(:issue_identifier, issue_identifier)
+    end
   end
 
   defp orchestrator do
@@ -308,6 +490,14 @@ defmodule SymphonyElixirWeb.DashboardLive do
   end
 
   defp format_int(_value), do: "n/a"
+
+  defp event_label(event) when is_atom(event), do: event |> Atom.to_string() |> String.replace("_", " ")
+  defp event_label(event), do: event |> to_string() |> String.replace("_", " ")
+
+  defp steer_error_message(:blank_message), do: "Steer message cannot be blank."
+  defp steer_error_message(:worker_not_running), do: "Worker is no longer running."
+  defp steer_error_message(:session_mismatch), do: "Worker session changed before the steer was sent."
+  defp steer_error_message(reason), do: "Steer failed: #{inspect(reason)}"
 
   defp state_badge_class(state) do
     base = "state-badge"

--- a/elixir/lib/symphony_elixir_web/presenter.ex
+++ b/elixir/lib/symphony_elixir_web/presenter.ex
@@ -74,8 +74,8 @@ defmodule SymphonyElixirWeb.Presenter do
     %{
       issue_identifier: issue_identifier,
       issue_id: issue_id_from_entries(running, retry),
-      title: running && Map.get(running, :title),
-      url: running && Map.get(running, :url),
+      title: issue_title(running),
+      url: issue_url(running),
       status: issue_status(running, retry),
       workspace: %{
         path: workspace_path(issue_identifier, running, retry),
@@ -85,20 +85,41 @@ defmodule SymphonyElixirWeb.Presenter do
         restart_count: restart_count(retry),
         current_retry_attempt: retry_attempt(retry)
       },
-      running: running && running_issue_payload(running),
-      retry: retry && retry_issue_payload(retry),
+      running: optional_running_payload(running),
+      retry: optional_retry_payload(retry),
       logs: %{
         codex_session_logs: []
       },
-      recent_events: (running && recent_events_payload(running)) || [],
-      timeline: (running && timeline_payload(running)) || [],
-      last_error: retry && retry.error,
+      recent_events: optional_recent_events(running),
+      timeline: optional_timeline(running),
+      last_error: retry_error(retry),
       tracked: %{}
     }
   end
 
   defp issue_id_from_entries(running, retry),
     do: (running && running.issue_id) || (retry && retry.issue_id)
+
+  defp issue_title(nil), do: nil
+  defp issue_title(running), do: Map.get(running, :title)
+
+  defp issue_url(nil), do: nil
+  defp issue_url(running), do: Map.get(running, :url)
+
+  defp optional_running_payload(nil), do: nil
+  defp optional_running_payload(running), do: running_issue_payload(running)
+
+  defp optional_retry_payload(nil), do: nil
+  defp optional_retry_payload(retry), do: retry_issue_payload(retry)
+
+  defp optional_recent_events(nil), do: []
+  defp optional_recent_events(running), do: recent_events_payload(running)
+
+  defp optional_timeline(nil), do: []
+  defp optional_timeline(running), do: timeline_payload(running)
+
+  defp retry_error(nil), do: nil
+  defp retry_error(retry), do: retry.error
 
   defp restart_count(retry), do: max(retry_attempt(retry) - 1, 0)
   defp retry_attempt(nil), do: 0

--- a/elixir/lib/symphony_elixir_web/presenter.ex
+++ b/elixir/lib/symphony_elixir_web/presenter.ex
@@ -49,6 +49,16 @@ defmodule SymphonyElixirWeb.Presenter do
     end
   end
 
+  @spec steer_payload(String.t(), String.t(), String.t() | nil, GenServer.name()) ::
+          {:ok, map()} | {:error, atom()}
+  def steer_payload(issue_identifier, message, expected_session_id, orchestrator)
+      when is_binary(issue_identifier) and is_binary(message) do
+    case Orchestrator.steer_worker(orchestrator, issue_identifier, message, expected_session_id) do
+      {:ok, payload} -> {:ok, Map.update!(payload, :queued_at, &DateTime.to_iso8601/1)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   @spec refresh_payload(GenServer.name()) :: {:ok, map()} | {:error, :unavailable}
   def refresh_payload(orchestrator) do
     case Orchestrator.request_refresh(orchestrator) do
@@ -64,6 +74,8 @@ defmodule SymphonyElixirWeb.Presenter do
     %{
       issue_identifier: issue_identifier,
       issue_id: issue_id_from_entries(running, retry),
+      title: running && Map.get(running, :title),
+      url: running && Map.get(running, :url),
       status: issue_status(running, retry),
       workspace: %{
         path: workspace_path(issue_identifier, running, retry),
@@ -79,6 +91,7 @@ defmodule SymphonyElixirWeb.Presenter do
         codex_session_logs: []
       },
       recent_events: (running && recent_events_payload(running)) || [],
+      timeline: (running && timeline_payload(running)) || [],
       last_error: retry && retry.error,
       tracked: %{}
     }
@@ -99,10 +112,14 @@ defmodule SymphonyElixirWeb.Presenter do
     %{
       issue_id: entry.issue_id,
       issue_identifier: entry.identifier,
+      title: Map.get(entry, :title),
+      url: Map.get(entry, :url),
       state: entry.state,
       worker_host: Map.get(entry, :worker_host),
       workspace_path: Map.get(entry, :workspace_path),
       session_id: entry.session_id,
+      thread_id: Map.get(entry, :thread_id),
+      turn_id: Map.get(entry, :turn_id),
       turn_count: Map.get(entry, :turn_count, 0),
       last_event: entry.last_codex_event,
       last_message: summarize_message(entry.last_codex_message),
@@ -133,6 +150,8 @@ defmodule SymphonyElixirWeb.Presenter do
       worker_host: Map.get(running, :worker_host),
       workspace_path: Map.get(running, :workspace_path),
       session_id: running.session_id,
+      thread_id: Map.get(running, :thread_id),
+      turn_id: Map.get(running, :turn_id),
       turn_count: Map.get(running, :turn_count, 0),
       state: running.state,
       started_at: iso8601(running.started_at),
@@ -176,6 +195,28 @@ defmodule SymphonyElixirWeb.Presenter do
       }
     ]
     |> Enum.reject(&is_nil(&1.at))
+  end
+
+  defp timeline_payload(running) do
+    running
+    |> Map.get(:recent_codex_events, [])
+    |> Enum.map(&timeline_event_payload/1)
+  end
+
+  defp timeline_event_payload(event) when is_map(event) do
+    %{
+      at: iso8601(event[:timestamp]),
+      event: event[:event],
+      message: summarize_message(event),
+      raw: raw_event_payload(event),
+      session_id: event[:session_id],
+      thread_id: event[:thread_id],
+      turn_id: event[:turn_id]
+    }
+  end
+
+  defp raw_event_payload(event) when is_map(event) do
+    event[:raw] || event[:message]
   end
 
   defp summarize_message(nil), do: nil

--- a/elixir/lib/symphony_elixir_web/presenter.ex
+++ b/elixir/lib/symphony_elixir_web/presenter.ex
@@ -3,7 +3,7 @@ defmodule SymphonyElixirWeb.Presenter do
   Shared projections for the observability API and dashboard.
   """
 
-  alias SymphonyElixir.{Config, Orchestrator, StatusDashboard}
+  alias SymphonyElixir.{Config, Orchestrator, Redactor, StatusDashboard}
 
   @spec state_payload(GenServer.name(), timeout()) :: map()
   def state_payload(orchestrator, snapshot_timeout_ms) do
@@ -237,11 +237,11 @@ defmodule SymphonyElixirWeb.Presenter do
   end
 
   defp raw_event_payload(event) when is_map(event) do
-    event[:raw] || event[:message]
+    Redactor.redact(event[:raw] || event[:message])
   end
 
   defp summarize_message(nil), do: nil
-  defp summarize_message(message), do: StatusDashboard.humanize_codex_message(message)
+  defp summarize_message(message), do: message |> Redactor.redact() |> StatusDashboard.humanize_codex_message()
 
   defp due_at_iso8601(due_in_ms) when is_integer(due_in_ms) do
     DateTime.utc_now()

--- a/elixir/lib/symphony_elixir_web/router.ex
+++ b/elixir/lib/symphony_elixir_web/router.ex
@@ -25,6 +25,7 @@ defmodule SymphonyElixirWeb.Router do
     pipe_through(:browser)
 
     live("/", DashboardLive, :index)
+    live("/workers/:issue_identifier", DashboardLive, :worker_detail)
   end
 
   scope "/", SymphonyElixirWeb do

--- a/elixir/priv/static/dashboard.css
+++ b/elixir/priv/static/dashboard.css
@@ -71,6 +71,17 @@ button:hover {
   box-shadow: 0 12px 24px rgba(16, 163, 127, 0.22);
 }
 
+button:disabled,
+textarea:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
+button:disabled:hover {
+  transform: none;
+  box-shadow: 0 8px 20px rgba(16, 163, 127, 0.18);
+}
+
 button.secondary {
   background: var(--card);
   color: var(--ink);
@@ -267,6 +278,13 @@ pre,
   font-size: 0.88rem;
 }
 
+.detail-session,
+.detail-path {
+  font-size: 1rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
 .section-card {
   border-radius: 24px;
   padding: 1.15rem;
@@ -410,6 +428,79 @@ pre,
 .empty-state {
   margin: 1rem 0 0;
   color: var(--muted);
+}
+
+.steer-form {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.steer-input {
+  width: 100%;
+  min-height: 7rem;
+  resize: vertical;
+  border: 1px solid var(--line-strong);
+  border-radius: 12px;
+  padding: 0.8rem;
+  background: rgba(255, 255, 255, 0.82);
+  color: var(--ink);
+  font: inherit;
+  line-height: 1.45;
+}
+
+.steer-input:focus {
+  outline: 2px solid rgba(16, 163, 127, 0.24);
+  border-color: var(--accent);
+}
+
+.timeline-list {
+  display: grid;
+  gap: 0.8rem;
+  margin: 1rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.timeline-item {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.9rem 0 0;
+  border-top: 1px solid var(--line);
+}
+
+.timeline-main {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.timeline-event {
+  font-weight: 700;
+}
+
+.timeline-time {
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.timeline-message {
+  margin: 0;
+  color: var(--ink);
+  overflow-wrap: anywhere;
+}
+
+.raw-details summary {
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.86rem;
+  font-weight: 600;
+}
+
+.raw-details .code-panel {
+  margin-top: 0.6rem;
 }
 
 .error-card {

--- a/elixir/priv/static/dashboard.css
+++ b/elixir/priv/static/dashboard.css
@@ -436,10 +436,9 @@ pre,
   margin-top: 1rem;
 }
 
-.steer-input {
+.steer-input,
+.steer-token {
   width: 100%;
-  min-height: 7rem;
-  resize: vertical;
   border: 1px solid var(--line-strong);
   border-radius: 12px;
   padding: 0.8rem;
@@ -449,7 +448,17 @@ pre,
   line-height: 1.45;
 }
 
-.steer-input:focus {
+.steer-input {
+  min-height: 7rem;
+  resize: vertical;
+}
+
+.steer-token {
+  max-width: 24rem;
+}
+
+.steer-input:focus,
+.steer-token:focus {
   outline: 2px solid rgba(16, 163, 127, 0.24);
   border-color: var(--accent);
 }

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -825,11 +825,15 @@ defmodule SymphonyElixir.AppServerTest do
       parent = self()
       on_message = fn message -> send(parent, {:app_server_message, message}) end
 
-      {:ok, session} = AppServer.start_session(workspace)
-
       task =
         Task.async(fn ->
-          AppServer.run_turn(session, "Wait for manager steer", issue, on_message: on_message)
+          {:ok, session} = AppServer.start_session(workspace)
+
+          try do
+            AppServer.run_turn(session, "Wait for manager steer", issue, on_message: on_message)
+          after
+            AppServer.stop_session(session)
+          end
         end)
 
       assert_receive {:app_server_message, %{event: :session_started, session_id: "thread-720-turn-720"}},

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -792,7 +792,7 @@ defmodule SymphonyElixir.AppServerTest do
             ;;
           5)
             steer_id=$(printf '%s' "$line" | sed -n 's/.*"id":\\([0-9][0-9]*\\).*/\\1/p')
-            printf '%s\\n' "{\"id\":${steer_id},\"result\":{\"turnId\":\"turn-720\"}}"
+            printf '{"id":%s,"result":{"turnId":"turn-720"}}\\n' "$steer_id"
             printf '%s\\n' '{"method":"turn/completed"}'
             exit 0
             ;;

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -793,8 +793,6 @@ defmodule SymphonyElixir.AppServerTest do
           5)
             steer_id=$(printf '%s' "$line" | sed -n 's/.*"id":\\([0-9][0-9]*\\).*/\\1/p')
             printf '%s\\n' "{\"id\":${steer_id},\"result\":{\"turnId\":\"turn-720\"}}"
-            ;;
-          6)
             printf '%s\\n' '{"method":"turn/completed"}'
             exit 0
             ;;

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -745,6 +745,120 @@ defmodule SymphonyElixir.AppServerTest do
     end
   end
 
+  test "app server records manager steer rejection responses from codex" do
+    if SymphonyElixir.LocalShell.windows?() do
+      :ok
+    else
+      do_test_app_server_records_manager_steer_rejection_response()
+    end
+  end
+
+  defp do_test_app_server_records_manager_steer_rejection_response do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-app-server-steer-reject-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-721")
+      codex_binary = Path.join(test_root, "fake-codex")
+      previous_trace = System.get_env("SYMP_TEST_CODEx_TRACE")
+
+      on_exit(fn ->
+        if is_binary(previous_trace) do
+          System.put_env("SYMP_TEST_CODEx_TRACE", previous_trace)
+        else
+          System.delete_env("SYMP_TEST_CODEx_TRACE")
+        end
+      end)
+
+      File.mkdir_p!(workspace)
+
+      File.write!(codex_binary, """
+      #!/bin/sh
+      count=0
+      while IFS= read -r line; do
+        count=$((count + 1))
+
+        case "$count" in
+          1)
+            printf '%s\\n' '{"id":1,"result":{}}'
+            ;;
+          2)
+            ;;
+          3)
+            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-721"}}}'
+            ;;
+          4)
+            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-721"}}}'
+            ;;
+          5)
+            steer_id=$(printf '%s' "$line" | sed -n 's/.*"id":\\([0-9][0-9]*\\).*/\\1/p')
+            printf '{"id":%s,"error":{"code":"turn_not_running","message":"turn stopped"}}\\n' "$steer_id"
+            printf '%s\\n' '{"method":"turn/completed"}'
+            exit 0
+            ;;
+          *)
+            exit 0
+            ;;
+        esac
+      done
+      """)
+
+      File.chmod!(codex_binary, 0o755)
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        codex_command: "#{codex_binary} app-server"
+      )
+
+      issue = %Issue{
+        id: "issue-steer-reject",
+        identifier: "MT-721",
+        title: "Steer rejected turn",
+        description: "Record app-server steer rejection",
+        state: "In Progress",
+        url: "https://example.org/issues/MT-721",
+        labels: ["backend"]
+      }
+
+      parent = self()
+      on_message = fn message -> send(parent, {:app_server_message, message}) end
+
+      task =
+        Task.async(fn ->
+          {:ok, session} = AppServer.start_session(workspace)
+
+          try do
+            AppServer.run_turn(session, "Wait for manager steer rejection", issue, on_message: on_message)
+          after
+            AppServer.stop_session(session)
+          end
+        end)
+
+      assert_receive {:app_server_message, %{event: :session_started, session_id: "thread-721-turn-721"}},
+                     1_000
+
+      request_ref = make_ref()
+      send(task.pid, {:codex_steer, self(), request_ref, "thread-721-turn-721", "Retry the focused test."})
+      assert_receive {:codex_steer_request_result, ^request_ref, {:ok, "thread-721-turn-721"}}, 1_000
+
+      assert {:ok, _result} = Task.await(task, 1_000)
+
+      assert_receive {:app_server_message,
+                      %{
+                        event: :manager_steer_failed,
+                        session_id: "thread-721-turn-721",
+                        reason: %{"code" => "turn_not_running", "message" => "turn stopped"}
+                      }},
+                     1_000
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
   defp do_test_app_server_sends_manager_steer_messages_to_the_active_turn do
     test_root =
       Path.join(

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -737,6 +737,145 @@ defmodule SymphonyElixir.AppServerTest do
     end
   end
 
+  test "app server sends manager steer messages to the active turn with expected turn id" do
+    if SymphonyElixir.LocalShell.windows?() do
+      :ok
+    else
+      do_test_app_server_sends_manager_steer_messages_to_the_active_turn()
+    end
+  end
+
+  defp do_test_app_server_sends_manager_steer_messages_to_the_active_turn do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-app-server-steer-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-720")
+      codex_binary = Path.join(test_root, "fake-codex")
+      trace_file = Path.join(test_root, "codex-steer.trace")
+      previous_trace = System.get_env("SYMP_TEST_CODEx_TRACE")
+
+      on_exit(fn ->
+        if is_binary(previous_trace) do
+          System.put_env("SYMP_TEST_CODEx_TRACE", previous_trace)
+        else
+          System.delete_env("SYMP_TEST_CODEx_TRACE")
+        end
+      end)
+
+      System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
+      File.mkdir_p!(workspace)
+
+      File.write!(codex_binary, """
+      #!/bin/sh
+      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-steer.trace}"
+      count=0
+      while IFS= read -r line; do
+        count=$((count + 1))
+        printf 'JSON:%s\\n' "$line" >> "$trace_file"
+
+        case "$count" in
+          1)
+            printf '%s\\n' '{"id":1,"result":{}}'
+            ;;
+          2)
+            ;;
+          3)
+            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-720"}}}'
+            ;;
+          4)
+            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-720"}}}'
+            ;;
+          5)
+            steer_id=$(printf '%s' "$line" | sed -n 's/.*"id":\\([0-9][0-9]*\\).*/\\1/p')
+            printf '%s\\n' "{\"id\":${steer_id},\"result\":{\"turnId\":\"turn-720\"}}"
+            ;;
+          6)
+            printf '%s\\n' '{"method":"turn/completed"}'
+            exit 0
+            ;;
+          *)
+            exit 0
+            ;;
+        esac
+      done
+      """)
+
+      File.chmod!(codex_binary, 0o755)
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        codex_command: "#{codex_binary} app-server"
+      )
+
+      issue = %Issue{
+        id: "issue-steer",
+        identifier: "MT-720",
+        title: "Steer active turn",
+        description: "Ensure manager steering uses the app-server steer method",
+        state: "In Progress",
+        url: "https://example.org/issues/MT-720",
+        labels: ["backend"]
+      }
+
+      parent = self()
+      on_message = fn message -> send(parent, {:app_server_message, message}) end
+
+      {:ok, session} = AppServer.start_session(workspace)
+
+      task =
+        Task.async(fn ->
+          AppServer.run_turn(session, "Wait for manager steer", issue, on_message: on_message)
+        end)
+
+      assert_receive {:app_server_message, %{event: :session_started, session_id: "thread-720-turn-720"}},
+                     1_000
+
+      request_ref = make_ref()
+      send(task.pid, {:codex_steer, self(), request_ref, "thread-720-turn-720", "Focus on the failing API test."})
+      assert_receive {:codex_steer_request_result, ^request_ref, {:ok, "thread-720-turn-720"}}, 1_000
+
+      assert {:ok, _result} = Task.await(task, 1_000)
+
+      assert_receive {:app_server_message,
+                      %{
+                        event: :manager_steer_delivered,
+                        session_id: "thread-720-turn-720",
+                        thread_id: "thread-720",
+                        turn_id: "turn-720",
+                        message: "Focus on the failing API test."
+                      }},
+                     1_000
+
+      trace = File.read!(trace_file)
+      lines = String.split(trace, "\n", trim: true)
+
+      assert Enum.any?(lines, fn line ->
+               if String.starts_with?(line, "JSON:") do
+                 payload =
+                   line
+                   |> String.trim_leading("JSON:")
+                   |> Jason.decode!()
+
+                 payload["method"] == "turn/steer" and
+                   get_in(payload, ["params", "threadId"]) == "thread-720" and
+                   get_in(payload, ["params", "expectedTurnId"]) == "turn-720" and
+                   get_in(payload, ["params", "input"]) == [
+                     %{"type" => "text", "text" => "Focus on the failing API test."}
+                   ]
+               else
+                 false
+               end
+             end)
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
   test "app server rejects unsupported dynamic tool calls without stalling" do
     test_root =
       Path.join(

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -149,6 +149,24 @@ defmodule SymphonyElixir.CoreTest do
     assert Config.settings!().tracker.assignee == env_assignee
   end
 
+  test "manager steer token resolves from SYMPHONY_STEER_TOKEN env var" do
+    previous_steer_token = System.get_env("SYMPHONY_STEER_TOKEN")
+    env_steer_token = "test-steer-token"
+
+    on_exit(fn -> restore_env("SYMPHONY_STEER_TOKEN", previous_steer_token) end)
+    System.put_env("SYMPHONY_STEER_TOKEN", env_steer_token)
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_project_slug: "project",
+      codex_command: "/bin/sh app-server"
+    )
+
+    assert Config.settings!().observability.steer_token == env_steer_token
+
+    System.put_env("SYMPHONY_STEER_TOKEN", "   ")
+    assert Config.settings!().observability.steer_token == nil
+  end
+
   test "workflow file path defaults to WORKFLOW.md in the current working directory when app env is unset" do
     original_workflow_path = Workflow.workflow_file_path()
 

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -1175,6 +1175,36 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert_received {:steer_worker_called, "MT-HTTP", "Use the narrower UI fix.", "thread-http"}
   end
 
+  test "worker detail liveview rejects missing or blank steer session ids" do
+    orchestrator_name = Module.concat(__MODULE__, :WorkerDetailSteerSessionGuardOrchestrator)
+
+    {:ok, _pid} =
+      StaticOrchestrator.start_link(
+        name: orchestrator_name,
+        parent: self(),
+        snapshot: static_snapshot()
+      )
+
+    start_test_endpoint(orchestrator: orchestrator_name, snapshot_timeout_ms: 50)
+
+    {:ok, view, _html} = live(build_conn(), "/workers/MT-HTTP")
+
+    render_submit(view, "steer", %{
+      "steer" => %{
+        "message" => "Do not send without a session."
+      }
+    })
+
+    render_submit(view, "steer", %{
+      "steer" => %{
+        "message" => "Do not send with a blank session.",
+        "session_id" => "   "
+      }
+    })
+
+    refute_received {:steer_worker_called, "MT-HTTP", _message, _session_id}
+  end
+
   test "worker detail projections redact secret-like raw event values" do
     orchestrator_name = Module.concat(__MODULE__, :WorkerDetailRedactionOrchestrator)
 

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -1124,6 +1124,27 @@ defmodule SymphonyElixir.ExtensionsTest do
     end)
   end
 
+  test "dashboard liveview does not double-count active runtime totals" do
+    orchestrator_name = Module.concat(__MODULE__, :DashboardRuntimeOrchestrator)
+
+    snapshot =
+      static_snapshot()
+      |> put_in([:codex_totals, :seconds_running], 120)
+      |> put_in([:running, Access.at(0), :started_at], DateTime.add(DateTime.utc_now(), -120, :second))
+
+    {:ok, _pid} =
+      StaticOrchestrator.start_link(
+        name: orchestrator_name,
+        snapshot: snapshot
+      )
+
+    start_test_endpoint(orchestrator: orchestrator_name, snapshot_timeout_ms: 50)
+
+    {:ok, _view, html} = live(build_conn(), "/")
+    assert html =~ "2m "
+    refute html =~ "4m "
+  end
+
   test "worker detail liveview renders timeline and submits session-scoped steer messages" do
     orchestrator_name = Module.concat(__MODULE__, :WorkerDetailOrchestrator)
 

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -678,6 +678,108 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert_received {:steer_worker_called, "MT-HTTP", "Use the narrower UI fix.", "thread-http"}
   end
 
+  test "worker detail projections redact secret-like raw event values" do
+    orchestrator_name = Module.concat(__MODULE__, :WorkerDetailRedactionOrchestrator)
+
+    {:ok, _pid} =
+      StaticOrchestrator.start_link(
+        name: orchestrator_name,
+        snapshot: secret_snapshot()
+      )
+
+    start_test_endpoint(orchestrator: orchestrator_name, snapshot_timeout_ms: 50)
+
+    api_payload = json_response(get(build_conn(), "/api/v1/MT-SECRET"), 200)
+    rendered_api = inspect(api_payload, limit: :infinity)
+
+    refute rendered_api =~ "sk-live-secret"
+    refute rendered_api =~ "p4ss"
+    refute rendered_api =~ "live-token"
+    refute rendered_api =~ "user:pass"
+    refute rendered_api =~ "token=abc123"
+    assert rendered_api =~ "[REDACTED]"
+
+    {:ok, _view, html} = live(build_conn(), "/workers/MT-SECRET")
+
+    refute html =~ "sk-live-secret"
+    refute html =~ "p4ss"
+    refute html =~ "live-token"
+    refute html =~ "user:pass"
+    refute html =~ "token=abc123"
+    assert html =~ "[REDACTED]"
+  end
+
+  test "worker detail liveview requires operator token when steer auth is enabled" do
+    orchestrator_name = Module.concat(__MODULE__, :WorkerDetailSteerAuthOrchestrator)
+
+    {:ok, _pid} =
+      StaticOrchestrator.start_link(
+        name: orchestrator_name,
+        parent: self(),
+        snapshot: static_snapshot()
+      )
+
+    start_test_endpoint(
+      orchestrator: orchestrator_name,
+      snapshot_timeout_ms: 50,
+      steer_auth_required: true,
+      steer_token: "letmein"
+    )
+
+    {:ok, view, html} = live(build_conn(), "/workers/MT-HTTP")
+    assert html =~ "Operator token"
+
+    render_submit(view, "steer", %{
+      "steer" => %{
+        "message" => "Do not send this.",
+        "session_id" => "thread-http",
+        "operator_token" => "wrong"
+      }
+    })
+
+    refute_received {:steer_worker_called, "MT-HTTP", "Do not send this.", "thread-http"}
+
+    render_submit(view, "steer", %{
+      "steer" => %{
+        "message" => "Use the authenticated steer path.",
+        "session_id" => "thread-http",
+        "operator_token" => "letmein"
+      }
+    })
+
+    assert_received {:steer_worker_called, "MT-HTTP", "Use the authenticated steer path.", "thread-http"}
+  end
+
+  test "worker detail liveview locks steering when exposed without an operator token" do
+    orchestrator_name = Module.concat(__MODULE__, :WorkerDetailSteerLockedOrchestrator)
+
+    {:ok, _pid} =
+      StaticOrchestrator.start_link(
+        name: orchestrator_name,
+        parent: self(),
+        snapshot: static_snapshot()
+      )
+
+    start_test_endpoint(
+      orchestrator: orchestrator_name,
+      snapshot_timeout_ms: 50,
+      steer_auth_required: true,
+      steer_token: "   "
+    )
+
+    {:ok, view, html} = live(build_conn(), "/workers/MT-HTTP")
+    assert html =~ "Steering is locked"
+
+    render_submit(view, "steer", %{
+      "steer" => %{
+        "message" => "Do not send this.",
+        "session_id" => "thread-http"
+      }
+    })
+
+    refute_received {:steer_worker_called, "MT-HTTP", "Do not send this.", "thread-http"}
+  end
+
   test "dashboard liveview renders an unavailable state without crashing" do
     start_test_endpoint(
       orchestrator: Module.concat(__MODULE__, :MissingDashboardOrchestrator),
@@ -811,6 +913,42 @@ defmodule SymphonyElixir.ExtensionsTest do
       codex_totals: %{input_tokens: 4, output_tokens: 8, total_tokens: 12, seconds_running: 42.5},
       rate_limits: %{"primary" => %{"remaining" => 11}}
     }
+  end
+
+  defp secret_snapshot do
+    snapshot = static_snapshot()
+
+    secret_event = %{
+      event: :notification,
+      message: %{
+        payload: %{
+          "method" => "item/commandExecution/outputDelta",
+          "params" => %{
+            "outputDelta" => "OPENAI_API_KEY=sk-live-secret curl https://user:pass@example.org?token=abc123",
+            "authorization" => "Bearer live-token"
+          }
+        }
+      },
+      raw: ~s({"api_key":"sk-live-secret","password":"p4ss","access_token":"live-token","url":"https://user:pass@example.org?token=abc123"}),
+      session_id: "thread-secret",
+      thread_id: "thread-secret",
+      turn_id: "turn-secret",
+      timestamp: ~U[2026-01-01 00:00:00Z]
+    }
+
+    secret_running =
+      snapshot.running
+      |> List.first()
+      |> Map.merge(%{
+        identifier: "MT-SECRET",
+        session_id: "thread-secret",
+        thread_id: "thread-secret",
+        turn_id: "turn-secret",
+        last_codex_message: secret_event.message,
+        recent_codex_events: [secret_event]
+      })
+
+    %{snapshot | running: [secret_running]}
   end
 
   defp wait_for_bound_port do

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -75,6 +75,21 @@ defmodule SymphonyElixir.ExtensionsTest do
     def handle_call(:request_refresh, _from, state) do
       {:reply, Keyword.get(state, :refresh, :unavailable), state}
     end
+
+    def handle_call({:steer_worker, issue_identifier, message, session_id}, _from, state) do
+      if parent = Keyword.get(state, :parent) do
+        send(parent, {:steer_worker_called, issue_identifier, message, session_id})
+      end
+
+      {:reply,
+       {:ok,
+        %{
+          issue_identifier: issue_identifier,
+          issue_id: "issue-http",
+          session_id: session_id,
+          queued_at: DateTime.utc_now()
+        }}, state}
+    end
   end
 
   setup do
@@ -365,9 +380,13 @@ defmodule SymphonyElixir.ExtensionsTest do
                  "issue_id" => "issue-http",
                  "issue_identifier" => "MT-HTTP",
                  "state" => "In Progress",
+                 "title" => "HTTP issue",
+                 "url" => "https://example.org/issues/MT-HTTP",
                  "worker_host" => nil,
                  "workspace_path" => nil,
                  "session_id" => "thread-http",
+                 "thread_id" => "thread-http",
+                 "turn_id" => "turn-http",
                  "turn_count" => 7,
                  "last_event" => "notification",
                  "last_message" => "rendered",
@@ -402,6 +421,8 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert issue_payload == %{
              "issue_identifier" => "MT-HTTP",
              "issue_id" => "issue-http",
+             "title" => "HTTP issue",
+             "url" => "https://example.org/issues/MT-HTTP",
              "status" => "running",
              "workspace" => %{
                "path" => Path.join(Config.settings!().workspace.root, "MT-HTTP"),
@@ -412,6 +433,8 @@ defmodule SymphonyElixir.ExtensionsTest do
                "worker_host" => nil,
                "workspace_path" => nil,
                "session_id" => "thread-http",
+               "thread_id" => "thread-http",
+               "turn_id" => "turn-http",
                "turn_count" => 7,
                "state" => "In Progress",
                "started_at" => issue_payload["running"]["started_at"],
@@ -423,6 +446,17 @@ defmodule SymphonyElixir.ExtensionsTest do
              "retry" => nil,
              "logs" => %{"codex_session_logs" => []},
              "recent_events" => [],
+             "timeline" => [
+               %{
+                 "at" => "2026-01-01T00:00:00Z",
+                 "event" => "manager_steer_delivered",
+                 "message" => "manager steer delivered: Keep the PR focused.",
+                 "raw" => %{"id" => 10_123, "result" => %{"turnId" => "turn-http"}},
+                 "session_id" => "thread-http",
+                 "thread_id" => "thread-http",
+                 "turn_id" => "turn-http"
+               }
+             ],
              "last_error" => nil,
              "tracked" => %{}
            }
@@ -442,6 +476,9 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     assert %{"queued" => true, "coalesced" => false, "operations" => ["poll", "reconcile"]} =
              json_response(conn, 202)
+
+    assert json_response(post(build_conn(), "/api/v1/MT-HTTP/steer", %{}), 404) ==
+             %{"error" => %{"code" => "not_found", "message" => "Route not found"}}
   end
 
   test "phoenix observability api preserves 405, 404, and unavailable behavior" do
@@ -613,6 +650,34 @@ defmodule SymphonyElixir.ExtensionsTest do
     end)
   end
 
+  test "worker detail liveview renders timeline and submits session-scoped steer messages" do
+    orchestrator_name = Module.concat(__MODULE__, :WorkerDetailOrchestrator)
+
+    {:ok, _pid} =
+      StaticOrchestrator.start_link(
+        name: orchestrator_name,
+        parent: self(),
+        snapshot: static_snapshot()
+      )
+
+    start_test_endpoint(orchestrator: orchestrator_name, snapshot_timeout_ms: 50)
+
+    {:ok, view, html} = live(build_conn(), "/workers/MT-HTTP")
+    assert html =~ "Worker Detail"
+    assert html =~ "thread-http"
+    assert html =~ "manager steer delivered: Keep the PR focused."
+    assert html =~ "Raw JSON"
+
+    render_submit(view, "steer", %{
+      "steer" => %{
+        "message" => "Use the narrower UI fix.",
+        "session_id" => "thread-http"
+      }
+    })
+
+    assert_received {:steer_worker_called, "MT-HTTP", "Use the narrower UI fix.", "thread-http"}
+  end
+
   test "dashboard liveview renders an unavailable state without crashing" do
     start_test_endpoint(
       orchestrator: Module.concat(__MODULE__, :MissingDashboardOrchestrator),
@@ -706,8 +771,12 @@ defmodule SymphonyElixir.ExtensionsTest do
         %{
           issue_id: "issue-http",
           identifier: "MT-HTTP",
+          title: "HTTP issue",
+          url: "https://example.org/issues/MT-HTTP",
           state: "In Progress",
           session_id: "thread-http",
+          thread_id: "thread-http",
+          turn_id: "turn-http",
           turn_count: 7,
           codex_app_server_pid: nil,
           last_codex_message: "rendered",
@@ -716,6 +785,17 @@ defmodule SymphonyElixir.ExtensionsTest do
           codex_input_tokens: 4,
           codex_output_tokens: 8,
           codex_total_tokens: 12,
+          recent_codex_events: [
+            %{
+              event: :manager_steer_delivered,
+              message: "Keep the PR focused.",
+              raw: %{"id" => 10_123, "result" => %{"turnId" => "turn-http"}},
+              session_id: "thread-http",
+              thread_id: "thread-http",
+              turn_id: "turn-http",
+              timestamp: ~U[2026-01-01 00:00:00Z]
+            }
+          ],
           started_at: DateTime.utc_now()
         }
       ],

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -125,9 +125,19 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     initial_state = :sys.get_state(pid)
     process_ref = make_ref()
     started_at = DateTime.utc_now()
+    parent = self()
+
+    worker_pid =
+      spawn(fn ->
+        receive do
+          {:codex_steer, reply_to, request_ref, session_id, message} ->
+            send(parent, {:codex_steer, session_id, message})
+            send(reply_to, {:codex_steer_request_result, request_ref, {:ok, session_id}})
+        end
+      end)
 
     running_entry = %{
-      pid: self(),
+      pid: worker_pid,
       ref: process_ref,
       identifier: issue.identifier,
       issue: issue,
@@ -197,6 +207,150 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     assert completed_state.codex_totals.output_tokens == 4
     assert completed_state.codex_totals.total_tokens == 16
     assert is_integer(completed_state.codex_totals.seconds_running)
+  end
+
+  test "orchestrator routes manager steer messages to the matching running worker session" do
+    issue_id = "issue-steer-route"
+
+    issue = %Issue{
+      id: issue_id,
+      identifier: "MT-240",
+      title: "Steer routing test",
+      description: "Route manager steer messages",
+      state: "In Progress",
+      url: "https://example.org/issues/MT-240"
+    }
+
+    orchestrator_name = Module.concat(__MODULE__, :SteerRouteOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    initial_state = :sys.get_state(pid)
+    process_ref = make_ref()
+    started_at = DateTime.utc_now()
+    parent = self()
+
+    worker_pid =
+      spawn(fn ->
+        receive do
+          {:codex_steer, reply_to, request_ref, session_id, message} ->
+            send(parent, {:codex_steer, session_id, message})
+            send(reply_to, {:codex_steer_request_result, request_ref, {:ok, session_id}})
+        end
+      end)
+
+    running_entry = %{
+      pid: worker_pid,
+      ref: process_ref,
+      identifier: issue.identifier,
+      issue: issue,
+      session_id: "thread-route-turn-route",
+      thread_id: "thread-route",
+      turn_id: "turn-route",
+      turn_count: 1,
+      last_codex_message: nil,
+      last_codex_timestamp: nil,
+      last_codex_event: nil,
+      codex_input_tokens: 0,
+      codex_output_tokens: 0,
+      codex_total_tokens: 0,
+      codex_last_reported_input_tokens: 0,
+      codex_last_reported_output_tokens: 0,
+      codex_last_reported_total_tokens: 0,
+      recent_codex_events: [],
+      started_at: started_at
+    }
+
+    :sys.replace_state(pid, fn _ ->
+      initial_state
+      |> Map.put(:running, %{issue_id => running_entry})
+      |> Map.put(:claimed, MapSet.put(initial_state.claimed, issue_id))
+    end)
+
+    assert {:ok, %{session_id: "thread-route-turn-route"}} =
+             Orchestrator.steer_worker(
+               orchestrator_name,
+               "MT-240",
+               "Inspect the failing worker detail test.",
+               "thread-route-turn-route"
+             )
+
+    assert_received {:codex_steer, "thread-route-turn-route", "Inspect the failing worker detail test."}
+
+    snapshot = GenServer.call(pid, :snapshot)
+    assert %{running: [snapshot_entry]} = snapshot
+    assert snapshot_entry.thread_id == "thread-route"
+    assert snapshot_entry.turn_id == "turn-route"
+
+    assert [
+             %{
+               event: :manager_steer_queued,
+               message: "Inspect the failing worker detail test.",
+               session_id: "thread-route-turn-route"
+             }
+           ] = snapshot_entry.recent_codex_events
+
+    Process.exit(worker_pid, :normal)
+  end
+
+  test "orchestrator rejects manager steer messages when the worker session changed" do
+    issue_id = "issue-steer-mismatch"
+
+    issue = %Issue{
+      id: issue_id,
+      identifier: "MT-241",
+      title: "Steer mismatch test",
+      description: "Reject stale session steer messages",
+      state: "In Progress",
+      url: "https://example.org/issues/MT-241"
+    }
+
+    orchestrator_name = Module.concat(__MODULE__, :SteerMismatchOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    initial_state = :sys.get_state(pid)
+
+    running_entry = %{
+      pid: self(),
+      ref: make_ref(),
+      identifier: issue.identifier,
+      issue: issue,
+      session_id: "thread-new-turn-new",
+      turn_count: 1,
+      last_codex_message: nil,
+      last_codex_timestamp: nil,
+      last_codex_event: nil,
+      codex_input_tokens: 0,
+      codex_output_tokens: 0,
+      codex_total_tokens: 0,
+      codex_last_reported_input_tokens: 0,
+      codex_last_reported_output_tokens: 0,
+      codex_last_reported_total_tokens: 0,
+      recent_codex_events: [],
+      started_at: DateTime.utc_now()
+    }
+
+    :sys.replace_state(pid, fn _ ->
+      initial_state
+      |> Map.put(:running, %{issue_id => running_entry})
+      |> Map.put(:claimed, MapSet.put(initial_state.claimed, issue_id))
+    end)
+
+    assert {:error, :session_mismatch} =
+             Orchestrator.steer_worker(orchestrator_name, "MT-241", "Use stale session", "thread-old-turn-old")
+
+    refute_received {:codex_steer, _session_id, _message}
   end
 
   test "orchestrator snapshot tracks turn completed usage when present" do

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -640,6 +640,17 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     assert {:error, :worker_not_running} =
              Orchestrator.steer_worker(orchestrator_name, "MT-MISSING", "message", "thread-failure-turn-failure")
 
+    assert {:error, :session_mismatch} =
+             Orchestrator.steer_worker(orchestrator_name, "MT-243", "message", nil)
+
+    assert {:error, :session_mismatch} =
+             Orchestrator.steer_worker(orchestrator_name, "MT-243", "message", "")
+
+    assert {:error, :session_mismatch} =
+             Orchestrator.steer_worker(orchestrator_name, "MT-243", "message", "   ")
+
+    refute_received {:codex_steer, _session_id, _message}
+
     Process.exit(worker_pid, :kill)
     wait_until_dead(worker_pid)
 

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -298,6 +298,84 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     Process.exit(worker_pid, :normal)
   end
 
+  test "orchestrator redacts secret-like codex event values before snapshot storage" do
+    issue_id = "issue-redaction"
+
+    issue = %Issue{
+      id: issue_id,
+      identifier: "MT-242",
+      title: "Redaction test",
+      description: "Redact secrets",
+      state: "In Progress",
+      url: "https://example.org/issues/MT-242"
+    }
+
+    orchestrator_name = Module.concat(__MODULE__, :RedactionOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    initial_state = :sys.get_state(pid)
+
+    running_entry = %{
+      pid: self(),
+      ref: make_ref(),
+      identifier: issue.identifier,
+      issue: issue,
+      session_id: "thread-redact-turn-redact",
+      turn_count: 1,
+      last_codex_message: nil,
+      last_codex_timestamp: nil,
+      last_codex_event: nil,
+      codex_input_tokens: 0,
+      codex_output_tokens: 0,
+      codex_total_tokens: 0,
+      codex_last_reported_input_tokens: 0,
+      codex_last_reported_output_tokens: 0,
+      codex_last_reported_total_tokens: 0,
+      recent_codex_events: [],
+      started_at: DateTime.utc_now()
+    }
+
+    :sys.replace_state(pid, fn _ ->
+      initial_state
+      |> Map.put(:running, %{issue_id => running_entry})
+      |> Map.put(:claimed, MapSet.put(initial_state.claimed, issue_id))
+    end)
+
+    send(
+      pid,
+      {:codex_worker_update, issue_id,
+       %{
+         event: :notification,
+         payload: %{
+           "method" => "item/commandExecution/outputDelta",
+           "params" => %{
+             "outputDelta" => "OPENAI_API_KEY=sk-live-secret curl https://user:pass@example.org?token=abc123",
+             "authorization" => "Bearer live-token"
+           }
+         },
+         raw: ~s({"api_key":"sk-live-secret","password":"p4ss","access_token":"live-token","url":"https://user:pass@example.org?token=abc123"}),
+         timestamp: DateTime.utc_now()
+       }}
+    )
+
+    snapshot = GenServer.call(pid, :snapshot)
+    assert %{running: [snapshot_entry]} = snapshot
+    rendered_snapshot = inspect(snapshot_entry, limit: :infinity)
+
+    refute rendered_snapshot =~ "sk-live-secret"
+    refute rendered_snapshot =~ "p4ss"
+    refute rendered_snapshot =~ "live-token"
+    refute rendered_snapshot =~ "user:pass"
+    refute rendered_snapshot =~ "token=abc123"
+    assert rendered_snapshot =~ "[REDACTED]"
+  end
+
   test "orchestrator rejects manager steer messages when the worker session changed" do
     issue_id = "issue-steer-mismatch"
 
@@ -351,6 +429,91 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
              Orchestrator.steer_worker(orchestrator_name, "MT-241", "Use stale session", "thread-old-turn-old")
 
     refute_received {:codex_steer, _session_id, _message}
+  end
+
+  test "orchestrator rejects blank, missing, stopped, and non-responsive steer targets" do
+    issue_id = "issue-steer-failures"
+
+    issue = %Issue{
+      id: issue_id,
+      identifier: "MT-243",
+      title: "Steer failure test",
+      description: "Reject unsafe steer attempts",
+      state: "In Progress",
+      url: "https://example.org/issues/MT-243"
+    }
+
+    orchestrator_name = Module.concat(__MODULE__, :SteerFailureOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    initial_state = :sys.get_state(pid)
+
+    worker_pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    running_entry = %{
+      pid: worker_pid,
+      ref: make_ref(),
+      identifier: issue.identifier,
+      issue: issue,
+      session_id: "thread-failure-turn-failure",
+      turn_count: 1,
+      last_codex_message: nil,
+      last_codex_timestamp: nil,
+      last_codex_event: nil,
+      codex_input_tokens: 0,
+      codex_output_tokens: 0,
+      codex_total_tokens: 0,
+      codex_last_reported_input_tokens: 0,
+      codex_last_reported_output_tokens: 0,
+      codex_last_reported_total_tokens: 0,
+      recent_codex_events: [],
+      started_at: DateTime.utc_now()
+    }
+
+    :sys.replace_state(pid, fn _ ->
+      initial_state
+      |> Map.put(:running, %{issue_id => running_entry})
+      |> Map.put(:claimed, MapSet.put(initial_state.claimed, issue_id))
+    end)
+
+    assert {:error, :blank_message} =
+             Orchestrator.steer_worker(orchestrator_name, "MT-243", "  ", "thread-failure-turn-failure")
+
+    assert {:error, :worker_not_running} =
+             Orchestrator.steer_worker(orchestrator_name, "MT-MISSING", "message", "thread-failure-turn-failure")
+
+    Process.exit(worker_pid, :kill)
+    wait_until_dead(worker_pid)
+
+    assert {:error, :worker_not_running} =
+             Orchestrator.steer_worker(orchestrator_name, "MT-243", "message", "thread-failure-turn-failure")
+
+    silent_worker =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    :sys.replace_state(pid, fn state ->
+      put_in(state.running[issue_id].pid, silent_worker)
+    end)
+
+    assert {:error, :worker_not_accepting_steer} =
+             Orchestrator.steer_worker(orchestrator_name, "MT-243", "message", "thread-failure-turn-failure")
+
+    Process.exit(silent_worker, :kill)
   end
 
   test "orchestrator snapshot tracks turn completed usage when present" do
@@ -1710,6 +1873,19 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     deadline_ms = System.monotonic_time(:millisecond) + timeout_ms
     do_wait_for_snapshot(pid, predicate, deadline_ms)
   end
+
+  defp wait_until_dead(pid, attempts \\ 20)
+
+  defp wait_until_dead(pid, attempts) when attempts > 0 do
+    if Process.alive?(pid) do
+      Process.sleep(10)
+      wait_until_dead(pid, attempts - 1)
+    else
+      :ok
+    end
+  end
+
+  defp wait_until_dead(pid, 0), do: refute(Process.alive?(pid))
 
   defp do_wait_for_snapshot(pid, predicate, deadline_ms) do
     snapshot = GenServer.call(pid, :snapshot)

--- a/elixir/test/symphony_elixir/redactor_test.exs
+++ b/elixir/test/symphony_elixir/redactor_test.exs
@@ -49,6 +49,33 @@ defmodule SymphonyElixir.RedactorTest do
                "https://[REDACTED]:[REDACTED]@example.org/path?client_secret=[REDACTED]"
   end
 
+  test "redacts token-bearing URLs and standalone provider tokens" do
+    value =
+      "callback=https://example.org/cb?id_token=id.jwt.secret&refresh_token=refresh-secret" <>
+        "&session_token=session-secret saw sk-live1234567890 and github_pat_1234567890abcdefABCDE"
+
+    redacted = Redactor.redact(value)
+
+    refute redacted =~ "id.jwt.secret"
+    refute redacted =~ "refresh-secret"
+    refute redacted =~ "session-secret"
+    refute redacted =~ "sk-live1234567890"
+    refute redacted =~ "github_pat_1234567890abcdefABCDE"
+    assert redacted =~ "id_token=[REDACTED]"
+    assert redacted =~ "refresh_token=[REDACTED]"
+    assert redacted =~ "session_token=[REDACTED]"
+  end
+
+  test "redacts secret-ish JSON string fields beyond exact key names" do
+    value = ~s({"stripe_secret":"sk-live1234567890","nested_access_token":"tok-secret","safe":"visible"})
+
+    redacted = Redactor.redact(value)
+
+    refute redacted =~ "sk-live1234567890"
+    refute redacted =~ "tok-secret"
+    assert redacted =~ ~s("safe":"visible")
+  end
+
   test "leaves scalar, struct, and non-secret JSON values intact" do
     timestamp = ~U[2026-05-01 00:00:00Z]
 

--- a/elixir/test/symphony_elixir/redactor_test.exs
+++ b/elixir/test/symphony_elixir/redactor_test.exs
@@ -1,0 +1,59 @@
+defmodule SymphonyElixir.RedactorTest do
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.Redactor
+
+  test "redacts sensitive nested values while preserving safe shapes" do
+    timestamp = ~U[2026-05-01 00:00:00Z]
+
+    assert Redactor.redact(%{
+             1 => "numeric-key",
+             safe: "visible",
+             count: 3,
+             token: "secret-token",
+             credentials: %{username: "user", password: "p4ss"},
+             private_key: ["line1", "line2"],
+             session_token: timestamp,
+             nested: [%{api_key: "sk-live-secret"}, %{url: "https://example.org/plain"}]
+           }) == %{
+             1 => "numeric-key",
+             safe: "visible",
+             count: 3,
+             token: "[REDACTED]",
+             credentials: "[REDACTED]",
+             private_key: "[REDACTED]",
+             session_token: "[REDACTED]",
+             nested: [%{api_key: "[REDACTED]"}, %{url: "https://example.org/plain"}]
+           }
+  end
+
+  test "redacts JSON string payloads and freeform secret patterns" do
+    json =
+      ~s({"api_key":"sk-live-secret","password":"p4ss","items":[{"access_token":"tok"}],"url":"https://user:pass@example.org?token=abc123"})
+
+    redacted_json = Redactor.redact(json)
+
+    refute redacted_json =~ "sk-live-secret"
+    refute redacted_json =~ "p4ss"
+    refute redacted_json =~ ~s("tok")
+    refute redacted_json =~ "user:pass"
+    refute redacted_json =~ "token=abc123"
+    assert redacted_json =~ "[REDACTED]"
+
+    freeform =
+      "Authorization: Bearer live-token OPENAI_API_KEY=sk-live " <>
+        "https://user:pass@example.org/path?client_secret=abc"
+
+    assert Redactor.redact(freeform) ==
+             "Authorization: Bearer [REDACTED] OPENAI_API_KEY=[REDACTED] " <>
+               "https://[REDACTED]:[REDACTED]@example.org/path?client_secret=[REDACTED]"
+  end
+
+  test "leaves scalar, struct, and non-secret JSON values intact" do
+    timestamp = ~U[2026-05-01 00:00:00Z]
+
+    assert Redactor.redact(42) == 42
+    assert Redactor.redact(timestamp) == timestamp
+    assert Redactor.redact(~s(["safe","values"])) == ~s(["safe","values"])
+  end
+end


### PR DESCRIPTION
#### Context

Managers need a readable worker detail view and auditable steering for active Codex workers.

#### TL;DR

*Adds worker detail timeline UI and session-scoped Codex steer messages, with sanitized raw event details and an exposed-dashboard steer gate.*

#### Summary

- Add `/workers/:issue_identifier` LiveView detail pages with readable Codex timelines and raw payload panes.
- Track bounded Codex timelines and manager steer audit events in orchestrator snapshots.
- Send steer messages through `turn/steer` with required active-session and turn checks.
- Reject missing, blank, stale, or changed steer session ids before sending to worker processes.
- Redact secret-like Codex/app-server event values before storage and API/UI presentation.
- Require an operator token for steer submissions when the dashboard is bound to a non-loopback host.
- Merge current `origin/main` command-watchdog and active-runtime state without losing ALB-18 timeline data.

#### Alternatives

- Considered a JSON POST steer endpoint, but kept writes behind LiveView for safety.
- Considered fire-and-forget steering, but now wait for worker acceptance and Codex response.
- Considered preserving truly raw events in the dashboard, but the UI/API now expose sanitized payloads only.

#### Test Plan

- [ ] `make -C elixir all` (not run locally: `make` is unavailable in this Windows shell; GitHub `make-all` pending on `35336eb`)
- [ ] `make windows-native-test` (not run locally: `make` is unavailable in this Windows shell; GitHub `windows-native-test` pending on `35336eb`)
- [x] `mix test test/symphony_elixir/orchestrator_status_test.exs`
- [x] `mix test test/symphony_elixir/extensions_test.exs`
- [x] `mix lint` (exits 0; reports known Windows line-ending consistency warnings)
- [x] `mix compile --warnings-as-errors` (passes; existing Phoenix LiveView colocated JS symlink warning on Windows)
- [x] `mix format --check-formatted lib/symphony_elixir/orchestrator.ex lib/symphony_elixir_web/live/dashboard_live.ex test/symphony_elixir/orchestrator_status_test.exs test/symphony_elixir/extensions_test.exs`
- [x] `git diff --check`
- [x] `mix pr_body.check --file <updated PR body>`

Notes:
- Merged latest `origin/main` in `a1206c6` after main advanced to `384a36f`. Manual conflicts were `elixir/lib/symphony_elixir/orchestrator.ex` and `elixir/test/symphony_elixir/orchestrator_status_test.exs`.
- Resolution keeps both ALB-18 `recent_codex_events`/redaction/steer audit state and main's `CommandWatchdog` snapshot/update behavior.
- Previous independent review found a merge blocker: LiveView double-counted active runtime after main added active runtime to `codex_totals`. Fixed in `1f6033e` with a LiveView regression test.
- Manager review then blocked `a1206c6` because crafted LiveView steer events could omit `steer[session_id]`. Fixed in `35336eb`.
- Full local `test/symphony_elixir/app_server_test.exs` fails in this Windows shell due existing fake POSIX executable/symlink limitations: `{:unsupported_windows_port_command, .../fake-codex}` and symlink permission errors. GitHub `make-all` covers this suite.
- Phoenix LiveView compile emits the existing Windows symlink warning for colocated JS.

SubAgent review:
- Earlier independent review for `e208447`: no blocking findings; residual risk noted that redaction is regex/heuristic based.
- Merge repair review for `0377306`: BLOCKED on LiveView runtime double-counting.
- Follow-up review for `1f6033e`: no blocking findings.
- Merge refresh review for `a1206c6`: no blocking findings.
- Session-id repair review for `35336eb`: no blocking findings; verified missing/blank session ids are rejected before any worker send and covered by tests.
