### PR TITLE
Add Windows workflow trust profiles

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -27,7 +27,7 @@ mise exec -- mix setup
 mise exec -- mix build
 
 [Environment]::SetEnvironmentVariable("LINEAR_API_KEY", "YOUR_LINEAR_API_KEY", "User")
-Copy-Item .\WORKFLOW.windows.example.md .\WORKFLOW.windows.md
+Copy-Item .\WORKFLOW.windows.safe.example.md .\WORKFLOW.windows.md
 notepad .\WORKFLOW.windows.md
 
 .\scripts\start-windows-native.ps1 -WorkflowPath .\WORKFLOW.windows.md -Port 4011
@@ -36,7 +36,9 @@ notepad .\WORKFLOW.windows.md
 Then open `http://127.0.0.1:4011/`.
 
 Do not commit `WORKFLOW.windows.md` if it contains private repository URLs, project slugs, or other
-local details.
+local details. Use `WORKFLOW.windows.safe.example.md` for first runs and
+`WORKFLOW.windows.trusted.example.md` only after the Linear project, cloned repository, and dedicated
+workspace root are trusted for unattended automation.
 
 ## Screenshot
 

--- a/elixir/WORKFLOW.windows.safe.example.md
+++ b/elixir/WORKFLOW.windows.safe.example.md
@@ -1,0 +1,73 @@
+---
+tracker:
+  kind: linear
+  api_key: $LINEAR_API_KEY
+  project_slug: "your-linear-project-slug"
+  # Optional: restrict candidate dispatch to issues with any of these labels.
+  # labels:
+  #   - symphony-optimization
+  active_states:
+    - Todo
+    - In Progress
+  terminal_states:
+    - Done
+    - Canceled
+    - Cancelled
+    - Duplicate
+polling:
+  interval_ms: 10000
+workspace:
+  # Use a dedicated automation root. Do not point this at a personal development checkout.
+  root: "D:/code/symphony-safe-workspaces"
+hooks:
+  timeout_ms: 300000
+  after_create: |
+    $ErrorActionPreference = "Stop"
+    git clone --depth 1 https://github.com/YOUR_ORG/YOUR_REPO.git .
+    git config user.email "codex-symphony@example.invalid"
+    git config user.name "Codex Symphony"
+  before_remove: |
+    $ErrorActionPreference = "Stop"
+    git status --short
+agent:
+  max_concurrent_agents: 1
+  max_turns: 10
+codex:
+  command: codex --config shell_environment_policy.inherit=all app-server
+  # Reject Codex approval escalations in this safer profile. Commands that need broader
+  # permission fail closed instead of widening access during an unattended run.
+  approval_policy:
+    reject:
+      sandbox_approval: true
+      rules: true
+      mcp_elicitations: true
+  thread_sandbox: workspace-write
+  # turn_sandbox_policy is intentionally omitted. Symphony resolves it at runtime to a
+  # workspaceWrite policy rooted at the current generated issue workspace with network disabled.
+---
+
+You are working on a Linear issue through Symphony on Windows.
+
+Issue:
+- Identifier: {{ issue.identifier }}
+- Title: {{ issue.title }}
+- State: {{ issue.state }}
+- URL: {{ issue.url }}
+- Labels: {{ issue.labels }}
+
+Description:
+{% if issue.description %}
+{{ issue.description }}
+{% else %}
+No description provided.
+{% endif %}
+
+Instructions:
+
+1. Work only in the current workspace.
+2. If the issue is `Todo`, move it to `In Progress` before implementation.
+3. Find or create exactly one Linear comment whose first line is `## Codex Workpad`.
+4. Keep that workpad updated with plan, acceptance criteria, validation, commits, and blockers.
+5. Reproduce or inspect the issue before changing code.
+6. Make focused changes and run targeted validation.
+7. Do not move the issue to review unless the configured validation has passed.

--- a/elixir/WORKFLOW.windows.trusted.example.md
+++ b/elixir/WORKFLOW.windows.trusted.example.md
@@ -1,0 +1,104 @@
+---
+tracker:
+  kind: linear
+  api_key: $LINEAR_API_KEY
+  project_slug: "your-linear-project-slug"
+  # Optional: restrict candidate dispatch to issues with any of these labels.
+  # labels:
+  #   - symphony-optimization
+  active_states:
+    - Todo
+    - In Progress
+    - Rework
+    - Merging
+  terminal_states:
+    - Done
+    - Canceled
+    - Cancelled
+    - Duplicate
+polling:
+  interval_ms: 5000
+workspace:
+  # This root is trusted by the workflow. Keep it dedicated to disposable Symphony workspaces.
+  root: "D:/code/symphony-trusted-workspaces"
+hooks:
+  timeout_ms: 300000
+  after_create: |
+    $ErrorActionPreference = "Stop"
+    $TrustedWorkspaceRoot = "D:/code/symphony-trusted-workspaces"
+    $WorkspacePath = (Get-Location).Path
+    $TrustedRootPath = (Resolve-Path -LiteralPath $TrustedWorkspaceRoot).Path.TrimEnd('\', '/')
+    if (-not $WorkspacePath.StartsWith($TrustedRootPath + [IO.Path]::DirectorySeparatorChar, [StringComparison]::OrdinalIgnoreCase)) {
+      throw "Refusing to trust workspace outside configured root: $WorkspacePath"
+    }
+
+    git clone --depth 1 https://github.com/YOUR_ORG/YOUR_REPO.git .
+    git config user.email "codex-symphony@example.invalid"
+    git config user.name "Codex Symphony"
+
+    if ($WorkspacePath.Contains("'")) {
+      throw "Codex project trust setup does not support single quotes in workspace paths: $WorkspacePath"
+    }
+
+    $CodexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $env:USERPROFILE ".codex" }
+    $CodexConfig = Join-Path $CodexHome "config.toml"
+    New-Item -ItemType Directory -Force -Path $CodexHome | Out-Null
+    if (-not (Test-Path -LiteralPath $CodexConfig)) {
+      New-Item -ItemType File -Force -Path $CodexConfig | Out-Null
+    }
+
+    $ProjectHeader = "[projects.'$WorkspacePath']"
+    $AlreadyTrusted = Select-String -LiteralPath $CodexConfig -SimpleMatch $ProjectHeader -Quiet
+    if (-not $AlreadyTrusted) {
+      Add-Content -LiteralPath $CodexConfig -Value ""
+      Add-Content -LiteralPath $CodexConfig -Value $ProjectHeader
+      Add-Content -LiteralPath $CodexConfig -Value 'trust_level = "trusted"'
+    }
+
+    if (Test-Path -LiteralPath "package.json") {
+      npm install
+    }
+  before_remove: |
+    $ErrorActionPreference = "Stop"
+    git status --short
+agent:
+  max_concurrent_agents: 1
+  max_turns: 20
+codex:
+  command: codex --config shell_environment_policy.inherit=all --config model=gpt-5.5 --config model_reasoning_effort=medium app-server
+  # Trusted unattended automation: Codex will not ask for approval, and shell commands run
+  # without sandboxing. Use only with a trusted repository, dedicated workspace root, and
+  # credentials scoped for automation.
+  approval_policy: never
+  thread_sandbox: danger-full-access
+  turn_sandbox_policy:
+    type: dangerFullAccess
+  review_readiness_repository: YOUR_ORG/YOUR_REPO
+  review_readiness_required_checks: []
+---
+
+You are working on a Linear issue through Symphony on Windows.
+
+Issue:
+- Identifier: {{ issue.identifier }}
+- Title: {{ issue.title }}
+- State: {{ issue.state }}
+- URL: {{ issue.url }}
+- Labels: {{ issue.labels }}
+
+Description:
+{% if issue.description %}
+{{ issue.description }}
+{% else %}
+No description provided.
+{% endif %}
+
+Instructions:
+
+1. Work only in the current workspace.
+2. If the issue is `Todo`, move it to `In Progress` before implementation.
+3. Find or create exactly one Linear comment whose first line is `## Codex Workpad`.
+4. Keep that workpad updated with plan, acceptance criteria, validation, commits, blockers, and PR links.
+5. Reproduce or inspect the issue before changing code.
+6. Make focused changes, run targeted validation, commit, push, and open or update a PR.
+7. Do not move the issue to review while required checks are pending, failing, or unverifiable.

--- a/elixir/docs/windows-native.md
+++ b/elixir/docs/windows-native.md
@@ -78,7 +78,31 @@ gh auth login
 
 ## Configure a workflow
 
-Copy the example and edit it for your Linear project and target repository:
+Start from the profile that matches the trust boundary for the run:
+
+- `WORKFLOW.windows.safe.example.md`: recommended first-run profile. Codex runs with workspace-write
+  thread sandboxing, approval escalations are rejected, and Symphony resolves each turn sandbox to
+  the generated issue workspace with network access disabled.
+- `WORKFLOW.windows.trusted.example.md`: unattended automation profile for trusted repositories and
+  dedicated workspace roots. Codex runs with `approval_policy: never`, `danger-full-access`, and an
+  explicit `dangerFullAccess` turn sandbox policy.
+- `WORKFLOW.windows.example.md`: compact general example for adapting your own local policy.
+
+For a safer first run:
+
+```powershell
+Copy-Item .\WORKFLOW.windows.safe.example.md .\WORKFLOW.windows.md
+notepad .\WORKFLOW.windows.md
+```
+
+For trusted unattended automation:
+
+```powershell
+Copy-Item .\WORKFLOW.windows.trusted.example.md .\WORKFLOW.windows.md
+notepad .\WORKFLOW.windows.md
+```
+
+You can still start from the compact example:
 
 ```powershell
 Copy-Item .\WORKFLOW.windows.example.md .\WORKFLOW.windows.md
@@ -113,6 +137,31 @@ Keep secrets out of the workflow file:
 tracker:
   api_key: $LINEAR_API_KEY
 ```
+
+### Choosing safe vs trusted profiles
+
+The safe profile is intended for evaluating a repository or workflow prompt before giving an agent
+broad local control. It still runs Symphony workspace hooks on the host, so inspect
+`hooks.after_create` before starting the service, but Codex turns fail closed when they need
+approval or access outside the generated issue workspace.
+
+The trusted profile is for production-like automation after you trust all three boundaries:
+
+- The Linear project only routes work you intend to automate.
+- The repository cloned by `hooks.after_create` is trusted to contribute local `.codex` project
+  configuration, hooks, and skills.
+- `workspace.root` is a dedicated disposable automation directory, not a personal development
+  checkout and not a directory shared with unrelated repositories.
+
+The trusted profile includes a PowerShell trust step that writes a Codex project entry for the
+current generated issue workspace after verifying that the workspace lives under the configured
+trusted root. This avoids per-issue warnings such as `.codex` project configuration being disabled
+for a newly generated workspace. If you change `workspace.root`, update the matching
+`$TrustedWorkspaceRoot` value in `hooks.after_create`.
+
+Do not add a broad trust entry for a drive root, home directory, or normal source tree. Trust only
+the dedicated workspace root or the specific generated workspaces you are willing to let unattended
+automation control.
 
 ## Run preflight
 

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -1450,12 +1450,34 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     end
   end
 
+  test "Windows workflow profile examples parse with expected safety posture" do
+    examples = [
+      {"WORKFLOW.windows.safe.example.md", "workspace-write", :reject, nil},
+      {"WORKFLOW.windows.trusted.example.md", "danger-full-access", "never", %{"type" => "dangerFullAccess"}}
+    ]
+
+    for {filename, thread_sandbox, approval_policy, turn_sandbox_policy} <- examples do
+      path = Path.expand(Path.join([__DIR__, "..", "..", filename]))
+
+      assert {:ok, workflow} = Workflow.load(path)
+      assert {:ok, settings} = Schema.parse(workflow.config)
+      assert settings.codex.thread_sandbox == thread_sandbox
+      assert_approval_policy(settings.codex.approval_policy, approval_policy)
+      assert settings.codex.turn_sandbox_policy == turn_sandbox_policy
+      assert workflow.prompt =~ "## Codex Workpad"
+      assert settings.workspace.root =~ "symphony-"
+    end
+  end
+
   test "workflow prompt is used when building base prompt" do
     workflow_prompt = "Workflow prompt body used as codex instruction."
 
     write_workflow_file!(Workflow.workflow_file_path(), prompt: workflow_prompt)
     assert Config.workflow_prompt() == workflow_prompt
   end
+
+  defp assert_approval_policy(%{"reject" => reject}, :reject) when is_map(reject), do: assert(map_size(reject) > 0)
+  defp assert_approval_policy(actual, expected), do: assert(actual == expected)
 
   test "remote workspace lifecycle uses ssh host aliases from worker config" do
     if windows?() do


### PR DESCRIPTION
#### Context

GH #5 asks for safe and trusted Windows workflow profiles so users can choose an appropriate trust boundary.

#### TL;DR

*Adds separate safe and trusted Windows workflow examples plus docs and parser coverage.*

#### Summary

- Add a safer first-run Windows workflow with rejected approval escalations.
- Add a trusted unattended workflow with explicit sandbox and trust setup.
- Document profile choice, credential boundaries, and dedicated workspace roots.
- Add schema parsing coverage for both Windows profile examples.

#### Alternatives

- Kept the original compact example instead of replacing it, so existing users can still adapt it.
- Used per-workspace Codex trust entries instead of broad drive or home directory trust.

#### Test Plan

- [ ] `make -C elixir all` not run: make is not installed in this Windows session.
- [x] `mix test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs`
- [x] `mix format --check-formatted test/symphony_elixir/workspace_and_config_test.exs`
- [x] `git diff --check`
- [x] SubAgent review: no blocking findings.

Closes #5.