### PR TITLE
fix(orchestrator): classify Linear retry poll closures

### DIFF
--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -45,6 +45,13 @@ Continuation context:
 - Resume from the current workspace state instead of restarting from scratch.
 - Do not repeat already-completed investigation or validation unless needed for new code changes.
 - Do not end the turn while the issue remains in an active state unless you are blocked by missing required permissions/secrets.
+{% if retry_error %}
+- Previous retry/backoff signal: {{ retry_error }}
+{% if retry_error_kind %}- Retry error kind: {{ retry_error_kind }}{% endif %}
+{% if retry_workspace_path %}- Existing workspace path: {{ retry_workspace_path }}{% endif %}
+{% if retry_worker_host %}- Worker host: {{ retry_worker_host }}{% endif %}
+- Record this retry/backoff signal in the existing `## Codex Workpad` before continuing implementation.
+{% endif %}
   {% endif %}
 
 Issue context:

--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -48,7 +48,10 @@ Continuation context:
 {% if retry_error %}
 - Previous retry/backoff signal: {{ retry_error }}
 {% if retry_error_kind %}- Retry error kind: {{ retry_error_kind }}{% endif %}
+{% if retry_prior_error %}- Prior worker/code failure before this retry signal: {{ retry_prior_error }}{% endif %}
+{% if retry_prior_error_kind %}- Prior failure kind: {{ retry_prior_error_kind }}{% endif %}
 {% if retry_workspace_path %}- Existing workspace path: {{ retry_workspace_path }}{% endif %}
+{% if retry_branch_name %}- Existing branch name: {{ retry_branch_name }}{% endif %}
 {% if retry_worker_host %}- Worker host: {{ retry_worker_host }}{% endif %}
 - Record this retry/backoff signal in the existing `## Codex Workpad` before continuing implementation.
 {% endif %}

--- a/elixir/lib/symphony_elixir/agent_runner.ex
+++ b/elixir/lib/symphony_elixir/agent_runner.ex
@@ -155,7 +155,10 @@ defmodule SymphonyElixir.AgentRunner do
     [
       retry_error: Map.get(metadata, :error),
       retry_error_kind: Map.get(metadata, :error_kind),
+      retry_prior_error: Map.get(metadata, :prior_error),
+      retry_prior_error_kind: Map.get(metadata, :prior_error_kind),
       retry_workspace_path: Map.get(metadata, :workspace_path),
+      retry_branch_name: Map.get(metadata, :branch_name),
       retry_worker_host: Map.get(metadata, :worker_host)
     ]
     |> Enum.reject(fn {_key, value} -> is_nil(value) or value == "" end)

--- a/elixir/lib/symphony_elixir/agent_runner.ex
+++ b/elixir/lib/symphony_elixir/agent_runner.ex
@@ -130,7 +130,14 @@ defmodule SymphonyElixir.AgentRunner do
     end
   end
 
-  defp build_turn_prompt(issue, opts, 1, _max_turns), do: PromptBuilder.build_prompt(issue, opts)
+  defp build_turn_prompt(issue, opts, 1, _max_turns) do
+    prompt_opts =
+      opts
+      |> Keyword.take([:attempt])
+      |> Keyword.merge(retry_prompt_opts(Keyword.get(opts, :retry_metadata, %{})))
+
+    PromptBuilder.build_prompt(issue, prompt_opts)
+  end
 
   defp build_turn_prompt(_issue, _opts, turn_number, max_turns) do
     """
@@ -143,6 +150,18 @@ defmodule SymphonyElixir.AgentRunner do
     - Focus on the remaining ticket work and do not end the turn while the issue stays active unless you are truly blocked.
     """
   end
+
+  defp retry_prompt_opts(metadata) when is_map(metadata) do
+    [
+      retry_error: Map.get(metadata, :error),
+      retry_error_kind: Map.get(metadata, :error_kind),
+      retry_workspace_path: Map.get(metadata, :workspace_path),
+      retry_worker_host: Map.get(metadata, :worker_host)
+    ]
+    |> Enum.reject(fn {_key, value} -> is_nil(value) or value == "" end)
+  end
+
+  defp retry_prompt_opts(_metadata), do: []
 
   defp continue_with_issue?(%Issue{id: issue_id} = issue, issue_state_fetcher) when is_binary(issue_id) do
     case issue_state_fetcher.([issue_id]) do

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -142,7 +142,8 @@ defmodule SymphonyElixir.Orchestrator do
                 delay_type: :continuation,
                 error_kind: "continuation",
                 worker_host: Map.get(running_entry, :worker_host),
-                workspace_path: Map.get(running_entry, :workspace_path)
+                workspace_path: Map.get(running_entry, :workspace_path),
+                branch_name: Map.get(running_entry, :branch_name)
               })
 
             _ ->
@@ -155,7 +156,8 @@ defmodule SymphonyElixir.Orchestrator do
                 error: "agent exited: #{inspect(reason)}",
                 error_kind: "worker",
                 worker_host: Map.get(running_entry, :worker_host),
-                workspace_path: Map.get(running_entry, :workspace_path)
+                workspace_path: Map.get(running_entry, :workspace_path),
+                branch_name: Map.get(running_entry, :branch_name)
               })
           end
 
@@ -490,7 +492,10 @@ defmodule SymphonyElixir.Orchestrator do
       |> schedule_issue_retry(issue_id, next_attempt, %{
         identifier: identifier,
         error: "stalled for #{elapsed_ms}ms without codex activity",
-        error_kind: "worker"
+        error_kind: "worker",
+        worker_host: Map.get(running_entry, :worker_host),
+        workspace_path: Map.get(running_entry, :workspace_path),
+        branch_name: Map.get(running_entry, :branch_name)
       })
     else
       state
@@ -714,7 +719,7 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp spawn_issue_on_worker_host(%State{} = state, issue, attempt, recipient, worker_host, claim, retry_metadata) do
-    case Task.Supervisor.start_child(SymphonyElixir.TaskSupervisor, fn ->
+    case start_agent_task(fn ->
            AgentRunner.run(issue, recipient,
              attempt: attempt,
              worker_host: worker_host,
@@ -734,6 +739,7 @@ defmodule SymphonyElixir.Orchestrator do
             issue: issue,
             worker_host: worker_host,
             workspace_path: Map.get(retry_metadata, :workspace_path),
+            branch_name: retry_metadata[:branch_name] || issue.branch_name,
             session_id: nil,
             last_codex_message: nil,
             last_codex_timestamp: nil,
@@ -769,9 +775,23 @@ defmodule SymphonyElixir.Orchestrator do
           error: "failed to spawn agent: #{inspect(reason)}",
           error_kind: "worker",
           worker_host: worker_host,
-          workspace_path: Map.get(retry_metadata, :workspace_path)
+          workspace_path: Map.get(retry_metadata, :workspace_path),
+          branch_name: retry_metadata[:branch_name] || issue.branch_name,
+          prior_error: Map.get(retry_metadata, :prior_error),
+          prior_error_kind: Map.get(retry_metadata, :prior_error_kind)
         })
     end
+  end
+
+  defp start_agent_task(fun) when is_function(fun, 0) do
+    start_child =
+      Application.get_env(
+        :symphony_elixir,
+        :task_supervisor_start_child,
+        &Task.Supervisor.start_child(SymphonyElixir.TaskSupervisor, &1)
+      )
+
+    start_child.(fun)
   end
 
   defp revalidate_issue_for_dispatch(%Issue{id: issue_id}, issue_fetcher, terminal_states)
@@ -814,7 +834,10 @@ defmodule SymphonyElixir.Orchestrator do
     error = pick_retry_error(previous_retry, metadata)
     worker_host = pick_retry_worker_host(previous_retry, metadata)
     workspace_path = pick_retry_workspace_path(previous_retry, metadata)
+    branch_name = pick_retry_branch_name(previous_retry, metadata)
     error_kind = pick_retry_error_kind(previous_retry, metadata)
+    prior_error = pick_retry_prior_error(previous_retry, metadata)
+    prior_error_kind = pick_retry_prior_error_kind(previous_retry, metadata)
 
     if is_reference(old_timer) do
       Process.cancel_timer(old_timer)
@@ -838,7 +861,10 @@ defmodule SymphonyElixir.Orchestrator do
             error: error,
             error_kind: error_kind,
             worker_host: worker_host,
-            workspace_path: workspace_path
+            workspace_path: workspace_path,
+            branch_name: branch_name,
+            prior_error: prior_error,
+            prior_error_kind: prior_error_kind
           })
     }
   end
@@ -851,7 +877,10 @@ defmodule SymphonyElixir.Orchestrator do
           error: Map.get(retry_entry, :error),
           error_kind: Map.get(retry_entry, :error_kind),
           worker_host: Map.get(retry_entry, :worker_host),
-          workspace_path: Map.get(retry_entry, :workspace_path)
+          workspace_path: Map.get(retry_entry, :workspace_path),
+          branch_name: Map.get(retry_entry, :branch_name),
+          prior_error: Map.get(retry_entry, :prior_error),
+          prior_error_kind: Map.get(retry_entry, :prior_error_kind)
         }
 
         {:ok, attempt, metadata, %{state | retry_attempts: Map.delete(state.retry_attempts, issue_id)}}
@@ -950,6 +979,7 @@ defmodule SymphonyElixir.Orchestrator do
          attempt + 1,
          Map.merge(metadata, %{
            identifier: issue.identifier,
+           branch_name: issue.branch_name || metadata[:branch_name],
            error: "no available orchestrator slots",
            error_kind: "capacity"
          })
@@ -1008,8 +1038,20 @@ defmodule SymphonyElixir.Orchestrator do
     metadata[:workspace_path] || Map.get(previous_retry, :workspace_path)
   end
 
+  defp pick_retry_branch_name(previous_retry, metadata) do
+    metadata[:branch_name] || Map.get(previous_retry, :branch_name)
+  end
+
   defp pick_retry_error_kind(previous_retry, metadata) do
     metadata[:error_kind] || Map.get(previous_retry, :error_kind) || infer_retry_error_kind(metadata[:error])
+  end
+
+  defp pick_retry_prior_error(previous_retry, metadata) do
+    metadata[:prior_error] || Map.get(previous_retry, :prior_error)
+  end
+
+  defp pick_retry_prior_error_kind(previous_retry, metadata) do
+    metadata[:prior_error_kind] || Map.get(previous_retry, :prior_error_kind)
   end
 
   defp infer_retry_error_kind(error) when is_binary(error) do
@@ -1027,7 +1069,9 @@ defmodule SymphonyElixir.Orchestrator do
     if linear_transport_closure?(reason) do
       Map.merge(metadata, %{
         error: "transient Linear transport closure during retry poll: #{inspect(reason)}; preserving existing workspace/branch context",
-        error_kind: "linear_transport"
+        error_kind: "linear_transport",
+        prior_error: preserved_prior_error(metadata),
+        prior_error_kind: preserved_prior_error_kind(metadata)
       })
     else
       Map.merge(metadata, %{
@@ -1040,6 +1084,25 @@ defmodule SymphonyElixir.Orchestrator do
   defp linear_transport_closure?({:linear_api_request, %Req.TransportError{reason: :closed}}), do: true
   defp linear_transport_closure?({:linear_api_request, %{reason: :closed}}), do: true
   defp linear_transport_closure?(_reason), do: false
+
+  defp preserved_prior_error(%{prior_error: prior_error}) when is_binary(prior_error), do: prior_error
+
+  defp preserved_prior_error(%{error_kind: "linear_transport"}), do: nil
+
+  defp preserved_prior_error(%{error: error, error_kind: kind})
+       when is_binary(error) and kind != "linear_transport",
+       do: error
+
+  defp preserved_prior_error(%{error: error}) when is_binary(error), do: error
+  defp preserved_prior_error(_metadata), do: nil
+
+  defp preserved_prior_error_kind(%{prior_error_kind: prior_error_kind}) when is_binary(prior_error_kind),
+    do: prior_error_kind
+
+  defp preserved_prior_error_kind(%{error_kind: kind}) when is_binary(kind) and kind != "linear_transport",
+    do: kind
+
+  defp preserved_prior_error_kind(_metadata), do: nil
 
   defp maybe_put_runtime_value(running_entry, _key, nil), do: running_entry
 
@@ -1214,7 +1277,10 @@ defmodule SymphonyElixir.Orchestrator do
           error: Map.get(retry, :error),
           error_kind: Map.get(retry, :error_kind),
           worker_host: Map.get(retry, :worker_host),
-          workspace_path: Map.get(retry, :workspace_path)
+          workspace_path: Map.get(retry, :workspace_path),
+          branch_name: Map.get(retry, :branch_name),
+          prior_error: Map.get(retry, :prior_error),
+          prior_error_kind: Map.get(retry, :prior_error_kind)
         }
       end)
 

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -140,6 +140,7 @@ defmodule SymphonyElixir.Orchestrator do
               |> schedule_issue_retry(issue_id, 1, %{
                 identifier: running_entry.identifier,
                 delay_type: :continuation,
+                error_kind: "continuation",
                 worker_host: Map.get(running_entry, :worker_host),
                 workspace_path: Map.get(running_entry, :workspace_path)
               })
@@ -152,6 +153,7 @@ defmodule SymphonyElixir.Orchestrator do
               schedule_issue_retry(state, issue_id, next_attempt, %{
                 identifier: running_entry.identifier,
                 error: "agent exited: #{inspect(reason)}",
+                error_kind: "worker",
                 worker_host: Map.get(running_entry, :worker_host),
                 workspace_path: Map.get(running_entry, :workspace_path)
               })
@@ -487,7 +489,8 @@ defmodule SymphonyElixir.Orchestrator do
       |> terminate_running_issue(issue_id, false)
       |> schedule_issue_retry(issue_id, next_attempt, %{
         identifier: identifier,
-        error: "stalled for #{elapsed_ms}ms without codex activity"
+        error: "stalled for #{elapsed_ms}ms without codex activity",
+        error_kind: "worker"
       })
     else
       state
@@ -665,10 +668,10 @@ defmodule SymphonyElixir.Orchestrator do
     |> MapSet.new()
   end
 
-  defp dispatch_issue(%State{} = state, issue, attempt \\ nil, preferred_worker_host \\ nil) do
+  defp dispatch_issue(%State{} = state, issue, attempt \\ nil, preferred_worker_host \\ nil, retry_metadata \\ %{}) do
     case revalidate_issue_for_dispatch(issue, &Tracker.fetch_issue_states_by_ids/1, terminal_state_set()) do
       {:ok, %Issue{} = refreshed_issue} ->
-        do_dispatch_issue(state, refreshed_issue, attempt, preferred_worker_host)
+        do_dispatch_issue(state, refreshed_issue, attempt, preferred_worker_host, retry_metadata)
 
       {:skip, :missing} ->
         Logger.info("Skipping dispatch; issue no longer active or visible: #{issue_context(issue)}")
@@ -685,12 +688,12 @@ defmodule SymphonyElixir.Orchestrator do
     end
   end
 
-  defp do_dispatch_issue(%State{} = state, issue, attempt, preferred_worker_host) do
+  defp do_dispatch_issue(%State{} = state, issue, attempt, preferred_worker_host, retry_metadata) do
     recipient = self()
 
     with worker_host when worker_host != :no_worker_capacity <- select_worker_host(state, preferred_worker_host),
          {:ok, claim} <- acquire_issue_claim(issue) do
-      spawn_issue_on_worker_host(state, issue, attempt, recipient, worker_host, claim)
+      spawn_issue_on_worker_host(state, issue, attempt, recipient, worker_host, claim, retry_metadata)
     else
       {:error, {:issue_claimed, claim}} ->
         Logger.info("Skipping dispatch; durable claim is held for #{issue_context(issue)} owner=#{claim.owner} expires_at=#{DateTime.to_iso8601(claim.expires_at)}")
@@ -710,9 +713,13 @@ defmodule SymphonyElixir.Orchestrator do
     Tracker.acquire_issue_claim(issue)
   end
 
-  defp spawn_issue_on_worker_host(%State{} = state, issue, attempt, recipient, worker_host, claim) do
+  defp spawn_issue_on_worker_host(%State{} = state, issue, attempt, recipient, worker_host, claim, retry_metadata) do
     case Task.Supervisor.start_child(SymphonyElixir.TaskSupervisor, fn ->
-           AgentRunner.run(issue, recipient, attempt: attempt, worker_host: worker_host)
+           AgentRunner.run(issue, recipient,
+             attempt: attempt,
+             worker_host: worker_host,
+             retry_metadata: retry_metadata
+           )
          end) do
       {:ok, pid} ->
         ref = Process.monitor(pid)
@@ -726,7 +733,7 @@ defmodule SymphonyElixir.Orchestrator do
             identifier: issue.identifier,
             issue: issue,
             worker_host: worker_host,
-            workspace_path: nil,
+            workspace_path: Map.get(retry_metadata, :workspace_path),
             session_id: nil,
             last_codex_message: nil,
             last_codex_timestamp: nil,
@@ -760,7 +767,9 @@ defmodule SymphonyElixir.Orchestrator do
         |> schedule_issue_retry(issue.id, next_attempt, %{
           identifier: issue.identifier,
           error: "failed to spawn agent: #{inspect(reason)}",
-          worker_host: worker_host
+          error_kind: "worker",
+          worker_host: worker_host,
+          workspace_path: Map.get(retry_metadata, :workspace_path)
         })
     end
   end
@@ -805,6 +814,7 @@ defmodule SymphonyElixir.Orchestrator do
     error = pick_retry_error(previous_retry, metadata)
     worker_host = pick_retry_worker_host(previous_retry, metadata)
     workspace_path = pick_retry_workspace_path(previous_retry, metadata)
+    error_kind = pick_retry_error_kind(previous_retry, metadata)
 
     if is_reference(old_timer) do
       Process.cancel_timer(old_timer)
@@ -826,6 +836,7 @@ defmodule SymphonyElixir.Orchestrator do
             due_at_ms: due_at_ms,
             identifier: identifier,
             error: error,
+            error_kind: error_kind,
             worker_host: worker_host,
             workspace_path: workspace_path
           })
@@ -838,6 +849,7 @@ defmodule SymphonyElixir.Orchestrator do
         metadata = %{
           identifier: Map.get(retry_entry, :identifier),
           error: Map.get(retry_entry, :error),
+          error_kind: Map.get(retry_entry, :error_kind),
           worker_host: Map.get(retry_entry, :worker_host),
           workspace_path: Map.get(retry_entry, :workspace_path)
         }
@@ -864,7 +876,7 @@ defmodule SymphonyElixir.Orchestrator do
            state,
            issue_id,
            attempt + 1,
-           Map.merge(metadata, %{error: "retry poll failed: #{inspect(reason)}"})
+           retry_poll_failure_metadata(metadata, reason)
          )}
     end
   end
@@ -927,7 +939,7 @@ defmodule SymphonyElixir.Orchestrator do
     if retry_candidate_issue?(issue, terminal_state_set()) and
          dispatch_slots_available?(issue, state) and
          worker_slots_available?(state, metadata[:worker_host]) do
-      {:noreply, dispatch_issue(state, issue, attempt, metadata[:worker_host])}
+      {:noreply, dispatch_issue(state, issue, attempt, metadata[:worker_host], metadata)}
     else
       Logger.debug("No available slots for retrying #{issue_context(issue)}; retrying again")
 
@@ -938,7 +950,8 @@ defmodule SymphonyElixir.Orchestrator do
          attempt + 1,
          Map.merge(metadata, %{
            identifier: issue.identifier,
-           error: "no available orchestrator slots"
+           error: "no available orchestrator slots",
+           error_kind: "capacity"
          })
        )}
     end
@@ -994,6 +1007,39 @@ defmodule SymphonyElixir.Orchestrator do
   defp pick_retry_workspace_path(previous_retry, metadata) do
     metadata[:workspace_path] || Map.get(previous_retry, :workspace_path)
   end
+
+  defp pick_retry_error_kind(previous_retry, metadata) do
+    metadata[:error_kind] || Map.get(previous_retry, :error_kind) || infer_retry_error_kind(metadata[:error])
+  end
+
+  defp infer_retry_error_kind(error) when is_binary(error) do
+    cond do
+      String.contains?(error, "retry poll failed") -> "retry_poll"
+      String.contains?(error, "agent exited") -> "worker"
+      String.contains?(error, "stalled for ") -> "worker"
+      true -> nil
+    end
+  end
+
+  defp infer_retry_error_kind(_error), do: nil
+
+  defp retry_poll_failure_metadata(metadata, reason) do
+    if linear_transport_closure?(reason) do
+      Map.merge(metadata, %{
+        error: "transient Linear transport closure during retry poll: #{inspect(reason)}; preserving existing workspace/branch context",
+        error_kind: "linear_transport"
+      })
+    else
+      Map.merge(metadata, %{
+        error: "retry poll failed: #{inspect(reason)}",
+        error_kind: "retry_poll"
+      })
+    end
+  end
+
+  defp linear_transport_closure?({:linear_api_request, %Req.TransportError{reason: :closed}}), do: true
+  defp linear_transport_closure?({:linear_api_request, %{reason: :closed}}), do: true
+  defp linear_transport_closure?(_reason), do: false
 
   defp maybe_put_runtime_value(running_entry, _key, nil), do: running_entry
 
@@ -1166,6 +1212,7 @@ defmodule SymphonyElixir.Orchestrator do
           due_in_ms: max(0, due_at_ms - now_ms),
           identifier: Map.get(retry, :identifier),
           error: Map.get(retry, :error),
+          error_kind: Map.get(retry, :error_kind),
           worker_host: Map.get(retry, :worker_host),
           workspace_path: Map.get(retry, :workspace_path)
         }

--- a/elixir/lib/symphony_elixir/prompt_builder.ex
+++ b/elixir/lib/symphony_elixir/prompt_builder.ex
@@ -20,7 +20,10 @@ defmodule SymphonyElixir.PromptBuilder do
         "attempt" => Keyword.get(opts, :attempt),
         "retry_error" => Keyword.get(opts, :retry_error),
         "retry_error_kind" => Keyword.get(opts, :retry_error_kind),
+        "retry_prior_error" => Keyword.get(opts, :retry_prior_error),
+        "retry_prior_error_kind" => Keyword.get(opts, :retry_prior_error_kind),
         "retry_workspace_path" => Keyword.get(opts, :retry_workspace_path),
+        "retry_branch_name" => Keyword.get(opts, :retry_branch_name),
         "retry_worker_host" => Keyword.get(opts, :retry_worker_host),
         "issue" => issue |> Map.from_struct() |> to_solid_map()
       },

--- a/elixir/lib/symphony_elixir/prompt_builder.ex
+++ b/elixir/lib/symphony_elixir/prompt_builder.ex
@@ -18,6 +18,10 @@ defmodule SymphonyElixir.PromptBuilder do
     |> Solid.render!(
       %{
         "attempt" => Keyword.get(opts, :attempt),
+        "retry_error" => Keyword.get(opts, :retry_error),
+        "retry_error_kind" => Keyword.get(opts, :retry_error_kind),
+        "retry_workspace_path" => Keyword.get(opts, :retry_workspace_path),
+        "retry_worker_host" => Keyword.get(opts, :retry_worker_host),
         "issue" => issue |> Map.from_struct() |> to_solid_map()
       },
       @render_opts

--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -661,12 +661,14 @@ defmodule SymphonyElixir.StatusDashboard do
     identifier = retry_entry.identifier || issue_id
     attempt = retry_entry.attempt || 0
     due_in_ms = retry_entry.due_in_ms || 0
+    error_kind = format_retry_error_kind(Map.get(retry_entry, :error_kind))
     error = format_retry_error(retry_entry.error)
 
     "│  #{colorize("↻", @ansi_orange)} " <>
       colorize("#{identifier}", @ansi_red) <>
       " " <>
       colorize("attempt=#{attempt}", @ansi_yellow) <>
+      error_kind <>
       colorize(" in ", @ansi_dim) <>
       colorize(next_in_words(due_in_ms), @ansi_cyan) <>
       error
@@ -700,6 +702,21 @@ defmodule SymphonyElixir.StatusDashboard do
   end
 
   defp format_retry_error(_), do: ""
+
+  defp format_retry_error_kind(kind) when is_binary(kind) do
+    sanitized =
+      kind
+      |> String.replace(~r/\s+/, "_")
+      |> String.trim()
+
+    if sanitized == "" do
+      ""
+    else
+      " " <> colorize("kind=#{truncate(sanitized, 32)}", @ansi_dim)
+    end
+  end
+
+  defp format_retry_error_kind(_kind), do: ""
 
   defp format_runtime_seconds(seconds) when is_integer(seconds) do
     mins = div(seconds, 60)

--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -662,16 +662,20 @@ defmodule SymphonyElixir.StatusDashboard do
     attempt = retry_entry.attempt || 0
     due_in_ms = retry_entry.due_in_ms || 0
     error_kind = format_retry_error_kind(Map.get(retry_entry, :error_kind))
+    branch_name = format_retry_branch_name(Map.get(retry_entry, :branch_name))
     error = format_retry_error(retry_entry.error)
+    prior_error = format_retry_prior_error(Map.get(retry_entry, :prior_error))
 
     "│  #{colorize("↻", @ansi_orange)} " <>
       colorize("#{identifier}", @ansi_red) <>
       " " <>
       colorize("attempt=#{attempt}", @ansi_yellow) <>
       error_kind <>
+      branch_name <>
       colorize(" in ", @ansi_dim) <>
       colorize(next_in_words(due_in_ms), @ansi_cyan) <>
-      error
+      error <>
+      prior_error
   end
 
   defp next_in_words(due_in_ms) when is_integer(due_in_ms) do
@@ -717,6 +721,30 @@ defmodule SymphonyElixir.StatusDashboard do
   end
 
   defp format_retry_error_kind(_kind), do: ""
+
+  defp format_retry_branch_name(branch_name) when is_binary(branch_name) do
+    sanitized =
+      branch_name
+      |> String.replace(~r/\s+/, "_")
+      |> String.trim()
+
+    if sanitized == "" do
+      ""
+    else
+      " " <> colorize("branch=#{truncate(sanitized, 48)}", @ansi_dim)
+    end
+  end
+
+  defp format_retry_branch_name(_branch_name), do: ""
+
+  defp format_retry_prior_error(error) when is_binary(error) do
+    case String.trim(error) do
+      "" -> ""
+      trimmed -> " " <> colorize("(prior: #{truncate(trimmed, 80)})", @ansi_dim)
+    end
+  end
+
+  defp format_retry_prior_error(_error), do: ""
 
   defp format_runtime_seconds(seconds) when is_integer(seconds) do
     mins = div(seconds, 60)

--- a/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
@@ -223,6 +223,7 @@ defmodule SymphonyElixirWeb.DashboardLive do
                   <tr>
                     <th>Issue</th>
                     <th>Attempt</th>
+                    <th>Kind</th>
                     <th>Due at</th>
                     <th>Error</th>
                   </tr>
@@ -236,6 +237,7 @@ defmodule SymphonyElixirWeb.DashboardLive do
                       </div>
                     </td>
                     <td><%= entry.attempt %></td>
+                    <td><%= entry.error_kind || "n/a" %></td>
                     <td class="mono"><%= entry.due_at || "n/a" %></td>
                     <td><%= entry.error || "n/a" %></td>
                   </tr>

--- a/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
@@ -224,8 +224,10 @@ defmodule SymphonyElixirWeb.DashboardLive do
                     <th>Issue</th>
                     <th>Attempt</th>
                     <th>Kind</th>
+                    <th>Branch</th>
                     <th>Due at</th>
                     <th>Error</th>
+                    <th>Prior error</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -238,8 +240,10 @@ defmodule SymphonyElixirWeb.DashboardLive do
                     </td>
                     <td><%= entry.attempt %></td>
                     <td><%= entry.error_kind || "n/a" %></td>
+                    <td class="mono"><%= entry.branch_name || "n/a" %></td>
                     <td class="mono"><%= entry.due_at || "n/a" %></td>
                     <td><%= entry.error || "n/a" %></td>
+                    <td><%= entry.prior_error || "n/a" %></td>
                   </tr>
                 </tbody>
               </table>

--- a/elixir/lib/symphony_elixir_web/presenter.ex
+++ b/elixir/lib/symphony_elixir_web/presenter.ex
@@ -124,8 +124,11 @@ defmodule SymphonyElixirWeb.Presenter do
       due_at: due_at_iso8601(entry.due_in_ms),
       error: entry.error,
       error_kind: Map.get(entry, :error_kind),
+      prior_error: Map.get(entry, :prior_error),
+      prior_error_kind: Map.get(entry, :prior_error_kind),
       worker_host: Map.get(entry, :worker_host),
-      workspace_path: Map.get(entry, :workspace_path)
+      workspace_path: Map.get(entry, :workspace_path),
+      branch_name: Map.get(entry, :branch_name)
     }
   end
 
@@ -154,8 +157,11 @@ defmodule SymphonyElixirWeb.Presenter do
       due_at: due_at_iso8601(retry.due_in_ms),
       error: retry.error,
       error_kind: Map.get(retry, :error_kind),
+      prior_error: Map.get(retry, :prior_error),
+      prior_error_kind: Map.get(retry, :prior_error_kind),
       worker_host: Map.get(retry, :worker_host),
-      workspace_path: Map.get(retry, :workspace_path)
+      workspace_path: Map.get(retry, :workspace_path),
+      branch_name: Map.get(retry, :branch_name)
     }
   end
 

--- a/elixir/lib/symphony_elixir_web/presenter.ex
+++ b/elixir/lib/symphony_elixir_web/presenter.ex
@@ -123,6 +123,7 @@ defmodule SymphonyElixirWeb.Presenter do
       attempt: entry.attempt,
       due_at: due_at_iso8601(entry.due_in_ms),
       error: entry.error,
+      error_kind: Map.get(entry, :error_kind),
       worker_host: Map.get(entry, :worker_host),
       workspace_path: Map.get(entry, :workspace_path)
     }
@@ -152,6 +153,7 @@ defmodule SymphonyElixirWeb.Presenter do
       attempt: retry.attempt,
       due_at: due_at_iso8601(retry.due_in_ms),
       error: retry.error,
+      error_kind: Map.get(retry, :error_kind),
       worker_host: Map.get(retry, :worker_host),
       workspace_path: Map.get(retry, :workspace_path)
     }

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -1,6 +1,15 @@
 defmodule SymphonyElixir.CoreTest do
   use SymphonyElixir.TestSupport
 
+  defmodule RetryPollFailureLinearClient do
+    def fetch_candidate_issues do
+      {:error, {:linear_api_request, %Req.TransportError{reason: :closed}}}
+    end
+
+    def fetch_issues_by_states(_states), do: {:ok, []}
+    def fetch_issue_states_by_ids(_issue_ids), do: {:ok, []}
+  end
+
   test "config defaults and validation checks" do
     write_workflow_file!(Workflow.workflow_file_path(),
       tracker_api_token: nil,
@@ -689,6 +698,109 @@ defmodule SymphonyElixir.CoreTest do
            } = :sys.get_state(pid).retry_attempts[issue_id]
   end
 
+  test "retry poll transport closure preserves retry context and classifies dashboard error" do
+    linear_client_module = Application.get_env(:symphony_elixir, :linear_client_module)
+    Application.put_env(:symphony_elixir, :linear_client_module, RetryPollFailureLinearClient)
+
+    on_exit(fn ->
+      if is_nil(linear_client_module) do
+        Application.delete_env(:symphony_elixir, :linear_client_module)
+      else
+        Application.put_env(:symphony_elixir, :linear_client_module, linear_client_module)
+      end
+    end)
+
+    issue_id = "issue-retry-poll-closed"
+    retry_token = make_ref()
+    orchestrator_name = Module.concat(__MODULE__, :RetryPollTransportClosureOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    :sys.replace_state(pid, fn state ->
+      %{
+        state
+        | retry_attempts: %{
+            issue_id => %{
+              attempt: 2,
+              timer_ref: nil,
+              retry_token: retry_token,
+              due_at_ms: System.monotonic_time(:millisecond),
+              identifier: "ALB-10",
+              error: "agent exited: :boom",
+              error_kind: "worker",
+              worker_host: "worker-a",
+              workspace_path: "D:/workspaces/ALB-10"
+            }
+          }
+      }
+    end)
+
+    send(pid, {:retry_issue, issue_id, retry_token})
+    Process.sleep(50)
+
+    assert %{
+             attempt: 3,
+             identifier: "ALB-10",
+             error: error,
+             error_kind: "linear_transport",
+             worker_host: "worker-a",
+             workspace_path: "D:/workspaces/ALB-10"
+           } = :sys.get_state(pid).retry_attempts[issue_id]
+
+    assert error =~ "transient Linear transport closure during retry poll"
+    assert error =~ "preserving existing workspace/branch context"
+  end
+
+  test "worker failure after retry dispatch preserves seeded workspace context" do
+    issue_id = "issue-retry-dispatch-crash"
+    ref = make_ref()
+    orchestrator_name = Module.concat(__MODULE__, :RetryDispatchCrashOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    initial_state = :sys.get_state(pid)
+
+    running_entry = %{
+      pid: self(),
+      ref: ref,
+      identifier: "ALB-15",
+      retry_attempt: 3,
+      issue: %Issue{id: issue_id, identifier: "ALB-15", state: "In Progress"},
+      worker_host: "worker-b",
+      workspace_path: "D:/workspaces/ALB-15",
+      started_at: DateTime.utc_now()
+    }
+
+    :sys.replace_state(pid, fn _ ->
+      initial_state
+      |> Map.put(:running, %{issue_id => running_entry})
+      |> Map.put(:claimed, MapSet.new([issue_id]))
+      |> Map.put(:retry_attempts, %{})
+    end)
+
+    send(pid, {:DOWN, ref, :process, self(), :boom})
+    Process.sleep(50)
+
+    assert %{
+             attempt: 4,
+             identifier: "ALB-15",
+             error: "agent exited: :boom",
+             error_kind: "worker",
+             worker_host: "worker-b",
+             workspace_path: "D:/workspaces/ALB-15"
+           } = :sys.get_state(pid).retry_attempts[issue_id]
+  end
+
   test "manual refresh coalesces repeated requests and ignores superseded ticks" do
     now_ms = System.monotonic_time(:millisecond)
     stale_tick_token = make_ref()
@@ -973,7 +1085,14 @@ defmodule SymphonyElixir.CoreTest do
 
     on_exit(fn -> Workflow.set_workflow_file_path(workflow_path) end)
 
-    prompt = PromptBuilder.build_prompt(issue, attempt: 2)
+    prompt =
+      PromptBuilder.build_prompt(issue,
+        attempt: 2,
+        retry_error: "transient Linear transport closure during retry poll",
+        retry_error_kind: "linear_transport",
+        retry_workspace_path: "D:/workspaces/MT-616",
+        retry_worker_host: "worker-a"
+      )
 
     assert prompt =~ "You are working on a Linear ticket `MT-616`"
     assert prompt =~ "Issue context:"
@@ -994,6 +1113,11 @@ defmodule SymphonyElixir.CoreTest do
     assert prompt =~ "Do not call `gh pr merge` directly"
     assert prompt =~ "Continuation context:"
     assert prompt =~ "retry attempt #2"
+    assert prompt =~ "Previous retry/backoff signal: transient Linear transport closure during retry poll"
+    assert prompt =~ "Retry error kind: linear_transport"
+    assert prompt =~ "Existing workspace path: D:/workspaces/MT-616"
+    assert prompt =~ "Worker host: worker-a"
+    assert prompt =~ "Record this retry/backoff signal in the existing `## Codex Workpad`"
   end
 
   test "prompt builder adds continuation guidance for retries" do

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -734,7 +734,8 @@ defmodule SymphonyElixir.CoreTest do
               error: "agent exited: :boom",
               error_kind: "worker",
               worker_host: "worker-a",
-              workspace_path: "D:/workspaces/ALB-10"
+              workspace_path: "D:/workspaces/ALB-10",
+              branch_name: "codex/ALB-10-retry-poll"
             }
           }
       }
@@ -748,12 +749,70 @@ defmodule SymphonyElixir.CoreTest do
              identifier: "ALB-10",
              error: error,
              error_kind: "linear_transport",
+             prior_error: "agent exited: :boom",
+             prior_error_kind: "worker",
              worker_host: "worker-a",
-             workspace_path: "D:/workspaces/ALB-10"
+             workspace_path: "D:/workspaces/ALB-10",
+             branch_name: "codex/ALB-10-retry-poll"
            } = :sys.get_state(pid).retry_attempts[issue_id]
 
     assert error =~ "transient Linear transport closure during retry poll"
     assert error =~ "preserving existing workspace/branch context"
+  end
+
+  test "repeated retry poll transport closure does not invent prior worker failure" do
+    linear_client_module = Application.get_env(:symphony_elixir, :linear_client_module)
+    Application.put_env(:symphony_elixir, :linear_client_module, RetryPollFailureLinearClient)
+
+    on_exit(fn ->
+      if is_nil(linear_client_module) do
+        Application.delete_env(:symphony_elixir, :linear_client_module)
+      else
+        Application.put_env(:symphony_elixir, :linear_client_module, linear_client_module)
+      end
+    end)
+
+    issue_id = "issue-repeated-retry-poll-closed"
+    retry_token = make_ref()
+    orchestrator_name = Module.concat(__MODULE__, :RepeatedRetryPollTransportClosureOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    :sys.replace_state(pid, fn state ->
+      %{
+        state
+        | retry_attempts: %{
+            issue_id => %{
+              attempt: 3,
+              timer_ref: nil,
+              retry_token: retry_token,
+              due_at_ms: System.monotonic_time(:millisecond),
+              identifier: "ALB-10",
+              error: "transient Linear transport closure during retry poll",
+              error_kind: "linear_transport",
+              worker_host: "worker-a",
+              workspace_path: "D:/workspaces/ALB-10",
+              branch_name: "codex/ALB-10-retry-poll"
+            }
+          }
+      }
+    end)
+
+    send(pid, {:retry_issue, issue_id, retry_token})
+    Process.sleep(50)
+
+    assert %{
+             attempt: 4,
+             error_kind: "linear_transport",
+             prior_error: nil,
+             prior_error_kind: nil,
+             branch_name: "codex/ALB-10-retry-poll"
+           } = :sys.get_state(pid).retry_attempts[issue_id]
   end
 
   test "worker failure after retry dispatch preserves seeded workspace context" do
@@ -778,6 +837,7 @@ defmodule SymphonyElixir.CoreTest do
       issue: %Issue{id: issue_id, identifier: "ALB-15", state: "In Progress"},
       worker_host: "worker-b",
       workspace_path: "D:/workspaces/ALB-15",
+      branch_name: "codex/ALB-15-retry-dispatch",
       started_at: DateTime.utc_now()
     }
 
@@ -797,8 +857,79 @@ defmodule SymphonyElixir.CoreTest do
              error: "agent exited: :boom",
              error_kind: "worker",
              worker_host: "worker-b",
-             workspace_path: "D:/workspaces/ALB-15"
+             workspace_path: "D:/workspaces/ALB-15",
+             branch_name: "codex/ALB-15-retry-dispatch"
            } = :sys.get_state(pid).retry_attempts[issue_id]
+  end
+
+  test "spawn failure requeue preserves retry branch and prior failure context" do
+    previous_memory_issues = Application.get_env(:symphony_elixir, :memory_tracker_issues)
+    previous_memory_recipient = Application.get_env(:symphony_elixir, :memory_tracker_recipient)
+    previous_start_child = Application.get_env(:symphony_elixir, :task_supervisor_start_child)
+
+    issue_id = "issue-spawn-failure-requeue"
+    retry_token = make_ref()
+
+    issue = %Issue{
+      id: issue_id,
+      identifier: "ALB-21",
+      title: "Handle Linear retry poll closures",
+      state: "In Progress",
+      branch_name: "codex/ALB-21-linear-retry-poll-closures"
+    }
+
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "memory")
+    Application.put_env(:symphony_elixir, :memory_tracker_issues, [issue])
+    Application.put_env(:symphony_elixir, :memory_tracker_recipient, self())
+
+    Application.put_env(:symphony_elixir, :task_supervisor_start_child, fn _fun ->
+      {:error, :simulated_spawn_failure}
+    end)
+
+    on_exit(fn ->
+      restore_app_env(:memory_tracker_issues, previous_memory_issues)
+      restore_app_env(:memory_tracker_recipient, previous_memory_recipient)
+      restore_app_env(:task_supervisor_start_child, previous_start_child)
+    end)
+
+    state = %Orchestrator.State{
+      max_concurrent_agents: 10,
+      running: %{},
+      claimed: MapSet.new(),
+      retry_attempts: %{
+        issue_id => %{
+          attempt: 3,
+          timer_ref: nil,
+          retry_token: retry_token,
+          due_at_ms: System.monotonic_time(:millisecond),
+          identifier: "ALB-21",
+          error: "transient Linear transport closure during retry poll",
+          error_kind: "linear_transport",
+          prior_error: "agent exited: :boom",
+          prior_error_kind: "worker",
+          worker_host: nil,
+          workspace_path: "D:/workspaces/ALB-21",
+          branch_name: "codex/ALB-21-linear-retry-poll-closures"
+        }
+      },
+      codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0}
+    }
+
+    assert {:noreply, updated_state} = Orchestrator.handle_info({:retry_issue, issue_id, retry_token}, state)
+
+    assert %{
+             attempt: 4,
+             identifier: "ALB-21",
+             error: "failed to spawn agent: :simulated_spawn_failure",
+             error_kind: "worker",
+             prior_error: "agent exited: :boom",
+             prior_error_kind: "worker",
+             workspace_path: "D:/workspaces/ALB-21",
+             branch_name: "codex/ALB-21-linear-retry-poll-closures"
+           } = updated_state.retry_attempts[issue_id]
+
+    assert_receive {:memory_tracker_claim_acquired, ^issue_id, "ALB-21", _claim}
+    assert_receive {:memory_tracker_claim_released, ^issue_id}
   end
 
   test "manual refresh coalesces repeated requests and ignores superseded ticks" do
@@ -1090,7 +1221,10 @@ defmodule SymphonyElixir.CoreTest do
         attempt: 2,
         retry_error: "transient Linear transport closure during retry poll",
         retry_error_kind: "linear_transport",
+        retry_prior_error: "agent exited: :boom",
+        retry_prior_error_kind: "worker",
         retry_workspace_path: "D:/workspaces/MT-616",
+        retry_branch_name: "codex/MT-616-transport-closure",
         retry_worker_host: "worker-a"
       )
 
@@ -1115,7 +1249,10 @@ defmodule SymphonyElixir.CoreTest do
     assert prompt =~ "retry attempt #2"
     assert prompt =~ "Previous retry/backoff signal: transient Linear transport closure during retry poll"
     assert prompt =~ "Retry error kind: linear_transport"
+    assert prompt =~ "Prior worker/code failure before this retry signal: agent exited: :boom"
+    assert prompt =~ "Prior failure kind: worker"
     assert prompt =~ "Existing workspace path: D:/workspaces/MT-616"
+    assert prompt =~ "Existing branch name: codex/MT-616-transport-closure"
     assert prompt =~ "Worker host: worker-a"
     assert prompt =~ "Record this retry/backoff signal in the existing `## Codex Workpad`"
   end

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -857,6 +857,7 @@ defmodule SymphonyElixir.ExtensionsTest do
                  "attempt" => 2,
                  "due_at" => state_payload["retrying"] |> List.first() |> Map.fetch!("due_at"),
                  "error" => "boom",
+                 "error_kind" => "linear_transport",
                  "worker_host" => nil,
                  "workspace_path" => nil
                }
@@ -903,7 +904,10 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     conn = get(build_conn(), "/api/v1/MT-RETRY")
 
-    assert %{"status" => "retrying", "retry" => %{"attempt" => 2, "error" => "boom"}} =
+    assert %{
+             "status" => "retrying",
+             "retry" => %{"attempt" => 2, "error" => "boom", "error_kind" => "linear_transport"}
+           } =
              json_response(conn, 200)
 
     conn = get(build_conn(), "/api/v1/MT-MISSING")
@@ -1199,7 +1203,8 @@ defmodule SymphonyElixir.ExtensionsTest do
           identifier: "MT-RETRY",
           attempt: 2,
           due_in_ms: 2_000,
-          error: "boom"
+          error: "boom",
+          error_kind: "linear_transport"
         }
       ],
       codex_totals: %{input_tokens: 4, output_tokens: 8, total_tokens: 12, seconds_running: 42.5},

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -858,8 +858,11 @@ defmodule SymphonyElixir.ExtensionsTest do
                  "due_at" => state_payload["retrying"] |> List.first() |> Map.fetch!("due_at"),
                  "error" => "boom",
                  "error_kind" => "linear_transport",
+                 "prior_error" => nil,
+                 "prior_error_kind" => nil,
                  "worker_host" => nil,
-                 "workspace_path" => nil
+                 "workspace_path" => nil,
+                 "branch_name" => nil
                }
              ],
              "codex_totals" => %{

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -728,7 +728,8 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       timer_ref: nil,
       due_at_ms: System.monotonic_time(:millisecond) + 5_000,
       identifier: "MT-500",
-      error: "agent exited: :boom"
+      error: "agent exited: :boom",
+      error_kind: "worker"
     }
 
     initial_state = :sys.get_state(pid)
@@ -744,7 +745,8 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
                attempt: 2,
                due_in_ms: due_in_ms,
                identifier: "MT-500",
-               error: "agent exited: :boom"
+               error: "agent exited: :boom",
+               error_kind: "worker"
              }
            ] = snapshot.retrying
 

--- a/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
+++ b/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
@@ -166,6 +166,31 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
     refute backoff_line =~ "\\n"
   end
 
+  test "backoff queue row renders retry error kind" do
+    snapshot_data =
+      {:ok,
+       %{
+         running: [],
+         retrying: [
+           retry_entry(%{
+             identifier: "MT-981",
+             attempt: 3,
+             due_in_ms: 2_500,
+             error: "transient Linear transport closure during retry poll",
+             error_kind: "linear_transport"
+           })
+         ],
+         codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         rate_limits: nil
+       }}
+
+    rendered = render_snapshot(snapshot_data, 0.0)
+    backoff_lines = rendered |> String.split("\n") |> Enum.filter(&String.contains?(&1, "MT-981"))
+
+    assert length(backoff_lines) == 1
+    assert List.first(backoff_lines) =~ "kind=linear_transport"
+  end
+
   test "snapshot fixture: unlimited credits variant" do
     snapshot_data =
       {:ok,

--- a/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
+++ b/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
@@ -177,7 +177,9 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
              attempt: 3,
              due_in_ms: 2_500,
              error: "transient Linear transport closure during retry poll",
-             error_kind: "linear_transport"
+             error_kind: "linear_transport",
+             prior_error: "agent exited: :boom",
+             branch_name: "codex/MT-981-linear-transport"
            })
          ],
          codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
@@ -189,6 +191,8 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
 
     assert length(backoff_lines) == 1
     assert List.first(backoff_lines) =~ "kind=linear_transport"
+    assert List.first(backoff_lines) =~ "branch=codex/MT-981-linear-transport"
+    assert List.first(backoff_lines) =~ "prior: agent exited: :boom"
   end
 
   test "snapshot fixture: unlimited credits variant" do


### PR DESCRIPTION
#### Context

Linear retry-poll transport closures need visible retry context without losing worker workspace or branch state.

#### TL;DR

*Classify Linear retry poll closures while preserving branch and prior worker failure context.*

#### Summary

- Mark retry poll transport closures as `linear_transport` in retry metadata.
- Preserve worker host, workspace path, and branch name through retry poll, dispatch, crash, stalled-worker, and spawn-failure requeues.
- Preserve the previous worker/spawn/code failure as `prior_error` / `prior_error_kind` when a Linear transport closure causes another backoff.
- Surface retry `error_kind`, branch, and prior error context in terminal and Phoenix dashboards/API.
- Pass retry/backoff context into continuation prompts for Workpad recording.

#### Alternatives

- Logging only was rejected because operators also need dashboard/API classification.
- Recreating workspaces was rejected because retry should preserve existing local work.
- Overwriting the retry error with only the Linear transport closure was rejected because it hides the prior worker/code failure that caused the retry lane.

#### Test Plan

- [ ] `make -C elixir all`
- [x] `mix compile --warnings-as-errors`
- [x] `mix test test/symphony_elixir/core_test.exs:701 test/symphony_elixir/core_test.exs:763 test/symphony_elixir/core_test.exs:818 test/symphony_elixir/core_test.exs:865 test/symphony_elixir/core_test.exs:1201`
- [x] `mix test test/symphony_elixir/status_dashboard_snapshot_test.exs:169 test/symphony_elixir/extensions_test.exs:813 test/symphony_elixir/orchestrator_status_test.exs:716`
- [x] `mix specs.check`
- [x] `mix format --check-formatted` for touched files
- [ ] `make windows-native-test` blocked locally: `make` is not installed on this Windows PATH.

Subagent review: requested for non-trivial orchestrator behavior. Initial repair review found one blocking repeated-transport prior-error issue; fixed with regression coverage. Final re-review reported no blocking findings and reran focused checks successfully.

Local broad-suite notes: full-file `core_test`, `orchestrator_status_test`, and dashboard snapshot runs exposed pre-existing Windows fake-port/snapshot timing/line-ending drift unrelated to this change. Focused ALB-21 tests pass.
