### PR TITLE
fix(windows): separate terminal dashboard from audit logs

### DIFF
--- a/elixir/lib/symphony_elixir/log_file.ex
+++ b/elixir/lib/symphony_elixir/log_file.ex
@@ -68,7 +68,12 @@ defmodule SymphonyElixir.LogFile do
   defp disk_log_handler_config(path, max_bytes, max_files) do
     %{
       level: :all,
-      formatter: {:logger_formatter, %{single_line: true}},
+      formatter:
+        {SymphonyElixir.LogFile.Formatter,
+         %{
+           single_line: true,
+           template: [:time, " ", :level, " event_id=", :event_id, " ", :msg, "\n"]
+         }},
       config: %{
         file: String.to_charlist(path),
         type: :wrap,
@@ -76,5 +81,34 @@ defmodule SymphonyElixir.LogFile do
         max_no_files: max_files
       }
     }
+  end
+end
+
+defmodule SymphonyElixir.LogFile.Formatter do
+  @moduledoc false
+
+  @osc_escape_pattern ~r/\e\].*?(?:\a|\e\\)/
+  @ansi_escape_pattern ~r/\e\[[0-?]*[ -\/]*[@-~]/
+  @control_pattern ~r/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/
+
+  @spec format(:logger.log_event(), map()) :: String.t()
+  def format(%{meta: metadata} = log_event, config) when is_map(metadata) do
+    log_event
+    |> put_in([:meta, :event_id], Map.get_lazy(metadata, :event_id, &event_id/0))
+    |> :logger_formatter.format(config)
+    |> IO.iodata_to_binary()
+    |> sanitize()
+  end
+
+  @spec sanitize(String.t()) :: String.t()
+  def sanitize(value) when is_binary(value) do
+    value
+    |> String.replace(@osc_escape_pattern, "")
+    |> String.replace(@ansi_escape_pattern, "")
+    |> String.replace(@control_pattern, "")
+  end
+
+  defp event_id do
+    ~c"log-" ++ Integer.to_charlist(System.unique_integer([:positive, :monotonic]))
   end
 end

--- a/elixir/lib/symphony_elixir/log_file.ex
+++ b/elixir/lib/symphony_elixir/log_file.ex
@@ -90,6 +90,7 @@ defmodule SymphonyElixir.LogFile.Formatter do
   @osc_escape_pattern ~r/\e\].*?(?:\a|\e\\)/
   @ansi_escape_pattern ~r/\e\[[0-?]*[ -\/]*[@-~]/
   @control_pattern ~r/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/
+  @carriage_return_pattern ~r/\r(?!\n)/
 
   @spec format(:logger.log_event(), map()) :: String.t()
   def format(%{meta: metadata} = log_event, config) when is_map(metadata) do
@@ -105,6 +106,8 @@ defmodule SymphonyElixir.LogFile.Formatter do
     value
     |> String.replace(@osc_escape_pattern, "")
     |> String.replace(@ansi_escape_pattern, "")
+    |> String.replace(@carriage_return_pattern, "")
+    |> String.replace("\r\n", "\n")
     |> String.replace(@control_pattern, "")
   end
 

--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -128,6 +128,14 @@ defmodule SymphonyElixir.StatusDashboard do
 
   @spec render_offline_status() :: :ok
   def render_offline_status do
+    if terminal_dashboard_disabled?() do
+      :ok
+    else
+      render_offline_status_to_terminal()
+    end
+  end
+
+  defp render_offline_status_to_terminal do
     content =
       [
         colorize("╭─ SYMPHONY STATUS", @ansi_bold),
@@ -1934,12 +1942,23 @@ defmodule SymphonyElixir.StatusDashboard do
   defp dashboard_enabled? do
     if Code.ensure_loaded?(Mix) and function_exported?(Mix, :env, 0) do
       try do
-        Mix.env() != :test
+        Mix.env() != :test and not terminal_dashboard_disabled?()
       rescue
-        _ -> true
+        _ -> not terminal_dashboard_disabled?()
       end
     else
-      true
+      not terminal_dashboard_disabled?()
+    end
+  end
+
+  @doc false
+  @spec terminal_dashboard_disabled_for_test?() :: boolean()
+  def terminal_dashboard_disabled_for_test?, do: terminal_dashboard_disabled?()
+
+  defp terminal_dashboard_disabled? do
+    case System.get_env("SYMPHONY_DISABLE_TERMINAL_DASHBOARD") do
+      value when value in [nil, "", "0", "false", "FALSE", "False"] -> false
+      _ -> true
     end
   end
 

--- a/elixir/scripts/start-windows-native.ps1
+++ b/elixir/scripts/start-windows-native.ps1
@@ -2,10 +2,30 @@ param(
   [string]$WorkflowPath = ".\WORKFLOW.windows.md",
   [int]$Port = 4011,
   [string]$LogsRoot = "$env:LOCALAPPDATA\Symphony\logs",
-  [string]$Mise = ""
+  [string]$Mise = "",
+  [switch]$TerminalDashboard
 )
 
 $ErrorActionPreference = "Stop"
+$utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+$OutputEncoding = $utf8NoBom
+
+try {
+  [Console]::InputEncoding = $utf8NoBom
+  [Console]::OutputEncoding = $utf8NoBom
+} catch {
+  Write-Warning "Unable to force console UTF-8 encoding: $($_.Exception.Message)"
+}
+
+if (Get-Command chcp.com -ErrorAction SilentlyContinue) {
+  & chcp.com 65001 | Out-Null
+}
+
+if ($TerminalDashboard) {
+  Remove-Item Env:\SYMPHONY_DISABLE_TERMINAL_DASHBOARD -ErrorAction SilentlyContinue
+} else {
+  $env:SYMPHONY_DISABLE_TERMINAL_DASHBOARD = "1"
+}
 
 if (-not $env:LINEAR_API_KEY) {
   $env:LINEAR_API_KEY = [Environment]::GetEnvironmentVariable("LINEAR_API_KEY", "User")
@@ -29,6 +49,10 @@ if (-not $Mise) {
 }
 
 New-Item -ItemType Directory -Force -Path $LogsRoot | Out-Null
+
+$AuditLog = Join-Path $LogsRoot "log\symphony.log"
+Write-Host "Symphony audit log: $AuditLog"
+Write-Host "Terminal dashboard: $(if ($TerminalDashboard) { 'enabled' } else { "disabled; open http://127.0.0.1:$Port/ or pass -TerminalDashboard" })"
 
 & $Mise exec -- escript .\bin\symphony $WorkflowPath `
   --port $Port `

--- a/elixir/test/symphony_elixir/log_file_test.exs
+++ b/elixir/test/symphony_elixir/log_file_test.exs
@@ -2,6 +2,7 @@ defmodule SymphonyElixir.LogFileTest do
   use ExUnit.Case, async: true
 
   alias SymphonyElixir.LogFile
+  alias SymphonyElixir.LogFile.Formatter
 
   test "default_log_file/0 uses the current working directory" do
     assert LogFile.default_log_file() == Path.join(File.cwd!(), "log/symphony.log")
@@ -9,5 +10,29 @@ defmodule SymphonyElixir.LogFileTest do
 
   test "default_log_file/1 builds the log path under a custom root" do
     assert LogFile.default_log_file("/tmp/symphony-logs") == "/tmp/symphony-logs/log/symphony.log"
+  end
+
+  test "file logger formatter emits plain single-line audit events" do
+    event = %{
+      level: :info,
+      msg:
+        {:string,
+         "SYMPHONY STATUS " <>
+           IO.ANSI.red() <> "red" <> IO.ANSI.reset() <> <<27>> <> "]0;title\a" <> <<0>>},
+      meta: %{time: 1_771_000_000_000_000}
+    }
+
+    line =
+      Formatter.format(event, %{
+        single_line: true,
+        template: [:time, " ", :level, " event_id=", :event_id, " ", :msg, "\n"]
+      })
+
+    assert line =~ " info event_id=log-"
+    assert line =~ "SYMPHONY STATUS red"
+    refute line =~ IO.ANSI.red()
+    refute line =~ IO.ANSI.reset()
+    refute line =~ "title"
+    refute line =~ <<0>>
   end
 end

--- a/elixir/test/symphony_elixir/log_file_test.exs
+++ b/elixir/test/symphony_elixir/log_file_test.exs
@@ -35,4 +35,22 @@ defmodule SymphonyElixir.LogFileTest do
     refute line =~ "title"
     refute line =~ <<0>>
   end
+
+  test "file logger formatter removes carriage-return redraw artifacts" do
+    event = %{
+      level: :info,
+      msg: {:string, "progress 10%\rprogress 20%\rprogress complete"},
+      meta: %{time: 1_771_000_000_000_000, event_id: ~c"event-123"}
+    }
+
+    line =
+      Formatter.format(event, %{
+        single_line: true,
+        template: [:time, " ", :level, " event_id=", :event_id, " ", :msg, "\n"]
+      })
+
+    assert line =~ " info event_id=event-123 progress 10%progress 20%progress complete\n"
+    refute line =~ "\r"
+    assert String.ends_with?(line, "\n")
+  end
 end

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -971,6 +971,22 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     refute rendered =~ "Timestamp:"
   end
 
+  test "terminal dashboard can be disabled for captured Windows runtime logs" do
+    previous = System.get_env("SYMPHONY_DISABLE_TERMINAL_DASHBOARD")
+    System.put_env("SYMPHONY_DISABLE_TERMINAL_DASHBOARD", "1")
+
+    on_exit(fn -> restore_env("SYMPHONY_DISABLE_TERMINAL_DASHBOARD", previous) end)
+
+    assert StatusDashboard.terminal_dashboard_disabled_for_test?()
+
+    rendered =
+      ExUnit.CaptureIO.capture_io(fn ->
+        assert :ok = StatusDashboard.render_offline_status()
+      end)
+
+    assert rendered == ""
+  end
+
   test "status dashboard renders linear project link in header" do
     snapshot_data =
       {:ok,


### PR DESCRIPTION
#### Context

Windows runtime logs captured terminal dashboard redraws and mojibake instead of a readable audit trail.

#### TL;DR

*Keep Windows TUI frames out of audit logs and make file logs plain and traceable.*

#### Summary

- Add a file logger formatter that strips ANSI/control bytes and writes event ids.
- Disable terminal dashboard frames by default in the Windows launcher.
- Force UTF-8 PowerShell console encoding before launching Symphony.
- Normalize carriage returns out of persistent audit log output so progress redraws stay line-oriented.
- Add focused formatter and dashboard-disable coverage.

#### Alternatives

- Kept the existing web dashboard available instead of persisting terminal snapshots.
- Used the existing rotating log sink rather than adding another audit file path.

#### Test Plan

- [x] GitHub `make-all` passed on commit `5e4c789`.
- [x] GitHub `validate-pr-description` passed on commit `5e4c789`.
- [x] GitHub `windows-native-test` passed on commit `5e4c789`.
- [x] `mix format lib/symphony_elixir/log_file.ex test/symphony_elixir/log_file_test.exs`
- [x] `mix test test/symphony_elixir/log_file_test.exs`
- [x] `mix test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs`
- [x] `mix dialyzer --format short`
- [x] `git diff --check`
- [x] PowerShell scriptblock parse of `scripts/start-windows-native.ps1`

Review:
- SubAgent review completed on the carriage-return repair; no blockers found.
- Previous SubAgent review completed on the broader dashboard/log separation; follow-up notes for OSC escape stripping and launcher dashboard wording were addressed.

Notes:
- `make windows-native-test` could not run directly because `make` is not installed in this Windows shell; the same ExUnit files from the target were run directly and passed.
- Local `mix lint` was previously blocked by broad CRLF consistency warnings in this Windows worktree, but the Linux CI `make-all` lint passed on a clean clone.

Closes #21