### PR TITLE
fix(dashboard): include active runtime in snapshots

### DIFF
--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -1137,6 +1137,8 @@ defmodule SymphonyElixir.Orchestrator do
     running =
       state.running
       |> Enum.map(fn {issue_id, metadata} ->
+        runtime_seconds = running_seconds(metadata.started_at, now)
+
         %{
           issue_id: issue_id,
           identifier: metadata.identifier,
@@ -1153,9 +1155,11 @@ defmodule SymphonyElixir.Orchestrator do
           last_codex_timestamp: metadata.last_codex_timestamp,
           last_codex_message: metadata.last_codex_message,
           last_codex_event: metadata.last_codex_event,
-          runtime_seconds: running_seconds(metadata.started_at, now)
+          runtime_seconds: runtime_seconds
         }
       end)
+
+    codex_totals = codex_totals_with_active_runtime(state.codex_totals, running)
 
     retrying =
       state.retry_attempts
@@ -1175,7 +1179,7 @@ defmodule SymphonyElixir.Orchestrator do
      %{
        running: running,
        retrying: retrying,
-       codex_totals: state.codex_totals,
+       codex_totals: codex_totals,
        rate_limits: Map.get(state, :codex_rate_limits),
        polling: %{
          checking?: state.poll_check_in_progress == true,
@@ -1323,6 +1327,26 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp record_session_completion_totals(state, _running_entry), do: state
+
+  defp codex_totals_with_active_runtime(codex_totals, running) when is_map(codex_totals) and is_list(running) do
+    apply_token_delta(codex_totals, %{
+      input_tokens: 0,
+      output_tokens: 0,
+      total_tokens: 0,
+      seconds_running: active_runtime_seconds(running)
+    })
+  end
+
+  defp codex_totals_with_active_runtime(_codex_totals, running) when is_list(running) do
+    codex_totals_with_active_runtime(@empty_codex_totals, running)
+  end
+
+  defp active_runtime_seconds(running) when is_list(running) do
+    Enum.reduce(running, 0, fn
+      %{runtime_seconds: seconds}, total when is_integer(seconds) -> total + max(0, seconds)
+      _entry, total -> total
+    end)
+  end
 
   defp refresh_runtime_config(%State{} = state) do
     config = Config.settings!()

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -136,6 +136,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       last_codex_message: nil,
       last_codex_timestamp: nil,
       last_codex_event: nil,
+      codex_app_server_pid: nil,
       codex_input_tokens: 0,
       codex_output_tokens: 0,
       codex_total_tokens: 0,
@@ -197,6 +198,63 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     assert completed_state.codex_totals.output_tokens == 4
     assert completed_state.codex_totals.total_tokens == 16
     assert is_integer(completed_state.codex_totals.seconds_running)
+  end
+
+  test "orchestrator snapshot includes active session runtime in codex totals" do
+    issue_id = "issue-active-runtime-snapshot"
+
+    issue = %Issue{
+      id: issue_id,
+      identifier: "MT-203",
+      title: "Active runtime snapshot test",
+      description: "Keep top-level runtime live while workers are active",
+      state: "In Progress",
+      url: "https://example.org/issues/MT-203"
+    }
+
+    orchestrator_name = Module.concat(__MODULE__, :ActiveRuntimeOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    initial_state = :sys.get_state(pid)
+    completed_runtime_seconds = 30
+    active_runtime_seconds = 14 * 60
+
+    running_entry = %{
+      pid: self(),
+      ref: make_ref(),
+      identifier: issue.identifier,
+      issue: issue,
+      session_id: nil,
+      turn_count: 1,
+      last_codex_message: nil,
+      last_codex_timestamp: nil,
+      last_codex_event: nil,
+      codex_app_server_pid: nil,
+      codex_input_tokens: 0,
+      codex_output_tokens: 0,
+      codex_total_tokens: 0,
+      started_at: DateTime.add(DateTime.utc_now(), -active_runtime_seconds, :second)
+    }
+
+    :sys.replace_state(pid, fn _ ->
+      initial_state
+      |> Map.put(:running, %{issue_id => running_entry})
+      |> Map.put(:claimed, MapSet.put(initial_state.claimed, issue_id))
+      |> Map.put(:codex_totals, %{initial_state.codex_totals | seconds_running: completed_runtime_seconds})
+    end)
+
+    snapshot = GenServer.call(pid, :snapshot)
+
+    assert %{running: [snapshot_entry], codex_totals: codex_totals} = snapshot
+    assert snapshot_entry.runtime_seconds >= active_runtime_seconds
+    assert codex_totals.seconds_running >= snapshot_entry.runtime_seconds
+    assert codex_totals.seconds_running >= completed_runtime_seconds + active_runtime_seconds
   end
 
   test "orchestrator snapshot tracks turn completed usage when present" do


### PR DESCRIPTION
#### Context

GH #17 reports Windows status output where workers show 14m AGE while top Runtime stays 0m 0s.

#### TL;DR

*Include active worker elapsed time in snapshot runtime totals.*

#### Summary

- Add active running-session seconds to snapshot `codex_totals.seconds_running`.
- Preserve completed-session runtime without mutating orchestrator state on each snapshot.
- Add regression coverage for a 14-minute active worker plus completed runtime.
- SubAgent review completed with no blockers; test was tightened after review feedback.

#### Alternatives

- Change only terminal formatting; rejected because web/API snapshot consumers need the same aggregate runtime.
- Continuously tick runtime totals in state; rejected because snapshots can compute live elapsed time without drift.

#### Test Plan

- [ ] `make -C elixir all` - not run locally: Windows workspace has no `make` executable on PATH.
- [x] `cd elixir; mix test test/symphony_elixir/orchestrator_status_test.exs:203`
- [x] `cd elixir; mix format --check-formatted lib/symphony_elixir/orchestrator.ex test/symphony_elixir/orchestrator_status_test.exs`
- [x] `cd elixir; mix test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs` (Makefile-equivalent for `windows-native-test`, rerun passed)
- [x] `git diff --check`
- [ ] `cd elixir; mix test` - fails on existing Windows-local gate issues outside this PR; filed GH #28 / Linear ALB-25.