### PR TITLE
Classify long-running worker commands

### DIFF
--- a/elixir/WORKFLOW.optimization.windows.example.md
+++ b/elixir/WORKFLOW.optimization.windows.example.md
@@ -41,6 +41,11 @@ codex:
   thread_sandbox: danger-full-access
   # Used when GitHub branch protection required-check metadata is private or unavailable.
   review_readiness_repository: albert-zen/symphony-windows-native
+  command_watchdog_long_running_ms: 300000
+  command_watchdog_idle_ms: 120000
+  command_watchdog_stalled_ms: 300000
+  command_watchdog_repeated_output_limit: 20
+  command_watchdog_block_on_stall: false
   review_readiness_required_checks:
     - make-all
     - validate-pr-description

--- a/elixir/lib/symphony_elixir/codex/command_watchdog.ex
+++ b/elixir/lib/symphony_elixir/codex/command_watchdog.ex
@@ -1,0 +1,271 @@
+defmodule SymphonyElixir.Codex.CommandWatchdog do
+  @moduledoc """
+  Tracks active Codex command execution progress and classifies long-running commands.
+  """
+
+  @type classification :: :healthy | :idle | :stalled | :needs_attention
+
+  @type policy :: %{
+          long_running_ms: non_neg_integer(),
+          idle_ms: non_neg_integer(),
+          stalled_ms: non_neg_integer(),
+          repeated_output_limit: non_neg_integer(),
+          block_on_stall: boolean()
+        }
+
+  @type t :: map()
+
+  @spec policy_from_config(term()) :: policy()
+  def policy_from_config(config) do
+    %{
+      long_running_ms: Map.get(config, :command_watchdog_long_running_ms, 300_000),
+      idle_ms: Map.get(config, :command_watchdog_idle_ms, 120_000),
+      stalled_ms: Map.get(config, :command_watchdog_stalled_ms, 300_000),
+      repeated_output_limit: Map.get(config, :command_watchdog_repeated_output_limit, 20),
+      block_on_stall: Map.get(config, :command_watchdog_block_on_stall, false) == true
+    }
+  end
+
+  @spec update(t() | nil, map(), policy()) :: t() | nil
+  def update(command, %{timestamp: %DateTime{} = timestamp} = update, policy) do
+    payload = update[:payload] || Map.get(update, "payload") || update
+    method = map_path(payload, ["method"]) || map_path(payload, [:method])
+
+    cond do
+      method in ["codex/event/exec_command_begin", "item/commandExecution/begin"] or
+          command_lifecycle_event?(payload, "item/started") ->
+        new_command(command_name(payload), timestamp)
+        |> classify(timestamp, policy)
+
+      method in ["codex/event/exec_command_end", "item/commandExecution/end"] or
+          command_lifecycle_event?(payload, "item/completed") ->
+        command
+        |> mark_completed(timestamp)
+        |> classify(timestamp, policy)
+
+      method in ["codex/event/exec_command_output_delta", "item/commandExecution/outputDelta"] ->
+        command
+        |> apply_output(output_delta(payload), timestamp)
+        |> classify(timestamp, policy)
+
+      true ->
+        command && classify(command, timestamp, policy)
+    end
+  end
+
+  def update(command, _update, _policy), do: command
+
+  @spec classify(t() | nil, DateTime.t(), policy()) :: t() | nil
+  def classify(nil, _now, _policy), do: nil
+
+  def classify(%{status: :completed} = command, _now, _policy) do
+    %{command | classification: :healthy, classification_reason: "command completed"}
+  end
+
+  def classify(%{started_at: %DateTime{} = started_at} = command, %DateTime{} = now, policy) do
+    age_ms = elapsed_ms(started_at, now)
+    last_progress_at = Map.get(command, :last_progress_at) || started_at
+    progress_idle_ms = elapsed_ms(last_progress_at, now)
+    repeated_count = Map.get(command, :repeated_output_count, 0)
+
+    {classification, reason} =
+      cond do
+        age_ms < policy.long_running_ms ->
+          {:healthy, "command has not crossed long-running threshold"}
+
+        progress_idle_ms >= policy.stalled_ms ->
+          {:stalled, "no command progress for #{progress_idle_ms}ms"}
+
+        repeated_count >= policy.repeated_output_limit ->
+          {:needs_attention, "same command output repeated #{repeated_count} times"}
+
+        progress_idle_ms >= policy.idle_ms ->
+          {:idle, "no command progress for #{progress_idle_ms}ms"}
+
+        true ->
+          {:healthy, "command is producing progress"}
+      end
+
+    command
+    |> Map.put(:classification, classification)
+    |> Map.put(:classification_reason, reason)
+  end
+
+  def classify(command, _now, _policy), do: command
+
+  @spec snapshot(t() | nil, DateTime.t(), policy()) :: map() | nil
+  def snapshot(nil, _now, _policy), do: nil
+
+  def snapshot(command, now, policy) do
+    command = classify(command, now, policy)
+    started_at = Map.get(command, :started_at)
+    last_output_at = Map.get(command, :last_output_at)
+    last_progress_at = Map.get(command, :last_progress_at)
+
+    %{
+      command: Map.get(command, :command),
+      status: Map.get(command, :status, :running),
+      classification: Map.get(command, :classification, :healthy),
+      classification_reason: Map.get(command, :classification_reason),
+      age_ms: elapsed_ms(started_at, now),
+      idle_ms: elapsed_ms(last_progress_at || started_at, now),
+      repeated_output_count: Map.get(command, :repeated_output_count, 0),
+      started_at: started_at,
+      last_output_at: last_output_at,
+      last_progress_at: last_progress_at
+    }
+  end
+
+  defp new_command(command, timestamp) do
+    %{
+      command: normalize_command(command) || "command",
+      status: :running,
+      started_at: timestamp,
+      last_output_at: nil,
+      last_progress_at: timestamp,
+      last_output_hash: nil,
+      repeated_output_count: 0,
+      stalled_policy_action?: false
+    }
+  end
+
+  defp mark_completed(nil, _timestamp), do: nil
+
+  defp mark_completed(command, timestamp) do
+    command
+    |> Map.put(:status, :completed)
+    |> Map.put(:completed_at, timestamp)
+    |> Map.put(:last_progress_at, timestamp)
+  end
+
+  defp apply_output(nil, _delta, _timestamp), do: nil
+  defp apply_output(command, nil, timestamp), do: %{command | last_output_at: timestamp}
+
+  defp apply_output(command, delta, timestamp) when is_binary(delta) do
+    hash = :crypto.hash(:sha256, delta)
+    previous_hash = Map.get(command, :last_output_hash)
+
+    if hash == previous_hash do
+      command
+      |> Map.put(:last_output_at, timestamp)
+      |> Map.update(:repeated_output_count, 1, &(&1 + 1))
+    else
+      command
+      |> Map.put(:last_output_at, timestamp)
+      |> Map.put(:last_progress_at, timestamp)
+      |> Map.put(:last_output_hash, hash)
+      |> Map.put(:repeated_output_count, 0)
+      |> Map.put(:stalled_policy_action?, false)
+    end
+  end
+
+  defp command_name(payload) do
+    map_path(payload, ["params", "msg", "command"]) ||
+      map_path(payload, [:params, :msg, :command]) ||
+      map_path(payload, ["params", "msg", "parsed_cmd"]) ||
+      map_path(payload, [:params, :msg, :parsed_cmd]) ||
+      map_path(payload, ["params", "item", "command"]) ||
+      map_path(payload, [:params, :item, :command]) ||
+      map_path(payload, ["params", "item", "parsed_cmd"]) ||
+      map_path(payload, [:params, :item, :parsed_cmd]) ||
+      map_path(payload, ["params", "item", "parsedCmd"]) ||
+      map_path(payload, [:params, :item, :parsedCmd]) ||
+      map_path(payload, ["params", "parsedCmd"]) ||
+      map_path(payload, [:params, :parsedCmd])
+  end
+
+  defp command_lifecycle_event?(payload, method) do
+    lifecycle_method = map_path(payload, ["method"]) || map_path(payload, [:method])
+
+    item_type =
+      map_path(payload, ["params", "item", "type"]) ||
+        map_path(payload, [:params, :item, :type])
+
+    lifecycle_method == method and item_type == "commandExecution"
+  end
+
+  defp normalize_command(%{} = command) do
+    binary_command =
+      map_path(command, ["parsedCmd"]) ||
+        map_path(command, [:parsedCmd]) ||
+        map_path(command, ["parsed_cmd"]) ||
+        map_path(command, [:parsed_cmd]) ||
+        map_path(command, ["command"]) ||
+        map_path(command, [:command]) ||
+        map_path(command, ["cmd"]) ||
+        map_path(command, [:cmd])
+
+    args =
+      map_path(command, ["args"]) ||
+        map_path(command, [:args]) ||
+        map_path(command, ["argv"]) ||
+        map_path(command, [:argv])
+
+    if is_binary(binary_command) and is_list(args) do
+      normalize_command([binary_command | args])
+    else
+      normalize_command(binary_command || args)
+    end
+  end
+
+  defp normalize_command(command) when is_binary(command) do
+    command
+    |> String.replace("\n", " ")
+    |> String.replace(~r/\s+/, " ")
+    |> String.trim()
+    |> case do
+      "" -> nil
+      normalized -> normalized
+    end
+  end
+
+  defp normalize_command(command) when is_list(command) do
+    if Enum.all?(command, &is_binary/1) do
+      command
+      |> Enum.join(" ")
+      |> normalize_command()
+    end
+  end
+
+  defp normalize_command(_command), do: nil
+
+  defp output_delta(payload) do
+    map_path(payload, ["params", "msg", "delta"]) ||
+      map_path(payload, [:params, :msg, :delta]) ||
+      map_path(payload, ["params", "msg", "output"]) ||
+      map_path(payload, [:params, :msg, :output]) ||
+      map_path(payload, ["params", "outputDelta"]) ||
+      map_path(payload, [:params, :outputDelta]) ||
+      map_path(payload, ["params", "delta"]) ||
+      map_path(payload, [:params, :delta])
+  end
+
+  defp elapsed_ms(%DateTime{} = from, %DateTime{} = to), do: max(0, DateTime.diff(to, from, :millisecond))
+  defp elapsed_ms(_from, _to), do: nil
+
+  defp map_path(data, [key | rest]) when is_map(data) do
+    case fetch_map_key(data, key) do
+      {:ok, value} when rest == [] -> value
+      {:ok, value} -> map_path(value, rest)
+      :error -> nil
+    end
+  end
+
+  defp map_path(_data, _path), do: nil
+
+  defp fetch_map_key(map, key) when is_map(map) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> {:ok, value}
+      :error -> Map.fetch(map, alternate_key(key))
+    end
+  end
+
+  defp alternate_key(key) when is_binary(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> key
+  end
+
+  defp alternate_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp alternate_key(key), do: key
+end

--- a/elixir/lib/symphony_elixir/codex/command_watchdog.ex
+++ b/elixir/lib/symphony_elixir/codex/command_watchdog.ex
@@ -274,11 +274,8 @@ defmodule SymphonyElixir.Codex.CommandWatchdog do
   end
 
   defp alternate_key(key) when is_binary(key) do
-    String.to_existing_atom(key)
-  rescue
-    ArgumentError -> key
+    String.to_atom(key)
   end
 
   defp alternate_key(key) when is_atom(key), do: Atom.to_string(key)
-  defp alternate_key(key), do: key
 end

--- a/elixir/lib/symphony_elixir/codex/command_watchdog.ex
+++ b/elixir/lib/symphony_elixir/codex/command_watchdog.ex
@@ -31,24 +31,22 @@ defmodule SymphonyElixir.Codex.CommandWatchdog do
     payload = update[:payload] || Map.get(update, "payload") || update
     method = map_path(payload, ["method"]) || map_path(payload, [:method])
 
-    cond do
-      method in ["codex/event/exec_command_begin", "item/commandExecution/begin"] or
-          command_lifecycle_event?(payload, "item/started") ->
+    case command_event(method, payload) do
+      :started ->
         new_command(command_name(payload), timestamp)
         |> classify(timestamp, policy)
 
-      method in ["codex/event/exec_command_end", "item/commandExecution/end"] or
-          command_lifecycle_event?(payload, "item/completed") ->
+      :completed ->
         command
         |> mark_completed(timestamp)
         |> classify(timestamp, policy)
 
-      method in ["codex/event/exec_command_output_delta", "item/commandExecution/outputDelta"] ->
+      :output ->
         command
         |> apply_output(output_delta(payload), timestamp)
         |> classify(timestamp, policy)
 
-      true ->
+      nil ->
         command && classify(command, timestamp, policy)
     end
   end
@@ -160,18 +158,42 @@ defmodule SymphonyElixir.Codex.CommandWatchdog do
   end
 
   defp command_name(payload) do
-    map_path(payload, ["params", "msg", "command"]) ||
-      map_path(payload, [:params, :msg, :command]) ||
-      map_path(payload, ["params", "msg", "parsed_cmd"]) ||
-      map_path(payload, [:params, :msg, :parsed_cmd]) ||
-      map_path(payload, ["params", "item", "command"]) ||
-      map_path(payload, [:params, :item, :command]) ||
-      map_path(payload, ["params", "item", "parsed_cmd"]) ||
-      map_path(payload, [:params, :item, :parsed_cmd]) ||
-      map_path(payload, ["params", "item", "parsedCmd"]) ||
-      map_path(payload, [:params, :item, :parsedCmd]) ||
-      map_path(payload, ["params", "parsedCmd"]) ||
-      map_path(payload, [:params, :parsedCmd])
+    first_path(payload, [
+      ["params", "msg", "command"],
+      [:params, :msg, :command],
+      ["params", "msg", "parsed_cmd"],
+      [:params, :msg, :parsed_cmd],
+      ["params", "item", "command"],
+      [:params, :item, :command],
+      ["params", "item", "parsed_cmd"],
+      [:params, :item, :parsed_cmd],
+      ["params", "item", "parsedCmd"],
+      [:params, :item, :parsedCmd],
+      ["params", "parsedCmd"],
+      [:params, :parsedCmd]
+    ])
+  end
+
+  defp command_event(method, payload) do
+    cond do
+      method in ["codex/event/exec_command_begin", "item/commandExecution/begin"] ->
+        :started
+
+      command_lifecycle_event?(payload, "item/started") ->
+        :started
+
+      method in ["codex/event/exec_command_end", "item/commandExecution/end"] ->
+        :completed
+
+      command_lifecycle_event?(payload, "item/completed") ->
+        :completed
+
+      method in ["codex/event/exec_command_output_delta", "item/commandExecution/outputDelta"] ->
+        :output
+
+      true ->
+        nil
+    end
   end
 
   defp command_lifecycle_event?(payload, method) do
@@ -185,21 +207,8 @@ defmodule SymphonyElixir.Codex.CommandWatchdog do
   end
 
   defp normalize_command(%{} = command) do
-    binary_command =
-      map_path(command, ["parsedCmd"]) ||
-        map_path(command, [:parsedCmd]) ||
-        map_path(command, ["parsed_cmd"]) ||
-        map_path(command, [:parsed_cmd]) ||
-        map_path(command, ["command"]) ||
-        map_path(command, [:command]) ||
-        map_path(command, ["cmd"]) ||
-        map_path(command, [:cmd])
-
-    args =
-      map_path(command, ["args"]) ||
-        map_path(command, [:args]) ||
-        map_path(command, ["argv"]) ||
-        map_path(command, [:argv])
+    binary_command = first_path(command, [["parsedCmd"], [:parsedCmd], ["parsed_cmd"], [:parsed_cmd], ["command"], [:command], ["cmd"], [:cmd]])
+    args = first_path(command, [["args"], [:args], ["argv"], [:argv]])
 
     if is_binary(binary_command) and is_list(args) do
       normalize_command([binary_command | args])
@@ -238,6 +247,10 @@ defmodule SymphonyElixir.Codex.CommandWatchdog do
       map_path(payload, [:params, :outputDelta]) ||
       map_path(payload, ["params", "delta"]) ||
       map_path(payload, [:params, :delta])
+  end
+
+  defp first_path(payload, paths) do
+    Enum.find_value(paths, &map_path(payload, &1))
   end
 
   defp elapsed_ms(%DateTime{} = from, %DateTime{} = to), do: max(0, DateTime.diff(to, from, :millisecond))

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -175,6 +175,11 @@ defmodule SymphonyElixir.Config.Schema do
       field(:turn_timeout_ms, :integer, default: 3_600_000)
       field(:read_timeout_ms, :integer, default: 5_000)
       field(:stall_timeout_ms, :integer, default: 300_000)
+      field(:command_watchdog_long_running_ms, :integer, default: 300_000)
+      field(:command_watchdog_idle_ms, :integer, default: 120_000)
+      field(:command_watchdog_stalled_ms, :integer, default: 300_000)
+      field(:command_watchdog_repeated_output_limit, :integer, default: 20)
+      field(:command_watchdog_block_on_stall, :boolean, default: false)
       field(:review_readiness_repository, :string)
       field(:review_readiness_required_checks, {:array, :string}, default: [])
     end
@@ -192,6 +197,11 @@ defmodule SymphonyElixir.Config.Schema do
           :turn_timeout_ms,
           :read_timeout_ms,
           :stall_timeout_ms,
+          :command_watchdog_long_running_ms,
+          :command_watchdog_idle_ms,
+          :command_watchdog_stalled_ms,
+          :command_watchdog_repeated_output_limit,
+          :command_watchdog_block_on_stall,
           :review_readiness_repository,
           :review_readiness_required_checks
         ],
@@ -201,6 +211,10 @@ defmodule SymphonyElixir.Config.Schema do
       |> validate_number(:turn_timeout_ms, greater_than: 0)
       |> validate_number(:read_timeout_ms, greater_than: 0)
       |> validate_number(:stall_timeout_ms, greater_than_or_equal_to: 0)
+      |> validate_number(:command_watchdog_long_running_ms, greater_than_or_equal_to: 0)
+      |> validate_number(:command_watchdog_idle_ms, greater_than_or_equal_to: 0)
+      |> validate_number(:command_watchdog_stalled_ms, greater_than_or_equal_to: 0)
+      |> validate_number(:command_watchdog_repeated_output_limit, greater_than: 0)
     end
   end
 

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -8,6 +8,7 @@ defmodule SymphonyElixir.Orchestrator do
   import Bitwise, only: [<<<: 2]
 
   alias SymphonyElixir.{AgentRunner, Config, StatusDashboard, Tracker, Workspace}
+  alias SymphonyElixir.Codex.CommandWatchdog
   alias SymphonyElixir.Linear.Issue
 
   @continuation_retry_delay_ms 1_000
@@ -196,9 +197,11 @@ defmodule SymphonyElixir.Orchestrator do
           state
           |> apply_codex_token_delta(token_delta)
           |> apply_codex_rate_limits(update)
+          |> put_running_entry(issue_id, updated_running_entry)
+          |> maybe_record_stalled_command(issue_id, DateTime.utc_now())
 
         notify_dashboard()
-        {:noreply, %{state | running: Map.put(running, issue_id, updated_running_entry)}}
+        {:noreply, state}
     end
   end
 
@@ -457,9 +460,6 @@ defmodule SymphonyElixir.Orchestrator do
     timeout_ms = Config.settings!().codex.stall_timeout_ms
 
     cond do
-      timeout_ms <= 0 ->
-        state
-
       map_size(state.running) == 0 ->
         state
 
@@ -467,7 +467,12 @@ defmodule SymphonyElixir.Orchestrator do
         now = DateTime.utc_now()
 
         Enum.reduce(state.running, state, fn {issue_id, running_entry}, state_acc ->
-          restart_stalled_issue(state_acc, issue_id, running_entry, now, timeout_ms)
+          running_entry = refresh_command_watchdog(running_entry, now)
+
+          state_acc
+          |> put_running_entry(issue_id, running_entry)
+          |> maybe_record_stalled_command(issue_id, now)
+          |> restart_stalled_issue(issue_id, running_entry, now, timeout_ms)
         end)
     end
   end
@@ -475,6 +480,19 @@ defmodule SymphonyElixir.Orchestrator do
   defp restart_stalled_issue(state, issue_id, running_entry, now, timeout_ms) do
     elapsed_ms = stall_elapsed_ms(running_entry, now)
 
+    cond do
+      active_command?(running_entry) ->
+        state
+
+      timeout_ms <= 0 ->
+        state
+
+      true ->
+        do_restart_stalled_issue(state, issue_id, running_entry, elapsed_ms, timeout_ms)
+    end
+  end
+
+  defp do_restart_stalled_issue(state, issue_id, running_entry, elapsed_ms, timeout_ms) do
     if is_integer(elapsed_ms) and elapsed_ms > timeout_ms do
       identifier = Map.get(running_entry, :identifier, issue_id)
       session_id = running_entry_session_id(running_entry)
@@ -731,6 +749,7 @@ defmodule SymphonyElixir.Orchestrator do
             last_codex_message: nil,
             last_codex_timestamp: nil,
             last_codex_event: nil,
+            command_watchdog: nil,
             codex_app_server_pid: nil,
             codex_input_tokens: 0,
             codex_output_tokens: 0,
@@ -1153,6 +1172,12 @@ defmodule SymphonyElixir.Orchestrator do
           last_codex_timestamp: metadata.last_codex_timestamp,
           last_codex_message: metadata.last_codex_message,
           last_codex_event: metadata.last_codex_event,
+          command_watchdog:
+            CommandWatchdog.snapshot(
+              Map.get(metadata, :command_watchdog),
+              now,
+              command_watchdog_policy()
+            ),
           runtime_seconds: running_seconds(metadata.started_at, now)
         }
       end)
@@ -1211,6 +1236,11 @@ defmodule SymphonyElixir.Orchestrator do
     last_reported_total = Map.get(running_entry, :codex_last_reported_total_tokens, 0)
     turn_count = Map.get(running_entry, :turn_count, 0)
 
+    command_watchdog =
+      running_entry
+      |> Map.get(:command_watchdog)
+      |> CommandWatchdog.update(update, command_watchdog_policy())
+
     {
       Map.merge(running_entry, %{
         last_codex_timestamp: timestamp,
@@ -1224,11 +1254,101 @@ defmodule SymphonyElixir.Orchestrator do
         codex_last_reported_input_tokens: max(last_reported_input, token_delta.input_reported),
         codex_last_reported_output_tokens: max(last_reported_output, token_delta.output_reported),
         codex_last_reported_total_tokens: max(last_reported_total, token_delta.total_reported),
-        turn_count: turn_count_for_update(turn_count, running_entry.session_id, update)
+        turn_count: turn_count_for_update(turn_count, running_entry.session_id, update),
+        command_watchdog: command_watchdog
       }),
       token_delta
     }
   end
+
+  defp put_running_entry(%State{} = state, issue_id, running_entry) when is_binary(issue_id) and is_map(running_entry) do
+    %{state | running: Map.put(state.running, issue_id, running_entry)}
+  end
+
+  defp refresh_command_watchdog(running_entry, %DateTime{} = now) when is_map(running_entry) do
+    command_watchdog =
+      running_entry
+      |> Map.get(:command_watchdog)
+      |> CommandWatchdog.classify(now, command_watchdog_policy())
+
+    Map.put(running_entry, :command_watchdog, command_watchdog)
+  end
+
+  defp active_command?(%{command_watchdog: %{status: :running}}), do: true
+  defp active_command?(_running_entry), do: false
+
+  defp maybe_record_stalled_command(%State{} = state, issue_id, %DateTime{} = now) do
+    case Map.get(state.running, issue_id) do
+      %{command_watchdog: %{classification: :stalled, stalled_policy_action?: false} = command} = running_entry ->
+        identifier = Map.get(running_entry, :identifier, issue_id)
+        session_id = running_entry_session_id(running_entry)
+        policy = command_watchdog_policy()
+
+        Logger.warning(
+          "Command watchdog stalled: issue_id=#{issue_id} issue_identifier=#{identifier} session_id=#{session_id} command=#{inspect(command.command)} age_ms=#{elapsed_value(command.started_at, now)} idle_ms=#{elapsed_value(command.last_progress_at || command.started_at, now)} reason=#{inspect(command.classification_reason)}"
+        )
+
+        :ok = create_stalled_command_comment(issue_id, identifier, session_id, command, now)
+        :ok = maybe_block_stalled_command(issue_id, policy)
+
+        updated_command = %{command | stalled_policy_action?: true}
+        put_running_entry(state, issue_id, %{running_entry | command_watchdog: updated_command})
+
+      _ ->
+        state
+    end
+  end
+
+  defp create_stalled_command_comment(issue_id, identifier, session_id, command, now) do
+    body =
+      [
+        "## Symphony Command Watchdog",
+        "",
+        "Issue: #{identifier}",
+        "Session: #{session_id}",
+        "Classification: stalled",
+        "Command: #{command.command}",
+        "Reason: #{command.classification_reason}",
+        "Observed at: #{DateTime.to_iso8601(now)}",
+        "",
+        "The worker was left running so an operator can decide whether the command is still useful."
+      ]
+      |> Enum.join("\n")
+
+    case Tracker.create_comment(issue_id, body) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Failed to create stalled command watchdog comment: issue_id=#{issue_id} reason=#{inspect(reason)}")
+        :ok
+    end
+  end
+
+  defp maybe_block_stalled_command(issue_id, %{block_on_stall: true}) do
+    case Tracker.update_issue_state(issue_id, "Blocked") do
+      :ok ->
+        :ok
+
+      {:error, :state_not_found} ->
+        Logger.warning("Blocked state missing for stalled command: issue_id=#{issue_id}")
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Failed to move stalled command issue to Blocked: issue_id=#{issue_id} reason=#{inspect(reason)}")
+        :ok
+    end
+  end
+
+  defp maybe_block_stalled_command(_issue_id, _policy), do: :ok
+
+  defp command_watchdog_policy do
+    Config.settings!().codex
+    |> CommandWatchdog.policy_from_config()
+  end
+
+  defp elapsed_value(%DateTime{} = from, %DateTime{} = to), do: DateTime.diff(to, from, :millisecond)
+  defp elapsed_value(_from, _to), do: nil
 
   defp codex_app_server_pid_for_update(_existing, %{codex_app_server_pid: pid})
        when is_binary(pid),

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -459,21 +459,19 @@ defmodule SymphonyElixir.Orchestrator do
   defp reconcile_stalled_running_issues(%State{} = state) do
     timeout_ms = Config.settings!().codex.stall_timeout_ms
 
-    cond do
-      map_size(state.running) == 0 ->
-        state
+    if map_size(state.running) == 0 do
+      state
+    else
+      now = DateTime.utc_now()
 
-      true ->
-        now = DateTime.utc_now()
+      Enum.reduce(state.running, state, fn {issue_id, running_entry}, state_acc ->
+        running_entry = refresh_command_watchdog(running_entry, now)
 
-        Enum.reduce(state.running, state, fn {issue_id, running_entry}, state_acc ->
-          running_entry = refresh_command_watchdog(running_entry, now)
-
-          state_acc
-          |> put_running_entry(issue_id, running_entry)
-          |> maybe_record_stalled_command(issue_id, now)
-          |> restart_stalled_issue(issue_id, running_entry, now, timeout_ms)
-        end)
+        state_acc
+        |> put_running_entry(issue_id, running_entry)
+        |> maybe_record_stalled_command(issue_id, now)
+        |> restart_stalled_issue(issue_id, running_entry, now, timeout_ms)
+      end)
     end
   end
 

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -526,8 +526,6 @@ defmodule SymphonyElixir.Orchestrator do
     Map.get(running_entry, :last_codex_timestamp) || Map.get(running_entry, :started_at)
   end
 
-  defp last_activity_timestamp(_running_entry), do: nil
-
   defp terminate_task(pid) when is_pid(pid) do
     case Task.Supervisor.terminate_child(SymphonyElixir.TaskSupervisor, pid) do
       :ok ->

--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -598,7 +598,12 @@ defmodule SymphonyElixir.StatusDashboard do
     turn_count = Map.get(running_entry, :turn_count, 0)
     age = format_cell(format_runtime_and_turns(runtime_seconds, turn_count), @running_age_width)
     event = running_entry.last_codex_event || "none"
-    event_label = format_cell(summarize_message(running_entry.last_codex_message), running_event_width)
+
+    event_label =
+      [format_command_watchdog(running_entry), summarize_message(running_entry.last_codex_message)]
+      |> Enum.reject(&(&1 in [nil, ""]))
+      |> Enum.join(" | ")
+      |> format_cell(running_event_width)
 
     tokens = format_count(total_tokens) |> format_cell(@running_tokens_width, :right)
 
@@ -644,6 +649,28 @@ defmodule SymphonyElixir.StatusDashboard do
   @doc false
   @spec tps_graph_for_test([{integer(), integer()}], integer(), integer()) :: String.t()
   def tps_graph_for_test(samples, now_ms, current_tokens), do: tps_graph(samples, now_ms, current_tokens)
+
+  defp format_command_watchdog(%{classification: classification, age_ms: age_ms} = watchdog) do
+    command =
+      case Map.get(watchdog, :command) do
+        value when is_binary(value) -> value
+        _ -> "command"
+      end
+
+    "cmd #{classification} #{format_watchdog_age(age_ms)} #{command}"
+  end
+
+  defp format_command_watchdog(%{command_watchdog: nil}), do: nil
+  defp format_command_watchdog(%{} = running_entry), do: format_command_watchdog(Map.get(running_entry, :command_watchdog))
+  defp format_command_watchdog(_watchdog), do: nil
+
+  defp format_watchdog_age(age_ms) when is_integer(age_ms) do
+    age_ms
+    |> div(1_000)
+    |> format_runtime_seconds()
+  end
+
+  defp format_watchdog_age(_age_ms), do: "n/a"
 
   defp format_retry_rows(retrying) do
     if retrying == [] do

--- a/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
@@ -334,14 +334,10 @@ defmodule SymphonyElixirWeb.DashboardLive do
   defp watchdog_badge_class(classification) do
     base = "state-badge"
 
-    case classification do
-      :healthy -> "#{base} state-badge-active"
+    case to_string(classification) do
       "healthy" -> "#{base} state-badge-active"
-      :idle -> "#{base} state-badge-warning"
       "idle" -> "#{base} state-badge-warning"
-      :stalled -> "#{base} state-badge-danger"
       "stalled" -> "#{base} state-badge-danger"
-      :needs_attention -> "#{base} state-badge-warning"
       "needs_attention" -> "#{base} state-badge-warning"
       _ -> base
     end

--- a/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
@@ -178,7 +178,17 @@ defmodule SymphonyElixirWeb.DashboardLive do
                         <% end %>
                       </div>
                     </td>
-                    <td class="numeric"><%= format_runtime_and_turns(entry.started_at, entry.turn_count, @now) %></td>
+                    <td>
+                      <div class="detail-stack numeric">
+                        <span><%= format_runtime_and_turns(entry.started_at, entry.turn_count, @now) %></span>
+                        <%= if entry.command_watchdog do %>
+                          <span class={watchdog_badge_class(entry.command_watchdog.classification)}>
+                            <%= entry.command_watchdog.classification %>
+                            · <%= format_watchdog_age(entry.command_watchdog.age_ms) %>
+                          </span>
+                        <% end %>
+                      </div>
+                    </td>
                     <td>
                       <div class="detail-stack">
                         <span
@@ -320,6 +330,30 @@ defmodule SymphonyElixirWeb.DashboardLive do
       true -> base
     end
   end
+
+  defp watchdog_badge_class(classification) do
+    base = "state-badge"
+
+    case classification do
+      :healthy -> "#{base} state-badge-active"
+      "healthy" -> "#{base} state-badge-active"
+      :idle -> "#{base} state-badge-warning"
+      "idle" -> "#{base} state-badge-warning"
+      :stalled -> "#{base} state-badge-danger"
+      "stalled" -> "#{base} state-badge-danger"
+      :needs_attention -> "#{base} state-badge-warning"
+      "needs_attention" -> "#{base} state-badge-warning"
+      _ -> base
+    end
+  end
+
+  defp format_watchdog_age(age_ms) when is_integer(age_ms) do
+    age_ms
+    |> div(1_000)
+    |> format_runtime_seconds()
+  end
+
+  defp format_watchdog_age(_age_ms), do: "n/a"
 
   defp schedule_runtime_tick do
     Process.send_after(self(), :runtime_tick, @runtime_tick_ms)

--- a/elixir/lib/symphony_elixir_web/presenter.ex
+++ b/elixir/lib/symphony_elixir_web/presenter.ex
@@ -108,6 +108,7 @@ defmodule SymphonyElixirWeb.Presenter do
       last_message: summarize_message(entry.last_codex_message),
       started_at: iso8601(entry.started_at),
       last_event_at: iso8601(entry.last_codex_timestamp),
+      command_watchdog: command_watchdog_payload(Map.get(entry, :command_watchdog)),
       tokens: %{
         input_tokens: entry.codex_input_tokens,
         output_tokens: entry.codex_output_tokens,
@@ -139,6 +140,7 @@ defmodule SymphonyElixirWeb.Presenter do
       last_event: running.last_codex_event,
       last_message: summarize_message(running.last_codex_message),
       last_event_at: iso8601(running.last_codex_timestamp),
+      command_watchdog: command_watchdog_payload(Map.get(running, :command_watchdog)),
       tokens: %{
         input_tokens: running.codex_input_tokens,
         output_tokens: running.codex_output_tokens,
@@ -180,6 +182,23 @@ defmodule SymphonyElixirWeb.Presenter do
 
   defp summarize_message(nil), do: nil
   defp summarize_message(message), do: StatusDashboard.humanize_codex_message(message)
+
+  defp command_watchdog_payload(nil), do: nil
+
+  defp command_watchdog_payload(watchdog) when is_map(watchdog) do
+    %{
+      command: Map.get(watchdog, :command),
+      status: Map.get(watchdog, :status),
+      classification: Map.get(watchdog, :classification),
+      classification_reason: Map.get(watchdog, :classification_reason),
+      age_ms: Map.get(watchdog, :age_ms),
+      idle_ms: Map.get(watchdog, :idle_ms),
+      repeated_output_count: Map.get(watchdog, :repeated_output_count),
+      started_at: iso8601(Map.get(watchdog, :started_at)),
+      last_output_at: iso8601(Map.get(watchdog, :last_output_at)),
+      last_progress_at: iso8601(Map.get(watchdog, :last_progress_at))
+    }
+  end
 
   defp due_at_iso8601(due_in_ms) when is_integer(due_in_ms) do
     DateTime.utc_now()

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -143,6 +143,11 @@ defmodule SymphonyElixir.TestSupport do
           codex_turn_timeout_ms: 3_600_000,
           codex_read_timeout_ms: 5_000,
           codex_stall_timeout_ms: 300_000,
+          codex_command_watchdog_long_running_ms: 300_000,
+          codex_command_watchdog_idle_ms: 120_000,
+          codex_command_watchdog_stalled_ms: 300_000,
+          codex_command_watchdog_repeated_output_limit: 20,
+          codex_command_watchdog_block_on_stall: false,
           codex_review_readiness_repository: "albert-zen/symphony-windows-native",
           codex_review_readiness_required_checks: [],
           hook_after_create: nil,
@@ -183,6 +188,11 @@ defmodule SymphonyElixir.TestSupport do
     codex_turn_timeout_ms = Keyword.get(config, :codex_turn_timeout_ms)
     codex_read_timeout_ms = Keyword.get(config, :codex_read_timeout_ms)
     codex_stall_timeout_ms = Keyword.get(config, :codex_stall_timeout_ms)
+    codex_command_watchdog_long_running_ms = Keyword.get(config, :codex_command_watchdog_long_running_ms)
+    codex_command_watchdog_idle_ms = Keyword.get(config, :codex_command_watchdog_idle_ms)
+    codex_command_watchdog_stalled_ms = Keyword.get(config, :codex_command_watchdog_stalled_ms)
+    codex_command_watchdog_repeated_output_limit = Keyword.get(config, :codex_command_watchdog_repeated_output_limit)
+    codex_command_watchdog_block_on_stall = Keyword.get(config, :codex_command_watchdog_block_on_stall)
     codex_review_readiness_repository = Keyword.get(config, :codex_review_readiness_repository)
     codex_review_readiness_required_checks = Keyword.get(config, :codex_review_readiness_required_checks)
     hook_after_create = Keyword.get(config, :hook_after_create)
@@ -227,6 +237,11 @@ defmodule SymphonyElixir.TestSupport do
         "  turn_timeout_ms: #{yaml_value(codex_turn_timeout_ms)}",
         "  read_timeout_ms: #{yaml_value(codex_read_timeout_ms)}",
         "  stall_timeout_ms: #{yaml_value(codex_stall_timeout_ms)}",
+        "  command_watchdog_long_running_ms: #{yaml_value(codex_command_watchdog_long_running_ms)}",
+        "  command_watchdog_idle_ms: #{yaml_value(codex_command_watchdog_idle_ms)}",
+        "  command_watchdog_stalled_ms: #{yaml_value(codex_command_watchdog_stalled_ms)}",
+        "  command_watchdog_repeated_output_limit: #{yaml_value(codex_command_watchdog_repeated_output_limit)}",
+        "  command_watchdog_block_on_stall: #{yaml_value(codex_command_watchdog_block_on_stall)}",
         "  review_readiness_repository: #{yaml_value(codex_review_readiness_repository)}",
         "  review_readiness_required_checks: #{yaml_value(codex_review_readiness_required_checks)}",
         hooks_yaml(hook_after_create, hook_before_run, hook_after_run, hook_before_remove, hook_timeout_ms),

--- a/elixir/test/symphony_elixir/command_watchdog_test.exs
+++ b/elixir/test/symphony_elixir/command_watchdog_test.exs
@@ -1,0 +1,196 @@
+defmodule SymphonyElixir.CommandWatchdogTest do
+  use ExUnit.Case, async: true
+
+  alias SymphonyElixir.Codex.CommandWatchdog
+
+  @policy %{
+    long_running_ms: 1_000,
+    idle_ms: 2_000,
+    stalled_ms: 5_000,
+    repeated_output_limit: 3,
+    block_on_stall: false
+  }
+
+  test "classifies healthy long-running output" do
+    started_at = ~U[2026-05-01 00:00:00Z]
+
+    command =
+      nil
+      |> CommandWatchdog.update(command_begin(started_at), @policy)
+      |> CommandWatchdog.update(output_delta("step 1", DateTime.add(started_at, 2, :second)), @policy)
+
+    snapshot =
+      CommandWatchdog.snapshot(command, DateTime.add(started_at, 3, :second), @policy)
+
+    assert snapshot.classification == :healthy
+    assert snapshot.last_output_at == DateTime.add(started_at, 2, :second)
+    assert snapshot.last_progress_at == DateTime.add(started_at, 2, :second)
+  end
+
+  test "classifies no-output command stall" do
+    started_at = ~U[2026-05-01 00:00:00Z]
+    command = CommandWatchdog.update(nil, command_begin(started_at), @policy)
+
+    snapshot =
+      CommandWatchdog.snapshot(command, DateTime.add(started_at, 6, :second), @policy)
+
+    assert snapshot.classification == :stalled
+    assert snapshot.idle_ms == 6_000
+  end
+
+  test "classifies repeated identical output as needing attention before stall" do
+    started_at = ~U[2026-05-01 00:00:00Z]
+
+    command =
+      nil
+      |> CommandWatchdog.update(command_begin(started_at), @policy)
+      |> CommandWatchdog.update(output_delta("make-all pending...", DateTime.add(started_at, 1, :second)), @policy)
+      |> CommandWatchdog.update(output_delta("make-all pending...", DateTime.add(started_at, 2, :second)), @policy)
+      |> CommandWatchdog.update(output_delta("make-all pending...", DateTime.add(started_at, 3, :second)), @policy)
+      |> CommandWatchdog.update(output_delta("make-all pending...", DateTime.add(started_at, 4, :second)), @policy)
+
+    snapshot =
+      CommandWatchdog.snapshot(command, DateTime.add(started_at, 4, :second), @policy)
+
+    assert snapshot.classification == :needs_attention
+    assert snapshot.repeated_output_count == 3
+    assert snapshot.last_progress_at == DateTime.add(started_at, 1, :second)
+  end
+
+  test "recovers after new output" do
+    started_at = ~U[2026-05-01 00:00:00Z]
+
+    command =
+      nil
+      |> CommandWatchdog.update(command_begin(started_at), @policy)
+      |> CommandWatchdog.update(output_delta("same", DateTime.add(started_at, 1, :second)), @policy)
+      |> CommandWatchdog.update(output_delta("same", DateTime.add(started_at, 2, :second)), @policy)
+      |> CommandWatchdog.update(output_delta("same", DateTime.add(started_at, 3, :second)), @policy)
+      |> CommandWatchdog.update(output_delta("same", DateTime.add(started_at, 4, :second)), @policy)
+      |> CommandWatchdog.update(output_delta("new progress", DateTime.add(started_at, 4, :second)), @policy)
+
+    snapshot =
+      CommandWatchdog.snapshot(command, DateTime.add(started_at, 4, :second), @policy)
+
+    assert snapshot.classification == :healthy
+    assert snapshot.repeated_output_count == 0
+    assert snapshot.last_progress_at == DateTime.add(started_at, 4, :second)
+  end
+
+  test "tracks app-server item command execution lifecycle" do
+    started_at = ~U[2026-05-01 00:00:00Z]
+
+    command =
+      nil
+      |> CommandWatchdog.update(item_started(["mix", "test"], started_at), @policy)
+      |> CommandWatchdog.update(output_delta("running", DateTime.add(started_at, 1, :second)), @policy)
+
+    snapshot =
+      CommandWatchdog.snapshot(command, DateTime.add(started_at, 2, :second), @policy)
+
+    assert snapshot.command == "mix test"
+    assert snapshot.classification == :healthy
+    assert snapshot.last_progress_at == DateTime.add(started_at, 1, :second)
+
+    completed =
+      CommandWatchdog.update(command, item_completed(DateTime.add(started_at, 3, :second)), @policy)
+
+    assert CommandWatchdog.snapshot(completed, DateTime.add(started_at, 4, :second), @policy).status ==
+             :completed
+  end
+
+  test "normalizes mapped parsed commands before storing them" do
+    started_at = ~U[2026-05-01 00:00:00Z]
+
+    command =
+      CommandWatchdog.update(
+        nil,
+        command_begin(%{"parsedCmd" => "mix", "args" => ["test", "--stale"]}, started_at),
+        @policy
+      )
+
+    snapshot =
+      CommandWatchdog.snapshot(command, DateTime.add(started_at, 1, :second), @policy)
+
+    assert snapshot.command == "mix test --stale"
+  end
+
+  test "ignores non-command item lifecycle events" do
+    started_at = ~U[2026-05-01 00:00:00Z]
+
+    assert CommandWatchdog.update(nil, item_started("fileChange", "mix test", started_at), @policy) == nil
+
+    command = CommandWatchdog.update(nil, item_started("commandExecution", "mix test", started_at), @policy)
+
+    completed =
+      CommandWatchdog.update(
+        command,
+        item_completed("fileChange", DateTime.add(started_at, 1, :second)),
+        @policy
+      )
+
+    assert CommandWatchdog.snapshot(completed, DateTime.add(started_at, 1, :second), @policy).status ==
+             :running
+  end
+
+  defp command_begin(timestamp) do
+    command_begin("make all", timestamp)
+  end
+
+  defp command_begin(command, timestamp) do
+    %{
+      event: :notification,
+      timestamp: timestamp,
+      payload: %{
+        "method" => "codex/event/exec_command_begin",
+        "params" => %{"msg" => %{"command" => command}}
+      }
+    }
+  end
+
+  defp item_started(command, timestamp) do
+    item_started("commandExecution", command, timestamp)
+  end
+
+  defp item_started(type, command, timestamp) do
+    %{
+      event: :notification,
+      timestamp: timestamp,
+      payload: %{
+        "method" => "item/started",
+        "params" => %{
+          "item" => %{
+            "type" => type,
+            "parsedCmd" => command
+          }
+        }
+      }
+    }
+  end
+
+  defp item_completed(timestamp) do
+    item_completed("commandExecution", timestamp)
+  end
+
+  defp item_completed(type, timestamp) do
+    %{
+      event: :notification,
+      timestamp: timestamp,
+      payload: %{
+        "method" => "item/completed",
+        "params" => %{"item" => %{"type" => type}}
+      }
+    }
+  end
+
+  defp output_delta(delta, timestamp) do
+    %{
+      event: :notification,
+      timestamp: timestamp,
+      payload: %{
+        "method" => "codex/event/exec_command_output_delta",
+        "params" => %{"msg" => %{"delta" => delta}}
+      }
+    }
+  end
+end

--- a/elixir/test/symphony_elixir/command_watchdog_test.exs
+++ b/elixir/test/symphony_elixir/command_watchdog_test.exs
@@ -38,6 +38,17 @@ defmodule SymphonyElixir.CommandWatchdogTest do
     assert snapshot.idle_ms == 6_000
   end
 
+  test "classifies idle before stalled" do
+    started_at = ~U[2026-05-01 00:00:00Z]
+    command = CommandWatchdog.update(nil, command_begin(started_at), @policy)
+
+    snapshot =
+      CommandWatchdog.snapshot(command, DateTime.add(started_at, 3, :second), @policy)
+
+    assert snapshot.classification == :idle
+    assert snapshot.classification_reason == "no command progress for 3000ms"
+  end
+
   test "classifies repeated identical output as needing attention before stall" do
     started_at = ~U[2026-05-01 00:00:00Z]
 
@@ -115,6 +126,25 @@ defmodule SymphonyElixir.CommandWatchdogTest do
     assert snapshot.command == "mix test --stale"
   end
 
+  test "normalizes alternate command shapes" do
+    started_at = ~U[2026-05-01 00:00:00Z]
+
+    cases = [
+      {%{cmd: "mix", argv: ["format"]}, "mix format"},
+      {%{"command" => "mix test\n--cover"}, "mix test --cover"},
+      {["git", "status", "--short"], "git status --short"},
+      {["git", :status], "command"},
+      {%{"args" => ["make", "all"]}, "make all"},
+      {%{"bad" => true}, "command"},
+      {"   ", "command"}
+    ]
+
+    for {input, expected} <- cases do
+      command = CommandWatchdog.update(nil, command_begin(input, started_at), @policy)
+      assert CommandWatchdog.snapshot(command, started_at, @policy).command == expected
+    end
+  end
+
   test "ignores non-command item lifecycle events" do
     started_at = ~U[2026-05-01 00:00:00Z]
 
@@ -133,8 +163,83 @@ defmodule SymphonyElixir.CommandWatchdogTest do
              :running
   end
 
+  test "handles ignored updates and nil snapshots" do
+    started_at = ~U[2026-05-01 00:00:00Z]
+
+    assert CommandWatchdog.snapshot(nil, started_at, @policy) == nil
+    assert CommandWatchdog.snapshot(%{}, started_at, @policy).age_ms == nil
+    assert CommandWatchdog.classify(%{}, started_at, @policy) == %{}
+    assert CommandWatchdog.update(nil, %{event: :notification}, @policy) == nil
+    assert CommandWatchdog.update(nil, command_end(started_at), @policy) == nil
+    assert CommandWatchdog.update(nil, output_delta("orphan", started_at), @policy) == nil
+
+    command = CommandWatchdog.update(nil, command_begin(started_at), @policy)
+    assert CommandWatchdog.update(command, ignored_event(DateTime.add(started_at, 1, :second)), @policy)
+
+    no_delta =
+      CommandWatchdog.update(
+        command,
+        %{
+          event: :notification,
+          timestamp: DateTime.add(started_at, 1, :second),
+          payload: %{"method" => "codex/event/exec_command_output_delta", "params" => %{"msg" => %{}}}
+        },
+        @policy
+      )
+
+    assert no_delta.last_output_at == DateTime.add(started_at, 1, :second)
+
+    non_map_path =
+      CommandWatchdog.update(
+        command,
+        %{
+          event: :notification,
+          timestamp: DateTime.add(started_at, 2, :second),
+          payload: %{"method" => "codex/event/exec_command_output_delta", "params" => "not a map"}
+        },
+        @policy
+      )
+
+    assert non_map_path.last_output_at == DateTime.add(started_at, 2, :second)
+  end
+
+  test "builds policy from config defaults and overrides" do
+    assert CommandWatchdog.policy_from_config(%{}) == %{
+             long_running_ms: 300_000,
+             idle_ms: 120_000,
+             stalled_ms: 300_000,
+             repeated_output_limit: 20,
+             block_on_stall: false
+           }
+
+    policy =
+      CommandWatchdog.policy_from_config(%{
+        command_watchdog_long_running_ms: 1,
+        command_watchdog_idle_ms: 2,
+        command_watchdog_stalled_ms: 3,
+        command_watchdog_repeated_output_limit: 4,
+        command_watchdog_block_on_stall: true
+      })
+
+    assert policy == %{
+             long_running_ms: 1,
+             idle_ms: 2,
+             stalled_ms: 3,
+             repeated_output_limit: 4,
+             block_on_stall: true
+           }
+  end
+
   defp command_begin(timestamp) do
     command_begin("make all", timestamp)
+  end
+
+  defp ignored_event(timestamp) do
+    %{
+      event: :notification,
+      timestamp: timestamp,
+      payload: %{"method" => "codex/event/agent_reasoning", "params" => %{"msg" => %{}}}
+    }
   end
 
   defp command_begin(command, timestamp) do
@@ -179,6 +284,17 @@ defmodule SymphonyElixir.CommandWatchdogTest do
       payload: %{
         "method" => "item/completed",
         "params" => %{"item" => %{"type" => type}}
+      }
+    }
+  end
+
+  defp command_end(timestamp) do
+    %{
+      event: :notification,
+      timestamp: timestamp,
+      payload: %{
+        method: "codex/event/exec_command_end",
+        params: %{msg: %{exit_code: 0}}
       }
     }
   end

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -847,6 +847,7 @@ defmodule SymphonyElixir.ExtensionsTest do
                  "last_message" => "rendered",
                  "started_at" => state_payload["running"] |> List.first() |> Map.fetch!("started_at"),
                  "last_event_at" => nil,
+                 "command_watchdog" => nil,
                  "tokens" => %{"input_tokens" => 4, "output_tokens" => 8, "total_tokens" => 12}
                }
              ],
@@ -892,6 +893,7 @@ defmodule SymphonyElixir.ExtensionsTest do
                "last_event" => "notification",
                "last_message" => "rendered",
                "last_event_at" => nil,
+               "command_watchdog" => nil,
                "tokens" => %{"input_tokens" => 4, "output_tokens" => 8, "total_tokens" => 12}
              },
              "retry" => nil,

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -101,6 +101,95 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
            }
   end
 
+  test "orchestrator snapshot includes command watchdog metadata and stalled policy comments" do
+    write_workflow_file!(
+      Workflow.workflow_file_path(),
+      tracker_kind: "memory",
+      codex_stall_timeout_ms: 0,
+      codex_command_watchdog_long_running_ms: 1_000,
+      codex_command_watchdog_idle_ms: 2_000,
+      codex_command_watchdog_stalled_ms: 5_000,
+      codex_command_watchdog_repeated_output_limit: 3
+    )
+
+    Application.put_env(:symphony_elixir, :memory_tracker_recipient, self())
+
+    issue_id = "issue-command-watchdog"
+
+    issue = %Issue{
+      id: issue_id,
+      identifier: "MT-240",
+      title: "Command watchdog",
+      description: "Track command progress",
+      state: "In Progress",
+      url: "https://example.org/issues/MT-240"
+    }
+
+    orchestrator_name = Module.concat(__MODULE__, :CommandWatchdogOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    initial_state = :sys.get_state(pid)
+    process_ref = make_ref()
+    started_at = ~U[2026-05-01 00:00:00Z]
+
+    running_entry = %{
+      pid: self(),
+      ref: process_ref,
+      identifier: issue.identifier,
+      issue: issue,
+      session_id: "thread-watchdog",
+      last_codex_message: nil,
+      last_codex_timestamp: nil,
+      last_codex_event: nil,
+      codex_input_tokens: 0,
+      codex_output_tokens: 0,
+      codex_total_tokens: 0,
+      codex_last_reported_input_tokens: 0,
+      codex_last_reported_output_tokens: 0,
+      codex_last_reported_total_tokens: 0,
+      started_at: started_at
+    }
+
+    :sys.replace_state(pid, fn _ ->
+      initial_state
+      |> Map.put(:running, %{issue_id => running_entry})
+      |> Map.put(:claimed, MapSet.put(initial_state.claimed, issue_id))
+    end)
+
+    send(pid, {:codex_worker_update, issue_id, command_begin("make all", started_at)})
+
+    send(
+      pid,
+      {:codex_worker_update, issue_id,
+       %{
+         event: :notification,
+         payload: %{"method" => "codex/event/agent_reasoning", "params" => %{"msg" => %{}}},
+         timestamp: DateTime.add(started_at, 6, :second)
+       }}
+    )
+
+    snapshot =
+      wait_for_snapshot(pid, fn snapshot ->
+        match?(%{running: [%{command_watchdog: %{classification: :stalled}}]}, snapshot)
+      end)
+
+    assert %{running: [snapshot_entry]} = snapshot
+    assert snapshot_entry.command_watchdog.command == "make all"
+    assert snapshot_entry.command_watchdog.age_ms >= 6_000
+    assert snapshot_entry.command_watchdog.idle_ms >= 6_000
+
+    assert_receive {:memory_tracker_comment, ^issue_id, body}
+    assert body =~ "## Symphony Command Watchdog"
+    assert body =~ "Classification: stalled"
+    assert body =~ "Command: make all"
+  end
+
   test "orchestrator snapshot tracks codex thread totals and app-server pid" do
     issue_id = "issue-usage-snapshot"
 
@@ -1274,25 +1363,35 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
   test "status dashboard renders last codex message in EVENT column" do
     row =
-      StatusDashboard.format_running_summary_for_test(%{
-        identifier: "MT-233",
-        state: "running",
-        session_id: "thread-1234567890",
-        codex_app_server_pid: "4242",
-        codex_total_tokens: 12,
-        runtime_seconds: 15,
-        last_codex_event: :notification,
-        last_codex_message: %{
-          event: :notification,
-          message: %{
-            "method" => "turn/completed",
-            "params" => %{"turn" => %{"status" => "completed"}}
+      StatusDashboard.format_running_summary_for_test(
+        %{
+          identifier: "MT-233",
+          state: "running",
+          session_id: "thread-1234567890",
+          codex_app_server_pid: "4242",
+          codex_total_tokens: 12,
+          runtime_seconds: 15,
+          last_codex_event: :notification,
+          last_codex_message: %{
+            event: :notification,
+            message: %{
+              "method" => "turn/completed",
+              "params" => %{"turn" => %{"status" => "completed"}}
+            }
+          },
+          command_watchdog: %{
+            command: "make all",
+            classification: :healthy,
+            age_ms: 90_000
           }
-        }
-      })
+        },
+        160
+      )
 
-    plain = Regex.replace(~r/\e\[[\\d;]*m/, row, "")
+    plain = Regex.replace(~r/\e\[[0-9;]*m/, row, "")
 
+    assert plain =~ "cmd healthy"
+    assert plain =~ "make all"
     assert plain =~ "turn completed (completed)"
     assert (String.split(plain, "turn completed (completed)") |> length()) - 1 == 1
     refute plain =~ " notification "
@@ -1555,6 +1654,17 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
   defp wait_for_snapshot(pid, predicate, timeout_ms \\ 200) when is_function(predicate, 1) do
     deadline_ms = System.monotonic_time(:millisecond) + timeout_ms
     do_wait_for_snapshot(pid, predicate, deadline_ms)
+  end
+
+  defp command_begin(command, timestamp) do
+    %{
+      event: :notification,
+      timestamp: timestamp,
+      payload: %{
+        "method" => "codex/event/exec_command_begin",
+        "params" => %{"msg" => %{"command" => command}}
+      }
+    }
   end
 
   defp do_wait_for_snapshot(pid, predicate, deadline_ms) do

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -967,6 +967,11 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert config.codex.turn_timeout_ms == 3_600_000
     assert config.codex.read_timeout_ms == 5_000
     assert config.codex.stall_timeout_ms == 300_000
+    assert config.codex.command_watchdog_long_running_ms == 300_000
+    assert config.codex.command_watchdog_idle_ms == 120_000
+    assert config.codex.command_watchdog_stalled_ms == 300_000
+    assert config.codex.command_watchdog_repeated_output_limit == 20
+    refute config.codex.command_watchdog_block_on_stall
 
     write_workflow_file!(Workflow.workflow_file_path(),
       codex_command: "codex --config 'model=\"gpt-5.5\"' app-server"
@@ -1039,6 +1044,10 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     write_workflow_file!(Workflow.workflow_file_path(), codex_stall_timeout_ms: "bad")
     assert {:error, {:invalid_workflow_config, message}} = Config.validate!()
     assert message =~ "codex.stall_timeout_ms"
+
+    write_workflow_file!(Workflow.workflow_file_path(), codex_command_watchdog_stalled_ms: "bad")
+    assert {:error, {:invalid_workflow_config, message}} = Config.validate!()
+    assert message =~ "codex.command_watchdog_stalled_ms"
 
     write_workflow_file!(Workflow.workflow_file_path(),
       tracker_active_states: %{todo: true},


### PR DESCRIPTION
#### Context

Operators cannot tell whether long-running worker commands are making progress, repeating output, or stalled.

#### TL;DR

*Classify active worker commands and show watchdog state in logs, API, and dashboards.*

#### Summary

- Add a configurable Codex command watchdog for output and progress tracking
- Classify commands as healthy, idle, stalled, or needs_attention
- Surface command age, idle time, and classification in observability views
- Comment on stalled commands and optionally move the issue to Blocked
- Cover wrapper and app-server command event shapes with focused tests

#### Alternatives

- Keep using worker-level stall restarts only, but that can kill useful long checks.
- Only surface raw command events, but operators still need policy classification.

#### Test Plan

- [ ] `make -C elixir all` (not run locally: make is not installed in this Windows shell)
- [x] `mix format --check-formatted`
- [x] `git diff --check`
- [x] `mix lint`
- [x] `mix test test/symphony_elixir/command_watchdog_test.exs test/symphony_elixir/orchestrator_status_test.exs test/symphony_elixir/workspace_and_config_test.exs`
- [x] `mix test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs`

SubAgent review:
- Initial review found blockers for app-server lifecycle support, command normalization, and stall-timeout coupling.
- Re-review found no blocking findings after fixes.

Closes #23.