### PR TITLE
[codex] Add Windows native lifecycle scripts

### DIFF
--- a/elixir/Makefile
+++ b/elixir/Makefile
@@ -38,7 +38,7 @@ test:
 	$(MIX) test
 
 windows-native-test:
-	$(MIX) test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs
+	$(MIX) test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs test/symphony_elixir/windows_lifecycle_scripts_test.exs
 
 dialyzer:
 	$(MIX) deps.get

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -35,6 +35,18 @@ notepad .\WORKFLOW.windows.md
 
 Then open `http://127.0.0.1:4011/`.
 
+Useful lifecycle commands:
+
+```powershell
+.\scripts\start-windows-native.ps1 -WorkflowPath .\WORKFLOW.windows.md -Port 4011 -Background
+.\scripts\stop-windows-native.ps1 -Force
+.\scripts\install-windows-native-service.ps1 -WorkflowPath .\WORKFLOW.windows.md -Port 4011
+.\scripts\cleanup-windows-native.ps1 -WorkflowPath .\WORKFLOW.windows.md -IssueIdentifier ALB-11
+```
+
+The install helper creates a Task Scheduler entry for the current Windows user. The cleanup helper
+requires explicit targets and refuses source-checkout-like workspace roots.
+
 Do not commit `WORKFLOW.windows.md` if it contains private repository URLs, project slugs, or other
 local details.
 

--- a/elixir/docs/windows-native.md
+++ b/elixir/docs/windows-native.md
@@ -171,6 +171,13 @@ Use the helper script:
 .\scripts\start-windows-native.ps1 -WorkflowPath .\WORKFLOW.windows.md -Port 4011
 ```
 
+The script writes PID metadata to `$env:LOCALAPPDATA\Symphony\logs\symphony.pid.json` by default.
+Use `-Background` when you want the launcher to return after starting a hidden PowerShell process:
+
+```powershell
+.\scripts\start-windows-native.ps1 -WorkflowPath .\WORKFLOW.windows.md -Port 4011 -Background
+```
+
 Or run the escript directly:
 
 ```powershell
@@ -183,6 +190,56 @@ Open the dashboard:
 ```text
 http://127.0.0.1:4011/
 ```
+
+## Stop Symphony
+
+Stop a launcher started by `start-windows-native.ps1`:
+
+```powershell
+.\scripts\stop-windows-native.ps1 -Force
+```
+
+The stop script reads the PID metadata and verifies that the target command line is a
+`start-windows-native.ps1` process before terminating that process tree. If the PID file is missing,
+pass `-WorkflowPath` to locate a matching launcher process:
+
+```powershell
+.\scripts\stop-windows-native.ps1 -WorkflowPath .\WORKFLOW.windows.md -Force
+```
+
+## Install a Windows long-running task
+
+The recommended Windows-native long-running setup is Task Scheduler. It runs under the same
+interactive Windows account that already has Codex, GitHub CLI, and `LINEAR_API_KEY` configured:
+
+```powershell
+.\scripts\install-windows-native-service.ps1 -WorkflowPath .\WORKFLOW.windows.md -Port 4011
+Start-ScheduledTask -TaskName "Symphony Windows Native"
+```
+
+Remove the task with:
+
+```powershell
+.\scripts\install-windows-native-service.ps1 -Uninstall
+```
+
+This script intentionally installs a scheduled task rather than a Windows service wrapper. That keeps
+the Codex and GitHub authentication context tied to the user account and avoids adding a service-host
+dependency such as NSSM.
+
+## Cleanup
+
+Use the cleanup helper for explicit maintenance tasks:
+
+```powershell
+.\scripts\cleanup-windows-native.ps1 -WorkflowPath .\WORKFLOW.windows.md -IssueIdentifier ALB-11
+.\scripts\cleanup-windows-native.ps1 -WorkflowPath .\WORKFLOW.windows.md -AllWorkspaces
+.\scripts\cleanup-windows-native.ps1 -Logs
+.\scripts\cleanup-windows-native.ps1 -BuildArtifacts
+```
+
+Cleanup refuses to treat the source checkout, a Git checkout, the current directory, the user profile,
+or a drive root as a workspace/log root. Use `-WhatIf` to preview removals before deleting.
 
 ## Linear state flow
 
@@ -292,6 +349,9 @@ issue in `In Progress` unless a manager explicitly chooses another state.
 
 When the issue moves to a terminal state such as `Done`, Symphony stops the
 active agent and runs `hooks.before_remove` before removing the workspace.
+At startup, Symphony also queries terminal states and removes matching issue workspaces under the
+configured `workspace.root`. The cleanup script above is for manual retention cleanup, log cleanup,
+and operator-initiated workspace cleanup.
 
 ## Known Windows limitations
 

--- a/elixir/scripts/cleanup-windows-native.ps1
+++ b/elixir/scripts/cleanup-windows-native.ps1
@@ -1,0 +1,193 @@
+param(
+  [string]$WorkflowPath = "",
+  [string]$WorkspaceRoot = "",
+  [string]$LogsRoot = "$env:LOCALAPPDATA\Symphony\logs",
+  [string]$IssueIdentifier = "",
+  [switch]$AllWorkspaces,
+  [switch]$Logs,
+  [switch]$BuildArtifacts,
+  [switch]$WhatIf
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-SymphonyPath {
+  param([string]$Path)
+
+  if (-not $Path) {
+    return ""
+  }
+
+  $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+}
+
+function ConvertTo-SafeIssueIdentifier {
+  param([string]$Identifier)
+
+  $safeIdentifier = ($Identifier -replace "[^a-zA-Z0-9._-]", "_")
+
+  if ($safeIdentifier -eq "." -or $safeIdentifier -eq "..") {
+    throw "Refusing unsafe issue identifier: $Identifier"
+  }
+
+  return $safeIdentifier
+}
+
+function Resolve-EnvBackedValue {
+  param([string]$Value)
+
+  if ($Value -match '^\$([A-Za-z_][A-Za-z0-9_]*)$') {
+    $resolved = [Environment]::GetEnvironmentVariable($Matches[1], "Process")
+    if (-not $resolved) {
+      $resolved = [Environment]::GetEnvironmentVariable($Matches[1], "User")
+    }
+
+    return $resolved
+  }
+
+  return $Value
+}
+
+function Get-WorkspaceRootFromWorkflow {
+  param([string]$Path)
+
+  if (-not $Path -or -not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    return ""
+  }
+
+  $lines = Get-Content -LiteralPath $Path
+  $inWorkspace = $false
+
+  foreach ($line in $lines) {
+    if ($line -match "^\S") {
+      $inWorkspace = $line -match "^workspace:\s*$"
+      continue
+    }
+
+    if ($inWorkspace -and $line -match "^\s+root:\s*(.+?)\s*$") {
+      return Resolve-EnvBackedValue $Matches[1].Trim().Trim("'").Trim('"')
+    }
+  }
+
+  return ""
+}
+
+function Assert-SafeCleanupRoot {
+  param(
+    [string]$Path,
+    [string]$Purpose,
+    [switch]$AllowSourceCheckout
+  )
+
+  if (-not $Path) {
+    throw "$Purpose path is required."
+  }
+
+  $resolved = Resolve-SymphonyPath $Path
+  $driveRoot = [System.IO.Path]::GetPathRoot($resolved)
+
+  if ($resolved.TrimEnd("\", "/") -eq $driveRoot.TrimEnd("\", "/")) {
+    throw "Refusing to clean drive root for $Purpose`: $resolved"
+  }
+
+  $scriptCheckout = Resolve-SymphonyPath (Join-Path $PSScriptRoot "..")
+  $current = Resolve-SymphonyPath "."
+
+  $protectedPaths =
+    if ($AllowSourceCheckout) {
+      @($env:USERPROFILE)
+    } else {
+      @($scriptCheckout, $current, $env:USERPROFILE)
+    }
+
+  foreach ($protected in $protectedPaths) {
+    if ($protected -and ($resolved.TrimEnd("\", "/") -ieq $protected.TrimEnd("\", "/"))) {
+      throw "Refusing to clean protected $Purpose path: $resolved"
+    }
+  }
+
+  if ((-not $AllowSourceCheckout) -and (Test-Path -LiteralPath (Join-Path $resolved ".git"))) {
+    throw "Refusing to clean $Purpose because it looks like a Git checkout: $resolved"
+  }
+
+  if ((-not $AllowSourceCheckout) -and
+      (Test-Path -LiteralPath (Join-Path $resolved "mix.exs")) -and
+      (Test-Path -LiteralPath (Join-Path $resolved "scripts\start-windows-native.ps1"))) {
+    throw "Refusing to clean $Purpose because it looks like the Symphony source checkout: $resolved"
+  }
+
+  return $resolved
+}
+
+function Assert-SafeCleanupTarget {
+  param(
+    [string]$Path,
+    [string]$SafeRoot,
+    [string]$Purpose
+  )
+
+  $resolved = Assert-SafeCleanupRoot -Path $Path -Purpose $Purpose
+  $root = Resolve-SymphonyPath $SafeRoot
+  $resolvedWithSlash = $resolved.Replace("\", "/").TrimEnd("/") + "/"
+  $rootWithSlash = $root.Replace("\", "/").TrimEnd("/") + "/"
+
+  if ($resolvedWithSlash -ieq $rootWithSlash) {
+    throw "Refusing to clean $Purpose because it is the workspace root: $resolved"
+  }
+
+  if (-not $resolvedWithSlash.StartsWith($rootWithSlash, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Refusing to clean $Purpose outside workspace root: $resolved"
+  }
+
+  return $resolved
+}
+
+function Remove-SymphonyPath {
+  param([string]$Path)
+
+  if (-not (Test-Path -LiteralPath $Path)) {
+    Write-Host "Already absent: $Path"
+    return
+  }
+
+  if ($WhatIf) {
+    Write-Host "Would remove: $Path"
+  } else {
+    Remove-Item -LiteralPath $Path -Recurse -Force
+    Write-Host "Removed: $Path"
+  }
+}
+
+if (-not ($AllWorkspaces -or $IssueIdentifier -or $Logs -or $BuildArtifacts)) {
+  throw "Choose at least one cleanup target: -IssueIdentifier, -AllWorkspaces, -Logs, or -BuildArtifacts."
+}
+
+if (-not $WorkspaceRoot -and $WorkflowPath) {
+  $WorkspaceRoot = Get-WorkspaceRootFromWorkflow (Resolve-SymphonyPath $WorkflowPath)
+}
+
+if ($IssueIdentifier -or $AllWorkspaces) {
+  $safeWorkspaceRoot = Assert-SafeCleanupRoot -Path $WorkspaceRoot -Purpose "workspace root"
+
+  if ($IssueIdentifier) {
+    $target = Assert-SafeCleanupTarget -Path (Join-Path $safeWorkspaceRoot (ConvertTo-SafeIssueIdentifier $IssueIdentifier)) -SafeRoot $safeWorkspaceRoot -Purpose "issue workspace"
+    Remove-SymphonyPath $target
+  } elseif ($AllWorkspaces) {
+    Get-ChildItem -LiteralPath $safeWorkspaceRoot -Directory -Force | ForEach-Object {
+      $target = Assert-SafeCleanupTarget -Path $_.FullName -SafeRoot $safeWorkspaceRoot -Purpose "workspace child"
+      Remove-SymphonyPath $target
+    }
+  }
+}
+
+if ($Logs) {
+  $safeLogsRoot = Assert-SafeCleanupRoot -Path $LogsRoot -Purpose "logs root"
+  Remove-SymphonyPath $safeLogsRoot
+}
+
+if ($BuildArtifacts) {
+  $sourceRoot = Assert-SafeCleanupRoot -Path (Join-Path $PSScriptRoot "..") -Purpose "build artifact root" -AllowSourceCheckout
+  foreach ($relative in @("_build", "deps", "bin\symphony")) {
+    Remove-SymphonyPath (Join-Path $sourceRoot $relative)
+  }
+}

--- a/elixir/scripts/install-windows-native-service.ps1
+++ b/elixir/scripts/install-windows-native-service.ps1
@@ -1,0 +1,83 @@
+param(
+  [string]$TaskName = "Symphony Windows Native",
+  [string]$WorkflowPath = ".\WORKFLOW.windows.md",
+  [int]$Port = 4011,
+  [string]$LogsRoot = "$env:LOCALAPPDATA\Symphony\logs",
+  [string]$PidFile = "",
+  [string]$User = "$env:USERDOMAIN\$env:USERNAME",
+  [switch]$Uninstall
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-SymphonyPath {
+  param([string]$Path)
+
+  if (-not $Path) {
+    return ""
+  }
+
+  $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+}
+
+function Join-SymphonyArguments {
+  param([string[]]$Arguments)
+
+  ($Arguments | ForEach-Object {
+    if ($_ -match "[\s`"]") {
+      '"' + ($_.Replace('"', '\"')) + '"'
+    } else {
+      $_
+    }
+  }) -join " "
+}
+
+if ($Uninstall) {
+  Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
+  Write-Host "Removed scheduled task: $TaskName"
+  exit 0
+}
+
+$scriptPath = Join-Path $PSScriptRoot "start-windows-native.ps1"
+$WorkflowPath = Resolve-SymphonyPath $WorkflowPath
+$LogsRoot = Resolve-SymphonyPath $LogsRoot
+
+if (-not $PidFile) {
+  $PidFile = Join-Path $LogsRoot "symphony.pid.json"
+}
+
+$PidFile = Resolve-SymphonyPath $PidFile
+
+if (-not (Test-Path -LiteralPath $WorkflowPath -PathType Leaf)) {
+  throw "Workflow file not found: $WorkflowPath"
+}
+
+New-Item -ItemType Directory -Force -Path $LogsRoot | Out-Null
+
+$powerShell = (Get-Process -Id $PID).Path
+$argumentList = @(
+  "-NoProfile",
+  "-ExecutionPolicy",
+  "Bypass",
+  "-File",
+  $scriptPath,
+  "-WorkflowPath",
+  $WorkflowPath,
+  "-Port",
+  $Port,
+  "-LogsRoot",
+  $LogsRoot,
+  "-PidFile",
+  $PidFile
+)
+
+$action = New-ScheduledTaskAction -Execute $powerShell -Argument (Join-SymphonyArguments $argumentList) -WorkingDirectory (Split-Path -Parent $PSScriptRoot)
+$trigger = New-ScheduledTaskTrigger -AtLogOn -User $User
+$principal = New-ScheduledTaskPrincipal -UserId $User -LogonType Interactive -RunLevel Highest
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit ([TimeSpan]::Zero) -MultipleInstances IgnoreNew
+
+Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Force | Out-Null
+
+Write-Host "Installed scheduled task: $TaskName"
+Write-Host "Start manually: Start-ScheduledTask -TaskName '$TaskName'"
+Write-Host "Stop manually: .\scripts\stop-windows-native.ps1 -PidFile '$PidFile' -Force"

--- a/elixir/scripts/start-windows-native.ps1
+++ b/elixir/scripts/start-windows-native.ps1
@@ -2,8 +2,10 @@ param(
   [string]$WorkflowPath = ".\WORKFLOW.windows.md",
   [int]$Port = 4011,
   [string]$LogsRoot = "$env:LOCALAPPDATA\Symphony\logs",
+  [string]$PidFile = "",
   [string]$Mise = "",
-  [switch]$TerminalDashboard
+  [switch]$TerminalDashboard,
+  [switch]$Background
 )
 
 $ErrorActionPreference = "Stop"
@@ -19,6 +21,98 @@ try {
 
 if (Get-Command chcp.com -ErrorAction SilentlyContinue) {
   & chcp.com 65001 | Out-Null
+}
+
+if (-not $PidFile) {
+  $PidFile = Join-Path $LogsRoot "symphony.pid.json"
+}
+
+function Resolve-SymphonyPath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+}
+
+function Test-SymphonyProcessAlive {
+  param([string]$Path)
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    return $false
+  }
+
+  try {
+    $metadata = Get-Content -Raw -LiteralPath $Path | ConvertFrom-Json
+    if (-not $metadata.ProcessId) {
+      return $false
+    }
+
+    return [bool](Get-Process -Id ([int]$metadata.ProcessId) -ErrorAction SilentlyContinue)
+  } catch {
+    return $false
+  }
+}
+
+function Join-SymphonyArguments {
+  param([string[]]$Arguments)
+
+  ($Arguments | ForEach-Object {
+    if ($_ -match "[\s`"]") {
+      '"' + ($_.Replace('"', '\"')) + '"'
+    } else {
+      $_
+    }
+  }) -join " "
+}
+
+$WorkflowPath = Resolve-SymphonyPath $WorkflowPath
+$LogsRoot = Resolve-SymphonyPath $LogsRoot
+$PidFile = Resolve-SymphonyPath $PidFile
+
+if ($Background) {
+  if (Test-SymphonyProcessAlive $PidFile) {
+    throw "Symphony already appears to be running according to PID file: $PidFile"
+  }
+
+  New-Item -ItemType Directory -Force -Path $LogsRoot | Out-Null
+  New-Item -ItemType Directory -Force -Path (Split-Path -Parent $PidFile) | Out-Null
+
+  $stdoutPath = Join-Path $LogsRoot "symphony.stdout.log"
+  $stderrPath = Join-Path $LogsRoot "symphony.stderr.log"
+  $scriptPath = $PSCommandPath
+  $pwsh = (Get-Process -Id $PID).Path
+  $arguments = @(
+    "-NoProfile",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-File",
+    $scriptPath,
+    "-WorkflowPath",
+    $WorkflowPath,
+    "-Port",
+    $Port,
+    "-LogsRoot",
+    $LogsRoot,
+    "-PidFile",
+    $PidFile
+  )
+
+  if ($Mise) {
+    $arguments += @("-Mise", $Mise)
+  }
+
+  if ($TerminalDashboard) {
+    $arguments += "-TerminalDashboard"
+  }
+
+  $process = Start-Process -FilePath $pwsh -ArgumentList (Join-SymphonyArguments $arguments) -WorkingDirectory (Get-Location).Path -WindowStyle Hidden -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath -PassThru
+  Write-Host "Symphony background launcher PID: $($process.Id)"
+  Write-Host "PID metadata: $PidFile"
+  Write-Host "Stdout: $stdoutPath"
+  Write-Host "Stderr: $stderrPath"
+  exit 0
 }
 
 if ($TerminalDashboard) {
@@ -49,12 +143,43 @@ if (-not $Mise) {
 }
 
 New-Item -ItemType Directory -Force -Path $LogsRoot | Out-Null
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $PidFile) | Out-Null
+
+if (Test-SymphonyProcessAlive $PidFile) {
+  throw "Symphony already appears to be running according to PID file: $PidFile"
+}
 
 $AuditLog = Join-Path $LogsRoot "log\symphony.log"
 Write-Host "Symphony audit log: $AuditLog"
+Write-Host "PID metadata: $PidFile"
 Write-Host "Terminal dashboard: $(if ($TerminalDashboard) { 'enabled' } else { "disabled; open http://127.0.0.1:$Port/ or pass -TerminalDashboard" })"
 
-& $Mise exec -- escript .\bin\symphony $WorkflowPath `
-  --port $Port `
-  --logs-root $LogsRoot `
-  --i-understand-that-this-will-be-running-without-the-usual-guardrails
+$metadata = [ordered]@{
+  ProcessId = $PID
+  StartedAt = (Get-Date).ToUniversalTime().ToString("o")
+  WorkflowPath = $WorkflowPath
+  LogsRoot = $LogsRoot
+  Port = $Port
+  ScriptPath = $PSCommandPath
+  Kind = "symphony-windows-native"
+}
+
+$metadata | ConvertTo-Json | Set-Content -LiteralPath $PidFile -Encoding UTF8
+
+try {
+  & $Mise exec -- escript .\bin\symphony $WorkflowPath `
+    --port $Port `
+    --logs-root $LogsRoot `
+    --i-understand-that-this-will-be-running-without-the-usual-guardrails
+} finally {
+  if (Test-Path -LiteralPath $PidFile -PathType Leaf) {
+    try {
+      $existing = Get-Content -Raw -LiteralPath $PidFile | ConvertFrom-Json
+      if ([int]$existing.ProcessId -eq $PID) {
+        Remove-Item -LiteralPath $PidFile -Force
+      }
+    } catch {
+      Write-Warning "Unable to remove PID metadata $PidFile`: $($_.Exception.Message)"
+    }
+  }
+}

--- a/elixir/scripts/stop-windows-native.ps1
+++ b/elixir/scripts/stop-windows-native.ps1
@@ -1,0 +1,116 @@
+param(
+  [string]$PidFile = "$env:LOCALAPPDATA\Symphony\logs\symphony.pid.json",
+  [string]$WorkflowPath = "",
+  [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-SymphonyPath {
+  param([string]$Path)
+
+  if (-not $Path) {
+    return ""
+  }
+
+  $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+}
+
+function Get-ProcessCommandLine {
+  param([int]$ProcessId)
+
+  $process = Get-CimInstance Win32_Process -Filter "ProcessId = $ProcessId" -ErrorAction SilentlyContinue
+  if ($process) {
+    return $process.CommandLine
+  }
+
+  return ""
+}
+
+function Test-OwnedSymphonyProcess {
+  param(
+    [int]$ProcessId,
+    [string]$ExpectedWorkflowPath
+  )
+
+  $commandLine = Get-ProcessCommandLine $ProcessId
+
+  if (-not $commandLine) {
+    return $false
+  }
+
+  $matchesScript = $commandLine -like "*start-windows-native.ps1*"
+  $matchesWorkflow = (-not $ExpectedWorkflowPath) -or
+    ($commandLine.IndexOf($ExpectedWorkflowPath, [System.StringComparison]::OrdinalIgnoreCase) -ge 0)
+
+  return ($matchesScript -and $matchesWorkflow)
+}
+
+function Stop-ProcessTree {
+  param([int]$RootProcessId)
+
+  $children = Get-CimInstance Win32_Process -Filter "ParentProcessId = $RootProcessId" -ErrorAction SilentlyContinue
+  foreach ($child in $children) {
+    Stop-ProcessTree -RootProcessId ([int]$child.ProcessId)
+  }
+
+  $process = Get-Process -Id $RootProcessId -ErrorAction SilentlyContinue
+  if ($process) {
+    Stop-Process -Id $RootProcessId -Force:$Force
+  }
+}
+
+$PidFile = Resolve-SymphonyPath $PidFile
+$WorkflowPath = Resolve-SymphonyPath $WorkflowPath
+$targetPid = $null
+
+if (Test-Path -LiteralPath $PidFile -PathType Leaf) {
+  $metadata = Get-Content -Raw -LiteralPath $PidFile | ConvertFrom-Json
+
+  if ($metadata.Kind -ne "symphony-windows-native") {
+    throw "PID file is not Symphony Windows-native metadata: $PidFile"
+  }
+
+  $targetPid = [int]$metadata.ProcessId
+
+  if (-not $WorkflowPath -and $metadata.WorkflowPath) {
+    $WorkflowPath = Resolve-SymphonyPath $metadata.WorkflowPath
+  }
+}
+
+if (-not $targetPid) {
+  if (-not $WorkflowPath) {
+    throw "No PID file found at $PidFile. Pass -WorkflowPath to locate a matching Symphony launcher process."
+  }
+
+  $candidates =
+    @(Get-CimInstance Win32_Process -Filter "CommandLine LIKE '%start-windows-native.ps1%'" |
+      Where-Object { $_.CommandLine.IndexOf($WorkflowPath, [System.StringComparison]::OrdinalIgnoreCase) -ge 0 })
+
+  if ($candidates.Count -gt 1) {
+    throw "Multiple Symphony launcher processes match $WorkflowPath. Use -PidFile to stop a specific run."
+  }
+
+  if ($candidates.Count -eq 1) {
+    $targetPid = [int]$candidates[0].ProcessId
+  }
+}
+
+if (-not $targetPid) {
+  Write-Host "No matching Symphony Windows-native process is running."
+  exit 0
+}
+
+if (-not (Get-Process -Id $targetPid -ErrorAction SilentlyContinue)) {
+  Write-Host "Symphony process $targetPid is not running."
+  Remove-Item -LiteralPath $PidFile -Force -ErrorAction SilentlyContinue
+  exit 0
+}
+
+if (-not (Test-OwnedSymphonyProcess -ProcessId $targetPid -ExpectedWorkflowPath $WorkflowPath)) {
+  throw "Refusing to stop PID $targetPid because it is not a matching start-windows-native.ps1 process."
+}
+
+Stop-ProcessTree -RootProcessId $targetPid
+Remove-Item -LiteralPath $PidFile -Force -ErrorAction SilentlyContinue
+Write-Host "Stopped Symphony Windows-native process tree rooted at PID $targetPid."

--- a/elixir/test/symphony_elixir/windows_lifecycle_scripts_test.exs
+++ b/elixir/test/symphony_elixir/windows_lifecycle_scripts_test.exs
@@ -1,0 +1,233 @@
+defmodule SymphonyElixir.WindowsLifecycleScriptsTest do
+  use SymphonyElixir.TestSupport, async: false
+
+  defp powershell do
+    Enum.find(["pwsh", "powershell"], fn command ->
+      System.find_executable(command)
+    end)
+  end
+
+  defp script_path(name) do
+    Path.expand(Path.join(["scripts", name]))
+  end
+
+  defp shell_quote(path), do: "'" <> String.replace(path, "'", "''") <> "'"
+
+  defp run_powershell!(args) do
+    shell = powershell() || flunk("PowerShell executable not found")
+    System.cmd(shell, args, stderr_to_stdout: true)
+  end
+
+  test "Windows lifecycle scripts parse in PowerShell" do
+    for script <- [
+          "start-windows-native.ps1",
+          "stop-windows-native.ps1",
+          "install-windows-native-service.ps1",
+          "cleanup-windows-native.ps1"
+        ] do
+      command = "[scriptblock]::Create((Get-Content -Raw -LiteralPath #{shell_quote(script_path(script))})) | Out-Null"
+
+      assert {"", 0} =
+               run_powershell!([
+                 "-NoProfile",
+                 "-ExecutionPolicy",
+                 "Bypass",
+                 "-Command",
+                 command
+               ])
+    end
+  end
+
+  test "cleanup removes only the requested issue workspace" do
+    workspace_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-lifecycle-cleanup-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      target = Path.join(workspace_root, "ALB_11")
+      other = Path.join(workspace_root, "ALB-12")
+      File.mkdir_p!(target)
+      File.mkdir_p!(other)
+      File.write!(Path.join(target, "marker.txt"), "remove")
+      File.write!(Path.join(other, "marker.txt"), "keep")
+
+      {_output, 0} =
+        run_powershell!([
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          script_path("cleanup-windows-native.ps1"),
+          "-WorkspaceRoot",
+          workspace_root,
+          "-IssueIdentifier",
+          "ALB/11"
+        ])
+
+      refute File.exists?(target)
+      assert File.exists?(Path.join(other, "marker.txt"))
+    after
+      File.rm_rf(workspace_root)
+    end
+  end
+
+  test "cleanup refuses to treat the source checkout as a workspace root" do
+    {_output, status} =
+      run_powershell!([
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        script_path("cleanup-windows-native.ps1"),
+        "-WorkspaceRoot",
+        Path.expand("."),
+        "-AllWorkspaces"
+      ])
+
+    assert status != 0
+  end
+
+  test "cleanup refuses issue identifiers that resolve to the workspace root" do
+    workspace_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-lifecycle-root-target-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      File.mkdir_p!(workspace_root)
+      File.write!(Path.join(workspace_root, "marker.txt"), "keep")
+
+      for issue_identifier <- [".", ".."] do
+        {_output, status} =
+          run_powershell!([
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            script_path("cleanup-windows-native.ps1"),
+            "-WorkspaceRoot",
+            workspace_root,
+            "-IssueIdentifier",
+            issue_identifier
+          ])
+
+        assert status != 0
+      end
+
+      assert File.exists?(Path.join(workspace_root, "marker.txt"))
+    after
+      File.rm_rf(workspace_root)
+    end
+  end
+
+  test "cleanup sanitizes traversal-like issue identifiers instead of leaving the workspace root" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-lifecycle-traversal-#{System.unique_integer([:positive])}"
+      )
+
+    workspace_root = Path.join(test_root, "workspaces")
+
+    try do
+      sanitized_target = Path.join(workspace_root, ".._ALB-11")
+      sibling = Path.join(test_root, "ALB-11")
+      File.mkdir_p!(sanitized_target)
+      File.mkdir_p!(sibling)
+      File.write!(Path.join(sanitized_target, "marker.txt"), "remove")
+      File.write!(Path.join(sibling, "marker.txt"), "keep")
+
+      {_output, 0} =
+        run_powershell!([
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          script_path("cleanup-windows-native.ps1"),
+          "-WorkspaceRoot",
+          workspace_root,
+          "-IssueIdentifier",
+          "../ALB-11"
+        ])
+
+      refute File.exists?(sanitized_target)
+      assert File.exists?(Path.join(sibling, "marker.txt"))
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "cleanup refuses to delete a checkout below the selected workspace root" do
+    workspace_parent = Path.expand("..")
+
+    {_output, status} =
+      run_powershell!([
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        script_path("cleanup-windows-native.ps1"),
+        "-WorkspaceRoot",
+        workspace_parent,
+        "-IssueIdentifier",
+        Path.basename(Path.expand("."))
+      ])
+
+    assert status != 0
+    assert File.exists?(Path.join(Path.expand("."), "mix.exs"))
+  end
+
+  test "cleanup resolves env-backed workspace root from workflow path" do
+    workspace_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-lifecycle-env-root-#{System.unique_integer([:positive])}"
+      )
+
+    workflow_path =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-lifecycle-env-workflow-#{System.unique_integer([:positive])}.md"
+      )
+
+    env_var = "SYMPHONY_LIFECYCLE_WORKSPACE_ROOT_#{System.unique_integer([:positive])}"
+    previous = System.get_env(env_var)
+
+    try do
+      target = Path.join(workspace_root, "ALB-11")
+      File.mkdir_p!(target)
+      File.write!(Path.join(target, "marker.txt"), "remove")
+      System.put_env(env_var, workspace_root)
+
+      File.write!(workflow_path, """
+      ---
+      workspace:
+        root: $#{env_var}
+      ---
+      """)
+
+      {_output, 0} =
+        run_powershell!([
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          script_path("cleanup-windows-native.ps1"),
+          "-WorkflowPath",
+          workflow_path,
+          "-IssueIdentifier",
+          "ALB-11"
+        ])
+
+      refute File.exists?(target)
+      refute File.exists?(Path.join(Path.expand("."), "$#{env_var}"))
+    after
+      restore_env(env_var, previous)
+      File.rm_rf(workspace_root)
+      File.rm(workflow_path)
+    end
+  end
+end


### PR DESCRIPTION
#### Context

Windows-native runs need repeatable start, stop, scheduled-task, and cleanup commands for unattended operation.

#### TL;DR

*Add PowerShell lifecycle scripts with guarded cleanup and task-scheduler support.*

#### Summary

- Add PID-aware start background mode and a targeted stop script.
- Add Task Scheduler install/uninstall for long-running Windows runs.
- Add guarded cleanup for issue workspaces, logs, and build artifacts.
- Reject cleanup issue identifiers that resolve to the workspace root, including `.` and `..`.
- Document lifecycle commands and add PowerShell/cleanup regression tests.

#### Alternatives

- A Windows service wrapper such as NSSM was avoided to keep Codex and GitHub auth in the current user context.
- Automatic broad cleanup was avoided; operators must choose explicit cleanup targets.

#### Test Plan

- [ ] `make -C elixir all` (not run locally)
- [ ] `make windows-native-test` (not run locally: `make` is not installed on PATH in this Windows shell)
- [x] `mix test test/symphony_elixir/windows_lifecycle_scripts_test.exs` (7 tests, 0 failures)
- [x] `mix test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs test/symphony_elixir/windows_lifecycle_scripts_test.exs` (61 tests, 0 failures, 2 skipped)
- [x] `git diff --check`
- [x] `mix format --check-formatted test/symphony_elixir/windows_lifecycle_scripts_test.exs`

Local notes:
- `make windows-native-test` could not run because `make` is not installed on PATH in this Windows shell; the exact Mix test list from that target passed.
- Full `mix format --check-formatted` was not rerun in this repair pass because previous local runs reported pre-existing formatting/line-ending differences outside this change; the touched Elixir test file passes format check.

Review:
- SubAgent review completed on the original lifecycle implementation.
- Manager review found that `-IssueIdentifier '.'` could target the workspace root; this repair rejects `.`/`..`, requires cleanup targets to be strictly below the workspace root, and adds focused regression coverage.
- SubAgent re-review found one blocking test fixture issue; fixed by keeping traversal fixtures under a unique test-owned temp root.
- SubAgent re-review then reported no remaining blocking findings in the cleanup script or lifecycle tests.

Linear: ALB-11
Closes #4
