### PR TITLE
Summarize worker rate-limit state in dashboard

### DIFF
--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -1153,6 +1153,8 @@ defmodule SymphonyElixir.Orchestrator do
           last_codex_timestamp: metadata.last_codex_timestamp,
           last_codex_message: metadata.last_codex_message,
           last_codex_event: metadata.last_codex_event,
+          codex_rate_limits: Map.get(metadata, :codex_rate_limits),
+          codex_rate_limits_updated_at: Map.get(metadata, :codex_rate_limits_updated_at),
           runtime_seconds: running_seconds(metadata.started_at, now)
         }
       end)
@@ -1202,6 +1204,7 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp integrate_codex_update(running_entry, %{event: event, timestamp: timestamp} = update) do
     token_delta = extract_token_delta(running_entry, update)
+    rate_limits = extract_rate_limits(update)
     codex_input_tokens = Map.get(running_entry, :codex_input_tokens, 0)
     codex_output_tokens = Map.get(running_entry, :codex_output_tokens, 0)
     codex_total_tokens = Map.get(running_entry, :codex_total_tokens, 0)
@@ -1225,10 +1228,19 @@ defmodule SymphonyElixir.Orchestrator do
         codex_last_reported_output_tokens: max(last_reported_output, token_delta.output_reported),
         codex_last_reported_total_tokens: max(last_reported_total, token_delta.total_reported),
         turn_count: turn_count_for_update(turn_count, running_entry.session_id, update)
-      }),
+      })
+      |> maybe_put_rate_limits(rate_limits, timestamp),
       token_delta
     }
   end
+
+  defp maybe_put_rate_limits(running_entry, %{} = rate_limits, timestamp) do
+    running_entry
+    |> Map.put(:codex_rate_limits, rate_limits)
+    |> Map.put(:codex_rate_limits_updated_at, timestamp)
+  end
+
+  defp maybe_put_rate_limits(running_entry, _rate_limits, _timestamp), do: running_entry
 
   defp codex_app_server_pid_for_update(_existing, %{codex_app_server_pid: pid})
        when is_binary(pid),
@@ -1456,6 +1468,8 @@ defmodule SymphonyElixir.Orchestrator do
       rate_limits_from_payload(Map.get(update, :rate_limits)) ||
       rate_limits_from_payload(update[:payload]) ||
       rate_limits_from_payload(Map.get(update, "payload")) ||
+      rate_limits_from_payload(map_at_path(update, ["payload", "params", "rateLimits"])) ||
+      rate_limits_from_payload(map_at_path(update, [:payload, :params, :rateLimits])) ||
       rate_limits_from_payload(update)
   end
 
@@ -1554,10 +1568,44 @@ defmodule SymphonyElixir.Orchestrator do
         &Map.has_key?(payload, &1)
       )
 
-    !is_nil(limit_id) and has_buckets
+    has_recognized_bucket =
+      Enum.any?(
+        ["primary", :primary, "secondary", :secondary, "credits", :credits],
+        fn key -> rate_limit_bucket?(Map.get(payload, key)) end
+      )
+
+    has_buckets and (!is_nil(limit_id) or has_recognized_bucket)
   end
 
   defp rate_limits_map?(_payload), do: false
+
+  defp rate_limit_bucket?(bucket) when is_map(bucket) do
+    Enum.any?(
+      [
+        "remaining",
+        :remaining,
+        "limit",
+        :limit,
+        "usedPercent",
+        :usedPercent,
+        "windowDurationMins",
+        :windowDurationMins,
+        "reset_in_seconds",
+        :reset_in_seconds,
+        "resetInSeconds",
+        :resetInSeconds,
+        "has_credits",
+        :has_credits,
+        "unlimited",
+        :unlimited,
+        "balance",
+        :balance
+      ],
+      &Map.has_key?(bucket, &1)
+    )
+  end
+
+  defp rate_limit_bucket?(_bucket), do: false
 
   defp explicit_map_at_paths(payload, paths) when is_map(payload) and is_list(paths) do
     Enum.find_value(paths, fn path ->

--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -925,7 +925,7 @@ defmodule SymphonyElixir.StatusDashboard do
     case worker_rate_limit_summary(running) do
       {:fresh, summary} -> colorize(summary, @ansi_cyan)
       {:stale, summary} -> colorize("unavailable (#{summary})", @ansi_gray)
-      {:unknown, summary} when is_nil(rate_limits) -> colorize("unavailable (#{summary})", @ansi_gray)
+      {:unknown, summary} -> colorize("unavailable (#{summary})", @ansi_gray)
       _ -> format_global_rate_limits(rate_limits)
     end
   end

--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -13,6 +13,7 @@ defmodule SymphonyElixir.StatusDashboard do
   @minimum_idle_rerender_ms 1_000
   @throughput_window_ms 5_000
   @throughput_graph_window_ms 10 * 60 * 1000
+  @rate_limit_fresh_ms 10 * 60 * 1000
   @throughput_graph_columns 24
   @sparkline_blocks ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"]
   @running_id_width 8
@@ -362,7 +363,7 @@ defmodule SymphonyElixir.StatusDashboard do
              colorize("out #{format_count(codex_output_tokens)}", @ansi_yellow) <>
              colorize(" | ", @ansi_gray) <>
              colorize("total #{format_count(codex_total_tokens)}", @ansi_yellow),
-           colorize("│ Rate Limits: ", @ansi_bold) <> format_rate_limits(rate_limits),
+           colorize("│ Rate Limits: ", @ansi_bold) <> format_rate_limits(rate_limits, running),
            project_link_lines,
            project_refresh_line,
            colorize("├─ Running", @ansi_bold),
@@ -920,9 +921,18 @@ defmodule SymphonyElixir.StatusDashboard do
   defp in_bucket?(timestamp, bucket_start, bucket_end, false),
     do: timestamp >= bucket_start and timestamp < bucket_end
 
-  defp format_rate_limits(nil), do: colorize("unavailable", @ansi_gray)
+  defp format_rate_limits(rate_limits, running) do
+    case worker_rate_limit_summary(running) do
+      {:fresh, summary} -> colorize(summary, @ansi_cyan)
+      {:stale, summary} -> colorize("unavailable (#{summary})", @ansi_gray)
+      {:unknown, summary} when is_nil(rate_limits) -> colorize("unavailable (#{summary})", @ansi_gray)
+      _ -> format_global_rate_limits(rate_limits)
+    end
+  end
 
-  defp format_rate_limits(rate_limits) when is_map(rate_limits) do
+  defp format_global_rate_limits(nil), do: colorize("unavailable", @ansi_gray)
+
+  defp format_global_rate_limits(rate_limits) when is_map(rate_limits) do
     limit_id =
       map_value(rate_limits, ["limit_id", :limit_id, "limit_name", :limit_name]) ||
         "unknown"
@@ -940,7 +950,7 @@ defmodule SymphonyElixir.StatusDashboard do
       colorize(credits, @ansi_green)
   end
 
-  defp format_rate_limits(other) do
+  defp format_global_rate_limits(other) do
     other
     |> inspect(limit: 10)
     |> truncate(80)
@@ -969,8 +979,13 @@ defmodule SymphonyElixir.StatusDashboard do
         :resetsAt
       ])
 
+    percent_text = format_rate_limit_bucket_percent(bucket)
+
     base =
       cond do
+        is_binary(percent_text) ->
+          percent_text
+
         integer_like?(remaining) and integer_like?(limit) ->
           "#{format_count(remaining)}/#{format_count(limit)}"
 
@@ -995,6 +1010,78 @@ defmodule SymphonyElixir.StatusDashboard do
   end
 
   defp format_rate_limit_bucket(other), do: to_string(other)
+
+  defp format_rate_limit_bucket_percent(bucket) when is_map(bucket) do
+    used_percent = map_value(bucket, ["usedPercent", :usedPercent])
+    window_mins = map_value(bucket, ["windowDurationMins", :windowDurationMins])
+
+    cond do
+      is_number(used_percent) and is_integer(window_mins) ->
+        "#{format_number(used_percent)}% / #{window_mins}m"
+
+      is_number(used_percent) ->
+        "#{format_number(used_percent)}% used"
+
+      true ->
+        nil
+    end
+  end
+
+  defp worker_rate_limit_summary(running) when is_list(running) do
+    workers = Enum.map(running, &worker_rate_limit_status/1)
+    fresh = Enum.filter(workers, &match?(%{status: :fresh}, &1))
+    stale = Enum.filter(workers, &match?(%{status: :stale}, &1))
+
+    cond do
+      fresh != [] ->
+        known =
+          fresh
+          |> Enum.map_join(" | ", fn worker ->
+            "#{worker.identifier} #{format_rate_limits_summary(worker.rate_limits)}"
+          end)
+
+        unknown_count = length(workers) - length(fresh)
+        unknown_suffix = if unknown_count > 0, do: " | unknown/stale #{unknown_count}", else: ""
+        {:fresh, "workers #{length(fresh)}/#{length(workers)} known | #{known}#{unknown_suffix}"}
+
+      stale != [] ->
+        stale_workers = Enum.map_join(stale, ", ", & &1.identifier)
+        {:stale, "worker data stale: #{stale_workers}"}
+
+      running == [] ->
+        :none
+
+      true ->
+        {:unknown, "no worker rate-limit data"}
+    end
+  end
+
+  defp worker_rate_limit_status(running_entry) when is_map(running_entry) do
+    rate_limits = Map.get(running_entry, :codex_rate_limits)
+    updated_at = Map.get(running_entry, :codex_rate_limits_updated_at) || Map.get(running_entry, :last_codex_timestamp)
+    identifier = Map.get(running_entry, :identifier) || Map.get(running_entry, :issue_id) || "unknown"
+
+    cond do
+      not is_map(rate_limits) ->
+        %{status: :unknown, identifier: identifier}
+
+      rate_limit_fresh?(updated_at) ->
+        %{status: :fresh, identifier: identifier, rate_limits: rate_limits}
+
+      true ->
+        %{status: :stale, identifier: identifier, rate_limits: rate_limits}
+    end
+  end
+
+  defp worker_rate_limit_status(_running_entry), do: %{status: :unknown, identifier: "unknown"}
+
+  defp rate_limit_fresh?(nil), do: true
+
+  defp rate_limit_fresh?(%DateTime{} = updated_at) do
+    DateTime.diff(DateTime.utc_now(), updated_at, :millisecond) <= @rate_limit_fresh_ms
+  end
+
+  defp rate_limit_fresh?(_updated_at), do: true
 
   defp format_rate_limit_credits(nil), do: "credits n/a"
 
@@ -1635,22 +1722,44 @@ defmodule SymphonyElixir.StatusDashboard do
   defp format_rate_limits_summary(_rate_limits), do: "n/a"
 
   defp format_rate_limit_bucket_summary(bucket) when is_map(bucket) do
-    used_percent = map_value(bucket, ["usedPercent", :usedPercent])
-    window_mins = map_value(bucket, ["windowDurationMins", :windowDurationMins])
+    format_rate_limit_bucket_percent(bucket) || format_rate_limit_remaining_summary(bucket)
+  end
+
+  defp format_rate_limit_bucket_summary(_bucket), do: nil
+
+  defp format_rate_limit_remaining_summary(bucket) when is_map(bucket) do
+    remaining = map_value(bucket, ["remaining", :remaining])
+    limit = map_value(bucket, ["limit", :limit])
+    reset_value = rate_limit_reset_value(bucket)
 
     cond do
-      is_number(used_percent) and is_integer(window_mins) ->
-        "#{used_percent}% / #{window_mins}m"
+      integer_like?(remaining) and integer_like?(limit) and is_nil(reset_value) ->
+        "#{format_count(remaining)}/#{format_count(limit)}"
 
-      is_number(used_percent) ->
-        "#{used_percent}% used"
+      integer_like?(remaining) and integer_like?(limit) ->
+        "#{format_count(remaining)}/#{format_count(limit)} reset #{format_reset_value(reset_value)}"
 
       true ->
         nil
     end
   end
 
-  defp format_rate_limit_bucket_summary(_bucket), do: nil
+  defp rate_limit_reset_value(bucket) when is_map(bucket) do
+    map_value(bucket, [
+      "reset_in_seconds",
+      :reset_in_seconds,
+      "resetInSeconds",
+      :resetInSeconds,
+      "reset_at",
+      :reset_at,
+      "resetAt",
+      :resetAt,
+      "resets_at",
+      :resets_at,
+      "resetsAt",
+      :resetsAt
+    ])
+  end
 
   defp format_error_value(%{"message" => message}) when is_binary(message), do: message
   defp format_error_value(%{message: message}) when is_binary(message), do: message

--- a/elixir/test/fixtures/status_dashboard_snapshots/backoff_queue.evidence.md
+++ b/elixir/test/fixtures/status_dashboard_snapshots/backoff_queue.evidence.md
@@ -4,7 +4,7 @@
 │ Throughput: 15 tps
 │ Runtime: 45m 0s
 │ Tokens: in 18,000 | out 2,200 | total 20,200
-│ Rate Limits: gpt-5 | primary 0/20,000 reset 95s | secondary 0/60 reset 45s | credits none
+│ Rate Limits: unavailable (no worker rate-limit data)
 │ Project: https://linear.app/project/project/issues
 │ Next refresh: n/a
 ├─ Running

--- a/elixir/test/fixtures/status_dashboard_snapshots/backoff_queue.snapshot.txt
+++ b/elixir/test/fixtures/status_dashboard_snapshots/backoff_queue.snapshot.txt
@@ -3,7 +3,7 @@
 \e[1m│ Throughput: \e[0m\e[36m15 tps\e[0m
 \e[1m│ Runtime: \e[0m\e[35m45m 0s\e[0m
 \e[1m│ Tokens: \e[0m\e[33min 18,000\e[0m\e[90m | \e[0m\e[33mout 2,200\e[0m\e[90m | \e[0m\e[33mtotal 20,200\e[0m
-\e[1m│ Rate Limits: \e[0m\e[33mgpt-5\e[0m\e[90m | \e[0m\e[36mprimary 0/20,000 reset 95s\e[0m\e[90m | \e[0m\e[36msecondary 0/60 reset 45s\e[0m\e[90m | \e[0m\e[32mcredits none\e[0m
+\e[1m│ Rate Limits: \e[0m\e[90munavailable (no worker rate-limit data)\e[0m
 \e[1m│ Project: \e[0m\e[36mhttps://linear.app/project/project/issues\e[0m
 \e[1m│ Next refresh: \e[0m\e[90mn/a\e[0m
 \e[1m├─ Running\e[0m

--- a/elixir/test/fixtures/status_dashboard_snapshots/credits_unlimited.evidence.md
+++ b/elixir/test/fixtures/status_dashboard_snapshots/credits_unlimited.evidence.md
@@ -4,7 +4,7 @@
 │ Throughput: 42 tps
 │ Runtime: 1m 15s
 │ Tokens: in 90 | out 12 | total 102
-│ Rate Limits: priority-tier | primary 100/100 reset 1s | secondary 500/500 reset 1s | credits unlimited
+│ Rate Limits: unavailable (no worker rate-limit data)
 │ Project: https://linear.app/project/project/issues
 │ Next refresh: n/a
 ├─ Running

--- a/elixir/test/fixtures/status_dashboard_snapshots/credits_unlimited.snapshot.txt
+++ b/elixir/test/fixtures/status_dashboard_snapshots/credits_unlimited.snapshot.txt
@@ -3,7 +3,7 @@
 \e[1m│ Throughput: \e[0m\e[36m42 tps\e[0m
 \e[1m│ Runtime: \e[0m\e[35m1m 15s\e[0m
 \e[1m│ Tokens: \e[0m\e[33min 90\e[0m\e[90m | \e[0m\e[33mout 12\e[0m\e[90m | \e[0m\e[33mtotal 102\e[0m
-\e[1m│ Rate Limits: \e[0m\e[33mpriority-tier\e[0m\e[90m | \e[0m\e[36mprimary 100/100 reset 1s\e[0m\e[90m | \e[0m\e[36msecondary 500/500 reset 1s\e[0m\e[90m | \e[0m\e[32mcredits unlimited\e[0m
+\e[1m│ Rate Limits: \e[0m\e[90munavailable (no worker rate-limit data)\e[0m
 \e[1m│ Project: \e[0m\e[36mhttps://linear.app/project/project/issues\e[0m
 \e[1m│ Next refresh: \e[0m\e[90mn/a\e[0m
 \e[1m├─ Running\e[0m

--- a/elixir/test/fixtures/status_dashboard_snapshots/super_busy.evidence.md
+++ b/elixir/test/fixtures/status_dashboard_snapshots/super_busy.evidence.md
@@ -4,7 +4,7 @@
 │ Throughput: 1,842 tps
 │ Runtime: 72m 1s
 │ Tokens: in 250,000 | out 18,500 | total 268,500
-│ Rate Limits: gpt-5 | primary 12,345/20,000 reset 30s | secondary 45/60 reset 12s | credits 9876.50
+│ Rate Limits: unavailable (no worker rate-limit data)
 │ Project: https://linear.app/project/project/issues
 │ Next refresh: n/a
 ├─ Running

--- a/elixir/test/fixtures/status_dashboard_snapshots/super_busy.snapshot.txt
+++ b/elixir/test/fixtures/status_dashboard_snapshots/super_busy.snapshot.txt
@@ -3,7 +3,7 @@
 \e[1m│ Throughput: \e[0m\e[36m1,842 tps\e[0m
 \e[1m│ Runtime: \e[0m\e[35m72m 1s\e[0m
 \e[1m│ Tokens: \e[0m\e[33min 250,000\e[0m\e[90m | \e[0m\e[33mout 18,500\e[0m\e[90m | \e[0m\e[33mtotal 268,500\e[0m
-\e[1m│ Rate Limits: \e[0m\e[33mgpt-5\e[0m\e[90m | \e[0m\e[36mprimary 12,345/20,000 reset 30s\e[0m\e[90m | \e[0m\e[36msecondary 45/60 reset 12s\e[0m\e[90m | \e[0m\e[32mcredits 9876.50\e[0m
+\e[1m│ Rate Limits: \e[0m\e[90munavailable (no worker rate-limit data)\e[0m
 \e[1m│ Project: \e[0m\e[36mhttps://linear.app/project/project/issues\e[0m
 \e[1m│ Next refresh: \e[0m\e[90mn/a\e[0m
 \e[1m├─ Running\e[0m

--- a/elixir/test/support/snapshot_support.exs
+++ b/elixir/test/support/snapshot_support.exs
@@ -34,7 +34,7 @@ defmodule SymphonyElixir.TestSupport.Snapshot do
     else
       case File.read(path) do
         {:ok, expected} ->
-          assert normalized == expected,
+          assert normalized == normalize_content(expected),
                  "Snapshot mismatch for `#{relative_path}`. #{@update_snapshot_hint}"
 
         {:error, :enoent} ->

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -437,10 +437,8 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     end)
 
     rate_limits = %{
-      "limit_id" => "codex",
-      "primary" => %{"remaining" => 90, "limit" => 100},
-      "secondary" => nil,
-      "credits" => %{"has_credits" => false, "unlimited" => false, "balance" => nil}
+      "primary" => %{"usedPercent" => 54, "windowDurationMins" => 300},
+      "secondary" => %{"usedPercent" => 12, "windowDurationMins" => 60}
     }
 
     send(
@@ -449,15 +447,9 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
        %{
          event: :notification,
          payload: %{
-           "method" => "codex/event/token_count",
+           "method" => "account/rateLimits/updated",
            "params" => %{
-             "msg" => %{
-               "type" => "event_msg",
-               "payload" => %{
-                 "type" => "token_count",
-                 "rate_limits" => rate_limits
-               }
-             }
+             "rateLimits" => rate_limits
            }
          },
          timestamp: DateTime.utc_now()
@@ -466,6 +458,9 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
     snapshot = GenServer.call(pid, :snapshot)
     assert snapshot.rate_limits == rate_limits
+
+    assert [%{codex_rate_limits: ^rate_limits, codex_rate_limits_updated_at: %DateTime{}}] =
+             snapshot.running
   end
 
   test "orchestrator token accounting prefers total_token_usage over last_token_usage in token_count payloads" do

--- a/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
+++ b/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
@@ -194,8 +194,89 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
     Snapshot.assert_dashboard_snapshot!("credits_unlimited", render_snapshot(snapshot_data, 42.0))
   end
 
+  test "rate-limit header aggregates fresh worker rate-limit data" do
+    snapshot_data =
+      {:ok,
+       %{
+         running: [
+           running_entry(%{
+             identifier: "MT-201",
+             codex_rate_limits: %{primary: %{usedPercent: 54, windowDurationMins: 300}},
+             codex_rate_limits_updated_at: DateTime.utc_now()
+           })
+         ],
+         retrying: [],
+         codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         rate_limits: %{primary: %{usedPercent: 55, windowDurationMins: 300}}
+       }}
+
+    assert rate_limit_header(snapshot_data) =~ "Rate Limits: workers 1/1 known | MT-201 primary 54% / 300m"
+  end
+
+  test "rate-limit header makes partially known worker data explicit" do
+    snapshot_data =
+      {:ok,
+       %{
+         running: [
+           running_entry(%{
+             identifier: "MT-211",
+             codex_rate_limits: %{primary: %{usedPercent: 55, windowDurationMins: 300}},
+             codex_rate_limits_updated_at: DateTime.utc_now()
+           }),
+           running_entry(%{identifier: "MT-212"})
+         ],
+         retrying: [],
+         codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         rate_limits: %{primary: %{usedPercent: 46, windowDurationMins: 300}}
+       }}
+
+    header = rate_limit_header(snapshot_data)
+    assert header =~ "Rate Limits: workers 1/2 known | MT-211 primary 55% / 300m"
+    assert header =~ "unknown/stale 1"
+  end
+
+  test "rate-limit header treats old worker rate-limit data as stale" do
+    snapshot_data =
+      {:ok,
+       %{
+         running: [
+           running_entry(%{
+             identifier: "MT-301",
+             codex_rate_limits: %{primary: %{usedPercent: 46, windowDurationMins: 300}},
+             codex_rate_limits_updated_at: DateTime.add(DateTime.utc_now(), -11 * 60, :second)
+           })
+         ],
+         retrying: [],
+         codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         rate_limits: nil
+       }}
+
+    assert rate_limit_header(snapshot_data) =~ "Rate Limits: unavailable (worker data stale: MT-301)"
+  end
+
+  test "rate-limit header explains unavailable worker rate-limit data" do
+    snapshot_data =
+      {:ok,
+       %{
+         running: [running_entry(%{identifier: "MT-401"})],
+         retrying: [],
+         codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         rate_limits: nil
+       }}
+
+    assert rate_limit_header(snapshot_data) =~ "Rate Limits: unavailable (no worker rate-limit data)"
+  end
+
   defp render_snapshot(snapshot_data, tps) do
     StatusDashboard.format_snapshot_content_for_test(snapshot_data, tps, @terminal_columns)
+  end
+
+  defp rate_limit_header(snapshot_data) do
+    snapshot_data
+    |> render_snapshot(0.0)
+    |> Snapshot.strip_ansi()
+    |> String.split("\n")
+    |> Enum.find(&String.contains?(&1, "Rate Limits:"))
   end
 
   defp running_entry(overrides) do

--- a/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
+++ b/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
@@ -267,6 +267,21 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
     assert rate_limit_header(snapshot_data) =~ "Rate Limits: unavailable (no worker rate-limit data)"
   end
 
+  test "rate-limit header does not mask active unknown workers with global data" do
+    snapshot_data =
+      {:ok,
+       %{
+         running: [running_entry(%{identifier: "MT-501"})],
+         retrying: [],
+         codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         rate_limits: %{primary: %{usedPercent: 91, windowDurationMins: 300}}
+       }}
+
+    header = rate_limit_header(snapshot_data)
+    assert header =~ "Rate Limits: unavailable (no worker rate-limit data)"
+    refute header =~ "91% / 300m"
+  end
+
   defp render_snapshot(snapshot_data, tps) do
     StatusDashboard.format_snapshot_content_for_test(snapshot_data, tps, @terminal_columns)
   end


### PR DESCRIPTION
#### Context

GH #22: dashboard header showed rate limits unavailable while worker rows had fresh Codex rate-limit updates. A manager review then found that active workers with unknown worker-scoped rate-limit data could still be masked by a stale global `rate_limits` snapshot.

#### TL;DR

*Use active worker rate-limit state in the dashboard header before any global fallback.*

#### Summary

- Trust bucket-only Codex account rate-limit updates without requiring a limit id.
- Carry per-worker rate-limit snapshots and timestamps into orchestrator status snapshots.
- Prefer fresh worker summaries in the header and show partial, stale, and unknown states.
- Keep active unknown/stale worker state from falling back to stale global rate-limit snapshots.
- Normalize expected snapshot fixture text so Windows checkout line endings do not break tests.

#### Alternatives

- Only fixing global extraction was not enough because partial and stale worker states would stay hidden.
- Falling back to global `rate_limits` for active unknown workers was rejected because it can present a previous/completed worker snapshot as current state.
- Adding a separate dashboard row was avoided to keep the change focused on the existing header.

#### Test Plan

- [ ] `make -C elixir all` - not run locally because `make` is not installed in this PowerShell session.
- [ ] `make windows-native-test` - not run locally because `make` is not installed in this PowerShell session.
- [x] `mix test test/symphony_elixir/status_dashboard_snapshot_test.exs`
- [x] `mix test test/symphony_elixir/status_dashboard_snapshot_test.exs test/symphony_elixir/orchestrator_status_test.exs:390`
- [x] `mix format --check-formatted lib/symphony_elixir/orchestrator.ex lib/symphony_elixir/status_dashboard.ex test/support/snapshot_support.exs test/symphony_elixir/orchestrator_status_test.exs test/symphony_elixir/status_dashboard_snapshot_test.exs`
- [x] `mix format --check-formatted lib/symphony_elixir/status_dashboard.ex test/symphony_elixir/status_dashboard_snapshot_test.exs`
- [x] `git diff --check`
- [x] `mix dialyzer --format short`
- [x] `mix test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs`
- [x] SubAgent review loop completed; latest repair review found no blocking findings and verified idle/no-running dashboards still fall through to global data.

Local full-project notes: whole-project `mix test` was not rerun in the repair loop; previous known unrelated Windows fake SSH/app-server/spec/PR-body issues and one retry timing assertion remain documented. Whole-project format-check previously reported unrelated `workspace_and_config_test.exs` output.