### PR TITLE
Stabilize Windows-local validation gates

### DIFF
--- a/elixir/.gitattributes
+++ b/elixir/.gitattributes
@@ -1,1 +1,10 @@
+*.ex text eol=lf
+*.exs text eol=lf
+*.heex text eol=lf
+*.lock text eol=lf
+*.md text eol=lf
+*.txt text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
 test/fixtures/status_dashboard_snapshots/* linguist-generated=true

--- a/elixir/Makefile
+++ b/elixir/Makefile
@@ -38,7 +38,7 @@ test:
 	$(MIX) test
 
 windows-native-test:
-	$(MIX) test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs
+	$(MIX) test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs test/symphony_elixir/ssh_test.exs test/mix/tasks/workspace_before_remove_test.exs test/mix/tasks/pr_body_check_test.exs test/symphony_elixir/specs_check_test.exs
 
 dialyzer:
 	$(MIX) deps.get

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -211,6 +211,14 @@ The observability UI now runs on a minimal Phoenix stack:
 make all
 ```
 
+On Windows checkouts without GNU Make installed, run the same targets from PowerShell or `cmd.exe`
+through the repository shim in this directory:
+
+```powershell
+make.cmd all
+make.cmd windows-native-test
+```
+
 For Windows shell, workspace/config, workflow, or path-handling changes, run the focused Windows
 profile as well:
 

--- a/elixir/lib/mix/tasks/pr_body.check.ex
+++ b/elixir/lib/mix/tasks/pr_body.check.ex
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.PrBody.Check do
 
   defp read_template_candidate(path) do
     case File.read(path) do
-      {:ok, content} -> {:ok, path, content}
+      {:ok, content} -> {:ok, path, normalize_newlines(content)}
       {:error, _reason} -> nil
     end
   end
@@ -69,10 +69,12 @@ defmodule Mix.Tasks.PrBody.Check do
 
   defp read_file(path) do
     case File.read(path) do
-      {:ok, content} -> {:ok, content}
+      {:ok, content} -> {:ok, normalize_newlines(content)}
       {:error, reason} -> {:error, "Unable to read #{path}: #{inspect(reason)}"}
     end
   end
+
+  defp normalize_newlines(content) when is_binary(content), do: String.replace(content, "\r\n", "\n")
 
   defp extract_template_headings(template, template_path) do
     headings =

--- a/elixir/lib/mix/tasks/workspace.before_remove.ex
+++ b/elixir/lib/mix/tasks/workspace.before_remove.ex
@@ -61,30 +61,32 @@ defmodule Mix.Tasks.Workspace.BeforeRemove do
   end
 
   defp list_open_pull_request_numbers(repo, branch) do
-    case run_command("gh", [
-           "pr",
-           "list",
-           "--repo",
-           repo,
-           "--head",
-           branch,
-           "--state",
-           "open",
-           "--json",
-           "number",
-           "--jq",
-           ".[].number"
-         ]) do
-      {:ok, output} ->
-        output
-        |> String.split("\n", trim: true)
-        |> Enum.map(&String.trim/1)
-        |> Enum.reject(&(&1 == ""))
-
-      {:error, _reason} ->
-        []
-    end
+    "gh"
+    |> run_command([
+      "pr",
+      "list",
+      "--repo",
+      repo,
+      "--head",
+      branch,
+      "--state",
+      "open",
+      "--json",
+      "number",
+      "--jq",
+      ".[].number"
+    ])
+    |> pull_request_numbers_from_result()
   end
+
+  defp pull_request_numbers_from_result({:ok, output}) do
+    output
+    |> String.split("\n", trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp pull_request_numbers_from_result({:error, _reason}), do: []
 
   defp close_pull_request(repo, branch, pr_number) do
     case run_command("gh", [

--- a/elixir/lib/mix/tasks/workspace.before_remove.ex
+++ b/elixir/lib/mix/tasks/workspace.before_remove.ex
@@ -129,7 +129,7 @@ defmodule Mix.Tasks.Workspace.BeforeRemove do
   end
 
   defp run_command(command, args) do
-    case System.find_executable(command) do
+    case find_executable(command) do
       nil ->
         {:error, {:enoent, ""}}
 
@@ -144,12 +144,14 @@ defmodule Mix.Tasks.Workspace.BeforeRemove do
   end
 
   defp windows_command_args(path, args) do
-    if windows?() and String.downcase(Path.extname(path)) in [".bat", ".cmd"] do
-      {System.find_executable("cmd.exe") || "cmd.exe", ["/c", path | args]}
+    if String.downcase(Path.extname(path)) in [".bat", ".cmd"] and not is_nil(System.find_executable("cmd.exe")) do
+      {System.find_executable("cmd.exe"), ["/c", path | args]}
     else
       {path, args}
     end
   end
 
-  defp windows?, do: match?({:win32, _}, :os.type())
+  defp find_executable(command) do
+    Enum.find_value([command, command <> ".cmd", command <> ".bat"], &System.find_executable/1)
+  end
 end

--- a/elixir/lib/mix/tasks/workspace.before_remove.ex
+++ b/elixir/lib/mix/tasks/workspace.before_remove.ex
@@ -78,6 +78,7 @@ defmodule Mix.Tasks.Workspace.BeforeRemove do
       {:ok, output} ->
         output
         |> String.split("\n", trim: true)
+        |> Enum.map(&String.trim/1)
         |> Enum.reject(&(&1 == ""))
 
       {:error, _reason} ->
@@ -131,10 +132,22 @@ defmodule Mix.Tasks.Workspace.BeforeRemove do
         {:error, {:enoent, ""}}
 
       path ->
-        case System.cmd(path, args, stderr_to_stdout: true) do
+        {command, command_args} = windows_command_args(path, args)
+
+        case System.cmd(command, command_args, stderr_to_stdout: true) do
           {output, 0} -> {:ok, output}
           {output, status} -> {:error, {status, output}}
         end
     end
   end
+
+  defp windows_command_args(path, args) do
+    if windows?() and String.downcase(Path.extname(path)) in [".bat", ".cmd"] do
+      {System.find_executable("cmd.exe") || "cmd.exe", ["/c", path | args]}
+    else
+      {path, args}
+    end
+  end
+
+  defp windows?, do: match?({:win32, _}, :os.type())
 end

--- a/elixir/lib/mix/tasks/workspace.before_remove.ex
+++ b/elixir/lib/mix/tasks/workspace.before_remove.ex
@@ -53,7 +53,7 @@ defmodule Mix.Tasks.Workspace.BeforeRemove do
   end
 
   defp gh_available? do
-    not is_nil(System.find_executable("gh"))
+    not is_nil(find_executable("gh"))
   end
 
   defp gh_authenticated? do

--- a/elixir/lib/symphony_elixir/specs_check.ex
+++ b/elixir/lib/symphony_elixir/specs_check.ex
@@ -33,10 +33,32 @@ defmodule SymphonyElixir.SpecsCheck do
         [path]
 
       File.dir?(path) ->
-        Path.wildcard(Path.join(path, "**/*.ex"))
+        path
+        |> collect_files()
+        |> Enum.filter(&String.ends_with?(&1, ".ex"))
 
       true ->
         []
+    end
+  end
+
+  defp collect_files(path) do
+    case File.ls(path) do
+      {:ok, entries} ->
+        Enum.flat_map(entries, &collect_child(path, &1))
+
+      {:error, _reason} ->
+        []
+    end
+  end
+
+  defp collect_child(parent, entry) do
+    child = Path.join(parent, entry)
+
+    cond do
+      File.regular?(child) -> [child]
+      File.dir?(child) -> collect_files(child)
+      true -> []
     end
   end
 

--- a/elixir/lib/symphony_elixir/ssh.ex
+++ b/elixir/lib/symphony_elixir/ssh.ex
@@ -4,7 +4,8 @@ defmodule SymphonyElixir.SSH do
   @spec run(String.t(), String.t(), keyword()) :: {:ok, {String.t(), non_neg_integer()}} | {:error, term()}
   def run(host, command, opts \\ []) when is_binary(host) and is_binary(command) do
     with {:ok, executable} <- ssh_executable() do
-      {:ok, System.cmd(executable, ssh_args(host, command), opts)}
+      {command_executable, command_args} = windows_command_args(executable, ssh_args(host, command))
+      {:ok, System.cmd(command_executable, command_args, opts)}
     end
   end
 
@@ -13,16 +14,18 @@ defmodule SymphonyElixir.SSH do
     with {:ok, executable} <- ssh_executable() do
       line_bytes = Keyword.get(opts, :line)
 
+      {command_executable, command_args} = windows_command_args(executable, ssh_args(host, command))
+
       port_opts =
         [
           :binary,
           :exit_status,
           :stderr_to_stdout,
-          args: Enum.map(ssh_args(host, command), &String.to_charlist/1)
+          args: Enum.map(command_args, &String.to_charlist/1)
         ]
         |> maybe_put_line_option(line_bytes)
 
-      {:ok, Port.open({:spawn_executable, String.to_charlist(executable)}, port_opts)}
+      {:ok, Port.open({:spawn_executable, String.to_charlist(command_executable)}, port_opts)}
     end
   end
 
@@ -37,6 +40,16 @@ defmodule SymphonyElixir.SSH do
       executable -> {:ok, executable}
     end
   end
+
+  defp windows_command_args(executable, args) do
+    if windows?() and String.downcase(Path.extname(executable)) in [".bat", ".cmd"] do
+      {System.find_executable("cmd.exe") || "cmd.exe", ["/c", executable | args]}
+    else
+      {executable, args}
+    end
+  end
+
+  defp windows?, do: match?({:win32, _}, :os.type())
 
   defp ssh_args(host, command) do
     %{destination: destination, port: port} = parse_target(host)

--- a/elixir/lib/symphony_elixir/ssh.ex
+++ b/elixir/lib/symphony_elixir/ssh.ex
@@ -35,21 +35,22 @@ defmodule SymphonyElixir.SSH do
   end
 
   defp ssh_executable do
-    case System.find_executable("ssh") do
+    case find_executable(["ssh", "ssh.cmd", "ssh.bat"]) do
       nil -> {:error, :ssh_not_found}
       executable -> {:ok, executable}
     end
   end
 
   defp windows_command_args(executable, args) do
-    if windows?() and String.downcase(Path.extname(executable)) in [".bat", ".cmd"] do
-      {System.find_executable("cmd.exe") || "cmd.exe", ["/c", executable | args]}
+    if String.downcase(Path.extname(executable)) in [".bat", ".cmd"] and
+         not is_nil(System.find_executable("cmd.exe")) do
+      {System.find_executable("cmd.exe"), ["/c", executable | args]}
     else
       {executable, args}
     end
   end
 
-  defp windows?, do: match?({:win32, _}, :os.type())
+  defp find_executable(names), do: Enum.find_value(names, &System.find_executable/1)
 
   defp ssh_args(host, command) do
     %{destination: destination, port: port} = parse_target(host)

--- a/elixir/make.cmd
+++ b/elixir/make.cmd
@@ -1,0 +1,109 @@
+@echo off
+setlocal
+
+set "MIX_CMD=%MIX%"
+if "%MIX_CMD%"=="" for %%I in (mix.bat) do set "MIX_CMD=%%~$PATH:I"
+if "%MIX_CMD%"=="" set "MIX_CMD=mix.bat"
+
+if "%~1"=="" goto help
+
+set "TARGET=%~1"
+shift /1
+
+if "%TARGET%"=="help" goto help
+if "%TARGET%"=="setup" goto setup
+if "%TARGET%"=="deps" goto deps
+if "%TARGET%"=="build" goto build
+if "%TARGET%"=="fmt" goto fmt
+if "%TARGET%"=="fmt-check" goto fmt_check
+if "%TARGET%"=="diff-check" goto diff_check
+if "%TARGET%"=="lint" goto lint
+if "%TARGET%"=="test" goto test
+if "%TARGET%"=="windows-native-test" goto windows_native_test
+if "%TARGET%"=="coverage" goto coverage
+if "%TARGET%"=="dialyzer" goto dialyzer
+if "%TARGET%"=="e2e" goto e2e
+if "%TARGET%"=="ci" goto ci
+if "%TARGET%"=="all" goto ci
+
+echo Unknown target: %TARGET% 1>&2
+goto help_error
+
+:help
+echo Targets: setup, deps, fmt, fmt-check, diff-check, lint, test, windows-native-test, coverage, dialyzer, e2e, ci
+exit /b 0
+
+:help_error
+echo Targets: setup, deps, fmt, fmt-check, diff-check, lint, test, windows-native-test, coverage, dialyzer, e2e, ci 1>&2
+exit /b 2
+
+:setup
+"%MIX_CMD%" setup
+exit /b %ERRORLEVEL%
+
+:deps
+"%MIX_CMD%" deps.get
+exit /b %ERRORLEVEL%
+
+:build
+"%MIX_CMD%" build
+exit /b %ERRORLEVEL%
+
+:fmt
+"%MIX_CMD%" format
+exit /b %ERRORLEVEL%
+
+:fmt_check
+"%MIX_CMD%" format --check-formatted
+exit /b %ERRORLEVEL%
+
+:diff_check
+if "%DIFF_RANGE%"=="" (
+  git diff --check
+) else (
+  git diff --check %DIFF_RANGE%
+)
+exit /b %ERRORLEVEL%
+
+:lint
+"%MIX_CMD%" lint
+exit /b %ERRORLEVEL%
+
+:test
+"%MIX_CMD%" test
+exit /b %ERRORLEVEL%
+
+:windows_native_test
+"%MIX_CMD%" test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs test/symphony_elixir/ssh_test.exs test/mix/tasks/workspace_before_remove_test.exs test/mix/tasks/pr_body_check_test.exs test/symphony_elixir/specs_check_test.exs
+exit /b %ERRORLEVEL%
+
+:coverage
+"%MIX_CMD%" test --cover
+exit /b %ERRORLEVEL%
+
+:dialyzer
+"%MIX_CMD%" deps.get
+if errorlevel 1 exit /b %ERRORLEVEL%
+"%MIX_CMD%" dialyzer --format short
+exit /b %ERRORLEVEL%
+
+:e2e
+set "SYMPHONY_RUN_LIVE_E2E=1"
+"%MIX_CMD%" test test/symphony_elixir/live_e2e_test.exs
+exit /b %ERRORLEVEL%
+
+:ci
+call "%~f0" setup
+if errorlevel 1 exit /b %ERRORLEVEL%
+call "%~f0" build
+if errorlevel 1 exit /b %ERRORLEVEL%
+call "%~f0" fmt-check
+if errorlevel 1 exit /b %ERRORLEVEL%
+call "%~f0" diff-check
+if errorlevel 1 exit /b %ERRORLEVEL%
+call "%~f0" lint
+if errorlevel 1 exit /b %ERRORLEVEL%
+call "%~f0" coverage
+if errorlevel 1 exit /b %ERRORLEVEL%
+call "%~f0" dialyzer
+exit /b %ERRORLEVEL%

--- a/elixir/make.cmd
+++ b/elixir/make.cmd
@@ -74,7 +74,7 @@ exit /b %ERRORLEVEL%
 exit /b %ERRORLEVEL%
 
 :windows_native_test
-"%MIX_CMD%" test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs test/symphony_elixir/ssh_test.exs test/mix/tasks/workspace_before_remove_test.exs test/mix/tasks/pr_body_check_test.exs test/symphony_elixir/specs_check_test.exs
+"%MIX_CMD%" test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs test/symphony_elixir/windows_lifecycle_scripts_test.exs test/symphony_elixir/ssh_test.exs test/mix/tasks/workspace_before_remove_test.exs test/mix/tasks/pr_body_check_test.exs test/symphony_elixir/specs_check_test.exs
 exit /b %ERRORLEVEL%
 
 :coverage

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -17,7 +17,6 @@ defmodule SymphonyElixir.MixProject do
           SymphonyElixir.Config,
           SymphonyElixir.Linear.Client,
           SymphonyElixir.LocalShell,
-          SymphonyElixir.SSH,
           SymphonyElixir.SpecsCheck,
           SymphonyElixir.Orchestrator,
           SymphonyElixir.Orchestrator.State,
@@ -41,8 +40,7 @@ defmodule SymphonyElixir.MixProject do
           SymphonyElixirWeb.StaticAssetController,
           SymphonyElixirWeb.StaticAssets,
           SymphonyElixirWeb.Router,
-          SymphonyElixirWeb.Router.Helpers,
-          Mix.Tasks.Workspace.BeforeRemove
+          SymphonyElixirWeb.Router.Helpers
         ]
       ],
       test_ignore_filters: [

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -17,6 +17,7 @@ defmodule SymphonyElixir.MixProject do
           SymphonyElixir.Config,
           SymphonyElixir.Linear.Client,
           SymphonyElixir.LocalShell,
+          SymphonyElixir.SSH,
           SymphonyElixir.SpecsCheck,
           SymphonyElixir.Orchestrator,
           SymphonyElixir.Orchestrator.State,
@@ -40,7 +41,8 @@ defmodule SymphonyElixir.MixProject do
           SymphonyElixirWeb.StaticAssetController,
           SymphonyElixirWeb.StaticAssets,
           SymphonyElixirWeb.Router,
-          SymphonyElixirWeb.Router.Helpers
+          SymphonyElixirWeb.Router.Helpers,
+          Mix.Tasks.Workspace.BeforeRemove
         ]
       ],
       test_ignore_filters: [

--- a/elixir/test/mix/tasks/pr_body_check_test.exs
+++ b/elixir/test/mix/tasks/pr_body_check_test.exs
@@ -122,7 +122,7 @@ defmodule Mix.Tasks.PrBody.CheckTest do
     in_temp_repo(fn ->
       write_template!(@template)
 
-      missing_heading = String.replace(@valid_body, "#### Alternatives\n\n- Alternative considered.\n\n", "")
+      missing_heading = Regex.replace(~r/#### Alternatives\r?\n\r?\n- Alternative considered\.\r?\n\r?\n/, @valid_body, "")
       File.write!("body.md", missing_heading)
 
       error_output =

--- a/elixir/test/mix/tasks/workspace_before_remove_test.exs
+++ b/elixir/test/mix/tasks/workspace_before_remove_test.exs
@@ -202,6 +202,37 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
     )
   end
 
+  test "no-ops when PR list exits through fallback failure" do
+    with_fake_gh(
+      """
+      #!/bin/sh
+      printf '%s\n' "$*" >> "$GH_LOG"
+
+      if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+        exit 0
+      fi
+
+      exit 99
+      """,
+      fn log_path ->
+        output =
+          capture_io(fn ->
+            BeforeRemove.run(["--branch", "feature/list-fallback-fails"])
+          end)
+
+        assert output == ""
+
+        log = File.read!(log_path)
+        assert log =~ "auth status"
+
+        assert log =~
+                 "pr list --repo openai/symphony --head feature/list-fallback-fails --state open --json number --jq .[].number"
+
+        refute log =~ "pr close"
+      end
+    )
+  end
+
   test "no-ops when git current branch is blank" do
     with_fake_gh_and_git(
       """
@@ -232,10 +263,6 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
         refute log =~ "pr list"
       end
     )
-  end
-
-  if match?({:win32, _}, :os.type()) do
-    @tag skip: "Windows cannot reliably model gh auth failure with a batch shim."
   end
 
   test "no-ops when gh auth is unavailable" do
@@ -355,11 +382,11 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
         env
         |> maybe_put_fake_env(
           "SYMPHONY_FAKE_GH_AUTH_FAIL",
-          String.contains?(script, "exit 99") and not String.contains?(script, "pr")
+          fake_gh_auth_fail?(script)
         )
         |> maybe_put_fake_env(
           "SYMPHONY_FAKE_GH_LIST_FAIL",
-          Regex.match?(~r/\[ "\$1" = "pr" \].*?\[ "\$2" = "list" \].*?then\s+exit 1\s+fi/s, script)
+          fake_gh_list_fail?(script) or fake_gh_fallback_fail?(script)
         )
         |> maybe_put_fake_env("SYMPHONY_FAKE_GH_SINGLE_PR", String.contains?(script, "printf '102\\n'"))
         |> maybe_put_fake_env(
@@ -402,8 +429,6 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
   end
 
   defp windows_fake_binary_script("gh", script) do
-    auth_status = if fake_gh_auth_fail?(script), do: "1", else: "0"
-    list_status = if fake_gh_list_fail?(script), do: "1", else: "0"
     single_pr = if String.contains?(script, "printf '102\\n'"), do: "1", else: "0"
     no_stderr = if fake_gh_no_stderr?(script), do: "1", else: "0"
 
@@ -411,11 +436,11 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
     @echo off
     echo %*>>"%GH_LOG%"
     if "%1 %2"=="auth status" (
-      if "#{auth_status}"=="1" exit /b 1
+      if "%SYMPHONY_FAKE_GH_AUTH_FAIL%"=="1" exit 1
       exit /b 0
     )
     if "%1 %2"=="pr list" (
-      if "#{list_status}"=="1" exit /b 1
+      if "%SYMPHONY_FAKE_GH_LIST_FAIL%"=="1" exit 1
       if "#{single_pr}"=="1" (
         echo 102
       ) else (
@@ -433,10 +458,22 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
     """
   end
 
-  defp fake_gh_auth_fail?(script), do: String.contains?(script, "exit 99") and not String.contains?(script, "101")
+  defp fake_gh_auth_fail?(script),
+    do:
+      script
+      |> String.split(~s([ "$1" = "pr" ]), parts: 2)
+      |> List.first()
+      |> String.contains?("exit 1")
 
   defp fake_gh_list_fail?(script),
-    do: Regex.match?(~r/\[ "\$1" = "pr" \].*?\[ "\$2" = "list" \].*?then\s+exit 1\s+fi/s, script)
+    do:
+      String.contains?(script, ~s([ "$1" = "pr" ])) and
+        String.contains?(script, ~s([ "$2" = "list" ])) and
+        Regex.match?(~r/\bexit\s+1\b/, script)
+
+  defp fake_gh_fallback_fail?(script) do
+    String.contains?(script, "exit 99") and not String.contains?(script, ~s([ "$2" = "list" ]))
+  end
 
   defp fake_gh_no_stderr?(script),
     do:

--- a/elixir/test/mix/tasks/workspace_before_remove_test.exs
+++ b/elixir/test/mix/tasks/workspace_before_remove_test.exs
@@ -234,6 +234,10 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
     )
   end
 
+  if match?({:win32, _}, :os.type()) do
+    @tag skip: "Windows cannot reliably model gh auth failure with a batch shim."
+  end
+
   test "no-ops when gh auth is unavailable" do
     with_fake_gh(
       """
@@ -305,19 +309,22 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
       File.mkdir_p!(bin_dir)
       File.write!(log_path, "")
       original_path = System.get_env("PATH") || ""
-      path_with_binaries = Enum.join([bin_dir, original_path], ":")
+      path_with_binaries = Enum.join([bin_dir, original_path], path_separator())
 
       Enum.each(scripts, fn {name, script} ->
-        path = Path.join(bin_dir, name)
-        File.write!(path, script)
+        path = Path.join(bin_dir, fake_binary_name(name))
+        File.write!(path, fake_binary_script(name, script))
         File.chmod!(path, 0o755)
       end)
 
       with_env(
-        %{
-          "GH_LOG" => log_path,
-          "PATH" => path_with_binaries
-        },
+        Map.merge(
+          %{
+            "GH_LOG" => log_path,
+            "PATH" => path_with_binaries
+          },
+          fake_binary_env(scripts)
+        ),
         fn ->
           fun.(log_path)
         end
@@ -328,8 +335,118 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
   end
 
   defp with_path(paths, fun) do
-    with_env(%{"PATH" => Enum.join(paths, ":")}, fun)
+    with_env(%{"PATH" => Enum.join(paths, path_separator())}, fun)
   end
+
+  defp fake_binary_name(name), do: if(windows?(), do: name <> ".cmd", else: name)
+
+  defp fake_binary_script(name, script) when name in ["gh", "git"] do
+    if windows?() do
+      windows_fake_binary_script(name, script)
+    else
+      script
+    end
+  end
+
+  defp fake_binary_env(scripts) do
+    scripts
+    |> Enum.reduce(%{}, fn
+      {"gh", script}, env ->
+        env
+        |> maybe_put_fake_env(
+          "SYMPHONY_FAKE_GH_AUTH_FAIL",
+          String.contains?(script, "exit 99") and not String.contains?(script, "pr")
+        )
+        |> maybe_put_fake_env(
+          "SYMPHONY_FAKE_GH_LIST_FAIL",
+          Regex.match?(~r/\[ "\$1" = "pr" \].*?\[ "\$2" = "list" \].*?then\s+exit 1\s+fi/s, script)
+        )
+        |> maybe_put_fake_env("SYMPHONY_FAKE_GH_SINGLE_PR", String.contains?(script, "printf '102\\n'"))
+        |> maybe_put_fake_env(
+          "SYMPHONY_FAKE_GH_NO_STDERR",
+          Regex.match?(~r/\[ "\$1" = "pr" \].*?\[ "\$2" = "close" \].*?\[ "\$3" = "102" \].*?then\s+exit 17\s+fi/s, script)
+        )
+
+      {"git", script}, env ->
+        cond do
+          String.contains?(script, "printf '\\n'") or String.contains?(script, "printf '\n'") ->
+            Map.put(env, "SYMPHONY_FAKE_GIT_BLANK_BRANCH", "1")
+
+          String.contains?(script, "feature/workpad") ->
+            Map.put(env, "SYMPHONY_FAKE_GIT_BRANCH", "feature/workpad")
+
+          true ->
+            env
+        end
+
+      _, env ->
+        env
+    end)
+  end
+
+  defp maybe_put_fake_env(env, key, true), do: Map.put(env, key, "1")
+  defp maybe_put_fake_env(env, _key, false), do: env
+
+  defp windows_fake_binary_script("git", _script) do
+    """
+    @echo off
+    if "%SYMPHONY_FAKE_GIT_BLANK_BRANCH%"=="1" (
+      echo.
+    ) else if "%SYMPHONY_FAKE_GIT_BRANCH%"=="" (
+      echo feature/workpad
+    ) else (
+      echo %SYMPHONY_FAKE_GIT_BRANCH%
+    )
+    exit /b 0
+    """
+  end
+
+  defp windows_fake_binary_script("gh", script) do
+    auth_status = if fake_gh_auth_fail?(script), do: "1", else: "0"
+    list_status = if fake_gh_list_fail?(script), do: "1", else: "0"
+    single_pr = if String.contains?(script, "printf '102\\n'"), do: "1", else: "0"
+    no_stderr = if fake_gh_no_stderr?(script), do: "1", else: "0"
+
+    """
+    @echo off
+    echo %*>>"%GH_LOG%"
+    if "%1 %2"=="auth status" (
+      if "#{auth_status}"=="1" exit /b 1
+      exit /b 0
+    )
+    if "%1 %2"=="pr list" (
+      if "#{list_status}"=="1" exit /b 1
+      if "#{single_pr}"=="1" (
+        echo 102
+      ) else (
+        echo 101
+        echo 102
+      )
+      exit /b 0
+    )
+    if "%1 %2 %3"=="pr close 101" exit /b 0
+    if "%1 %2 %3"=="pr close 102" (
+      if not "#{no_stderr}"=="1" echo boom 1>&2
+      exit /b 17
+    )
+    exit /b 99
+    """
+  end
+
+  defp fake_gh_auth_fail?(script), do: String.contains?(script, "exit 99") and not String.contains?(script, "101")
+
+  defp fake_gh_list_fail?(script),
+    do: Regex.match?(~r/\[ "\$1" = "pr" \].*?\[ "\$2" = "list" \].*?then\s+exit 1\s+fi/s, script)
+
+  defp fake_gh_no_stderr?(script),
+    do:
+      Regex.match?(
+        ~r/\[ "\$1" = "pr" \].*?\[ "\$2" = "close" \].*?\[ "\$3" = "102" \].*?then\s+exit 17\s+fi/s,
+        script
+      )
+
+  defp path_separator, do: if(windows?(), do: ";", else: ":")
+  defp windows?, do: match?({:win32, _}, :os.type())
 
   defp with_env(overrides, fun) do
     keys = Map.keys(overrides)

--- a/elixir/test/mix/tasks/workspace_before_remove_test.exs
+++ b/elixir/test/mix/tasks/workspace_before_remove_test.exs
@@ -233,6 +233,62 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
     )
   end
 
+  test "wraps gh cmd shims through cmd.exe when only gh.cmd is available" do
+    if windows?() do
+      :ok
+    else
+      with_only_fake_binaries(
+        %{
+          "gh.cmd" => """
+          #!/bin/sh
+          printf 'GH:%s\n' "$*" >> "$GH_LOG"
+
+          if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+            exit 0
+          fi
+
+          if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+            printf '101\n'
+            exit 0
+          fi
+
+          if [ "$1" = "pr" ] && [ "$2" = "close" ] && [ "$3" = "101" ]; then
+            exit 0
+          fi
+
+          exit 99
+          """,
+          "cmd.exe" => """
+          #!/bin/sh
+          printf 'CMD:%s\n' "$*" >> "$GH_LOG"
+
+          if [ "$1" = "/c" ]; then
+            shift
+            shim="$1"
+            shift
+            "$shim" "$@"
+            exit $?
+          fi
+
+          exit 99
+          """
+        },
+        fn log_path ->
+          capture_io(fn ->
+            BeforeRemove.run(["--branch", "feature/cmd-shim"])
+          end)
+
+          log = File.read!(log_path)
+          assert log =~ "CMD:/c"
+          assert log =~ "gh.cmd"
+          assert log =~ "GH:auth status"
+          assert log =~ "GH:pr list --repo openai/symphony --head feature/cmd-shim"
+          assert log =~ "GH:pr close 101 --repo openai/symphony"
+        end
+      )
+    end
+  end
+
   test "no-ops when git current branch is blank" do
     with_fake_gh_and_git(
       """
@@ -326,6 +382,14 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
   end
 
   defp with_fake_binaries(scripts, fun) do
+    with_fake_binaries(scripts, true, fun)
+  end
+
+  defp with_only_fake_binaries(scripts, fun) do
+    with_fake_binaries(scripts, false, fun)
+  end
+
+  defp with_fake_binaries(scripts, include_original_path?, fun) do
     unique = System.unique_integer([:positive, :monotonic])
     root = Path.join(System.tmp_dir!(), "workspace-before-remove-task-test-#{unique}")
     bin_dir = Path.join(root, "bin")
@@ -336,7 +400,13 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
       File.mkdir_p!(bin_dir)
       File.write!(log_path, "")
       original_path = System.get_env("PATH") || ""
-      path_with_binaries = Enum.join([bin_dir, original_path], path_separator())
+
+      path_with_binaries =
+        if include_original_path? do
+          Enum.join([bin_dir, original_path], path_separator())
+        else
+          bin_dir
+        end
 
       Enum.each(scripts, fn {name, script} ->
         path = Path.join(bin_dir, fake_binary_name(name))
@@ -365,7 +435,13 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
     with_env(%{"PATH" => Enum.join(paths, path_separator())}, fun)
   end
 
-  defp fake_binary_name(name), do: if(windows?(), do: name <> ".cmd", else: name)
+  defp fake_binary_name(name) do
+    cond do
+      Path.extname(name) != "" -> name
+      windows?() -> name <> ".cmd"
+      true -> name
+    end
+  end
 
   defp fake_binary_script(name, script) when name in ["gh", "git"] do
     if windows?() do
@@ -374,6 +450,8 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
       script
     end
   end
+
+  defp fake_binary_script(_name, script), do: script
 
   defp fake_binary_env(scripts) do
     scripts

--- a/elixir/test/symphony_elixir/ssh_test.exs
+++ b/elixir/test/symphony_elixir/ssh_test.exs
@@ -19,7 +19,8 @@ defmodule SymphonyElixir.SSHTest do
              SSH.run("root@[::1]:2200", "printf ok", stderr_to_stdout: true)
 
     trace = File.read!(trace_file)
-    assert trace =~ "-T -p 2200 root@[::1] bash -lc"
+    assert trace =~ "-T -p 2200 root@[::1]"
+    assert trace =~ "bash -lc"
     assert trace =~ "printf ok"
   end
 
@@ -39,7 +40,8 @@ defmodule SymphonyElixir.SSHTest do
              SSH.run("::1:2200", "printf ok", stderr_to_stdout: true)
 
     trace = File.read!(trace_file)
-    assert trace =~ "-T ::1:2200 bash -lc"
+    assert trace =~ "-T ::1:2200"
+    assert trace =~ "bash -lc"
     refute trace =~ "-p 2200"
   end
 
@@ -63,7 +65,8 @@ defmodule SymphonyElixir.SSHTest do
 
     trace = File.read!(trace_file)
     assert trace =~ "-F /tmp/symphony-test-ssh-config"
-    assert trace =~ "-T -p 2222 localhost bash -lc"
+    assert trace =~ "-T -p 2222 localhost"
+    assert trace =~ "bash -lc"
     assert trace =~ "echo ready"
   end
 
@@ -83,7 +86,8 @@ defmodule SymphonyElixir.SSHTest do
              SSH.run("root@127.0.0.1:2200", "printf ok", stderr_to_stdout: true)
 
     trace = File.read!(trace_file)
-    assert trace =~ "-T -p 2200 root@127.0.0.1 bash -lc"
+    assert trace =~ "-T -p 2200 root@127.0.0.1"
+    assert trace =~ "bash -lc"
     assert trace =~ "printf ok"
   end
 
@@ -128,7 +132,8 @@ defmodule SymphonyElixir.SSHTest do
     wait_for_trace!(trace_file)
 
     trace = File.read!(trace_file)
-    assert trace =~ "-T localhost bash -lc"
+    assert trace =~ "-T localhost"
+    assert trace =~ "bash -lc"
     refute trace =~ " -F "
   end
 
@@ -154,7 +159,8 @@ defmodule SymphonyElixir.SSHTest do
     wait_for_trace!(trace_file)
 
     trace = File.read!(trace_file)
-    assert trace =~ "-T -p 2222 localhost bash -lc"
+    assert trace =~ "-T -p 2222 localhost"
+    assert trace =~ "bash -lc"
   end
 
   test "remote_shell_command/1 escapes embedded single quotes" do
@@ -164,23 +170,47 @@ defmodule SymphonyElixir.SSHTest do
 
   defp install_fake_ssh!(test_root, trace_file, script \\ nil) do
     fake_bin_dir = Path.join(test_root, "bin")
-    fake_ssh = Path.join(fake_bin_dir, "ssh")
+    fake_ssh = Path.join(fake_bin_dir, if(windows?(), do: "ssh.cmd", else: "ssh"))
 
     File.mkdir_p!(fake_bin_dir)
 
-    File.write!(
-      fake_ssh,
-      script ||
-        """
-        #!/bin/sh
-        printf 'ARGV:%s\\n' "$*" >> "#{trace_file}"
-        exit 0
-        """
-    )
+    File.write!(fake_ssh, fake_ssh_script(trace_file, script))
 
     File.chmod!(fake_ssh, 0o755)
-    System.put_env("PATH", fake_bin_dir <> ":" <> (System.get_env("PATH") || ""))
+    System.put_env("PATH", fake_bin_dir <> path_separator() <> (System.get_env("PATH") || ""))
   end
+
+  defp fake_ssh_script(trace_file, nil) do
+    if windows?() do
+      """
+      @echo off
+      echo ARGV:%*>>"#{trace_file}"
+      exit /b 0
+      """
+    else
+      """
+      #!/bin/sh
+      printf 'ARGV:%s\\n' "$*" >> "#{trace_file}"
+      exit 0
+      """
+    end
+  end
+
+  defp fake_ssh_script(trace_file, script) do
+    if windows?() do
+      """
+      @echo off
+      echo ARGV:%*>>"#{trace_file}"
+      echo ready
+      exit /b 0
+      """
+    else
+      script
+    end
+  end
+
+  defp path_separator, do: if(windows?(), do: ";", else: ":")
+  defp windows?, do: match?({:win32, _}, :os.type())
 
   defp wait_for_trace!(trace_file, attempts \\ 20)
   defp wait_for_trace!(trace_file, 0), do: flunk("timed out waiting for fake ssh trace at #{trace_file}")

--- a/elixir/test/symphony_elixir/ssh_test.exs
+++ b/elixir/test/symphony_elixir/ssh_test.exs
@@ -106,6 +106,48 @@ defmodule SymphonyElixir.SSHTest do
     assert {:error, :ssh_not_found} = SSH.run("localhost", "printf ok")
   end
 
+  test "run/3 wraps cmd shims through cmd.exe when ssh.cmd is the available executable" do
+    if windows?() do
+      :ok
+    else
+      test_root = Path.join(System.tmp_dir!(), "symphony-ssh-cmd-shim-test-#{System.unique_integer([:positive])}")
+      trace_file = Path.join(test_root, "ssh.trace")
+      previous_path = System.get_env("PATH")
+
+      on_exit(fn ->
+        restore_env("PATH", previous_path)
+        File.rm_rf(test_root)
+      end)
+
+      fake_bin_dir = Path.join(test_root, "bin")
+      File.mkdir_p!(fake_bin_dir)
+
+      fake_ssh = Path.join(fake_bin_dir, "ssh.cmd")
+      fake_cmd = Path.join(fake_bin_dir, "cmd.exe")
+
+      File.write!(fake_ssh, "")
+
+      File.write!(fake_cmd, """
+      #!/bin/sh
+      printf 'CMD:%s\\n' "$*" >> "#{trace_file}"
+      exit 0
+      """)
+
+      File.chmod!(fake_ssh, 0o755)
+      File.chmod!(fake_cmd, 0o755)
+      System.put_env("PATH", fake_bin_dir)
+
+      assert {:ok, {"", 0}} =
+               SSH.run("localhost:2222", "printf ok", stderr_to_stdout: true)
+
+      trace = File.read!(trace_file)
+      assert trace =~ "/c"
+      assert trace =~ "ssh.cmd"
+      assert trace =~ "-T -p 2222 localhost"
+      assert trace =~ "bash -lc"
+    end
+  end
+
   test "start_port/3 supports binary output without line mode" do
     test_root = Path.join(System.tmp_dir!(), "symphony-ssh-port-test-#{System.unique_integer([:positive])}")
     trace_file = Path.join(test_root, "ssh.trace")

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -95,10 +95,6 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     if windows?(), do: "Start-Sleep -Seconds 1", else: "sleep 1"
   end
 
-  defp hook_block_command do
-    if windows?(), do: "while ($true) { Start-Sleep -Seconds 1 }", else: "while true; do sleep 1; done"
-  end
-
   defp hook_large_output_fail_command do
     if windows?() do
       "[Console]::Out.Write(('a' * 3000)); exit 17"
@@ -356,10 +352,6 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     end
   end
 
-  if match?({:win32, _}, :os.type()) do
-    @tag skip: "Windows hook timeout is covered by before_remove timeout handling."
-  end
-
   test "workspace surfaces after_create hook timeouts" do
     workspace_root =
       Path.join(
@@ -368,15 +360,18 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
       )
 
     try do
+      File.rm_rf!(workspace_root)
+
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
         hook_timeout_ms: 100,
-        hook_after_create: hook_block_command()
+        hook_after_create: hook_sleep_command()
       )
 
       assert {:error, {:workspace_hook_timeout, "after_create", 100}} =
                Workspace.create_for_issue("MT-TIMEOUT")
     after
+      if windows?(), do: Process.sleep(1_100)
       File.rm_rf(workspace_root)
     end
   end

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -95,6 +95,10 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     if windows?(), do: "Start-Sleep -Seconds 1", else: "sleep 1"
   end
 
+  defp hook_block_command do
+    if windows?(), do: "while ($true) { Start-Sleep -Seconds 1 }", else: "while true; do sleep 1; done"
+  end
+
   defp hook_large_output_fail_command do
     if windows?() do
       "[Console]::Out.Write(('a' * 3000)); exit 17"
@@ -352,6 +356,10 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     end
   end
 
+  if match?({:win32, _}, :os.type()) do
+    @tag skip: "Windows hook timeout is covered by before_remove timeout handling."
+  end
+
   test "workspace surfaces after_create hook timeouts" do
     workspace_root =
       Path.join(
@@ -362,11 +370,11 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     try do
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        hook_timeout_ms: 10,
-        hook_after_create: hook_sleep_command()
+        hook_timeout_ms: 100,
+        hook_after_create: hook_block_command()
       )
 
-      assert {:error, {:workspace_hook_timeout, "after_create", 10}} =
+      assert {:error, {:workspace_hook_timeout, "after_create", 100}} =
                Workspace.create_for_issue("MT-TIMEOUT")
     after
       File.rm_rf(workspace_root)


### PR DESCRIPTION
#### Context

Windows-local validation for GH #28 was noisy when GNU Make was missing, CRLF line endings were present, and fake command tests assumed Unix executables. This update repairs manager-blocked PR #31 and merges current `main`.

#### TL;DR

Windows agents now have a local make shim and broader native validation coverage without weakening checks.

#### Summary

- Add `make.cmd` for Windows-local Makefile target equivalents.
- Normalize source line-ending policy for fresh Windows checkouts.
- Run `.cmd` fake executables through `cmd.exe /c` in affected command paths.
- Expand `windows-native-test` to include SSH, workspace cleanup, PR body, specs, and lifecycle tests.
- Keep the `after_create` workspace hook timeout assertion active on Windows.
- Cover `SymphonyElixir.SSH` and `Mix.Tasks.Workspace.BeforeRemove` instead of ignoring them.
- Merge current `origin/main` and preserve its cross-platform fake executable fixtures.

#### Alternatives

- Installing GNU Make locally was rejected because GH #28 asks for a repo-provided Windows path.
- Renormalizing every existing CRLF file was avoided to keep the PR reviewable.
- Ignoring changed modules in coverage was rejected; focused tests cover the new branches instead.
- Skipping Windows hook timeout coverage was rejected after SubAgent review.

#### Test Plan

- [ ] `make -C elixir all` (not run locally; clean GitHub `make-all` is authoritative)
- [x] `make windows-native-test` from `elixir/` after merging current `main` (103 tests, 0 failures, 14 skipped)
- [x] `.\make.cmd windows-native-test` from `elixir/` after merging current `main` (103 tests, 0 failures, 14 skipped)
- [x] `mix test test/symphony_elixir/ssh_test.exs test/mix/tasks/workspace_before_remove_test.exs` (21 tests, 0 failures, 12 skipped)
- [x] `mix test test/symphony_elixir/workspace_and_config_test.exs:355 --trace`
- [x] `mix format --check-formatted test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/ssh_test.exs test/mix/tasks/workspace_before_remove_test.exs`
- [x] `git diff --check`
- [x] Focused coverage for SSH and workspace cleanup earlier in this PR: target modules reached 100%.
- [x] SubAgent review `019de64b-3960-71c1-908a-5761d864f220`: no blocking findings.