### PR TITLE
Add cross-platform fake test fixtures

### DIFF
--- a/elixir/test/mix/tasks/workspace_before_remove_test.exs
+++ b/elixir/test/mix/tasks/workspace_before_remove_test.exs
@@ -5,6 +5,11 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
 
   import ExUnit.CaptureIO
 
+  @fake_cli_skip if(SymphonyElixir.TestSupport.windows?(),
+                   do: "Fake gh/git fixtures are Unix scripts; Windows coverage for gh uses real gh.exe availability checks.",
+                   else: nil
+                 )
+
   setup do
     Mix.Task.reenable("workspace.before_remove")
     :ok
@@ -48,6 +53,8 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
       assert output == ""
     end)
   end
+
+  if @fake_cli_skip, do: @tag(skip: @fake_cli_skip)
 
   test "uses current branch for lookup when branch option is omitted" do
     with_fake_gh_and_git(
@@ -100,6 +107,8 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
     )
   end
 
+  if @fake_cli_skip, do: @tag(skip: @fake_cli_skip)
+
   test "closes open pull requests for the branch and tolerates close failures" do
     with_fake_gh(fn log_path ->
       File.write!(log_path, "")
@@ -129,6 +138,8 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
       assert error_output =~ "Failed to close PR #102 for branch feature/workpad"
     end)
   end
+
+  if @fake_cli_skip, do: @tag(skip: @fake_cli_skip)
 
   test "formats close failures without command stderr output" do
     with_fake_gh(
@@ -167,6 +178,8 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
     )
   end
 
+  if @fake_cli_skip, do: @tag(skip: @fake_cli_skip)
+
   test "no-ops when PR list fails for current branch" do
     with_fake_gh(
       """
@@ -202,6 +215,8 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
     )
   end
 
+  if @fake_cli_skip, do: @tag(skip: @fake_cli_skip)
+
   test "no-ops when git current branch is blank" do
     with_fake_gh_and_git(
       """
@@ -233,6 +248,8 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
       end
     )
   end
+
+  if @fake_cli_skip, do: @tag(skip: @fake_cli_skip)
 
   test "no-ops when gh auth is unavailable" do
     with_fake_gh(
@@ -305,7 +322,7 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
       File.mkdir_p!(bin_dir)
       File.write!(log_path, "")
       original_path = System.get_env("PATH") || ""
-      path_with_binaries = Enum.join([bin_dir, original_path], ":")
+      path_with_binaries = Enum.join([bin_dir, original_path], SymphonyElixir.TestSupport.path_separator())
 
       Enum.each(scripts, fn {name, script} ->
         path = Path.join(bin_dir, name)

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -1,4 +1,18 @@
 defmodule SymphonyElixir.TestSupport do
+  @moduledoc """
+  Shared test helpers.
+
+  Use `write_fake_codex!/3` for app-server protocol fixtures that must run on
+  both Windows and Unix. It writes a Node payload behind a Unix-style shim; the
+  production `LocalShell` Windows launcher recognizes that shim and executes the
+  `.js` file with `node.exe`.
+
+  Direct executable fakes for tools launched with `System.cmd/3` or
+  `Port.open/2`, such as `ssh` and `gh`, should be real platform executables.
+  Keep Unix shell-script fakes Unix-only when the production code intentionally
+  resolves and launches the real host executable directly.
+  """
+
   @workflow_prompt "You are an agent for this repository."
 
   defmacro __using__(_opts) do
@@ -22,7 +36,15 @@ defmodule SymphonyElixir.TestSupport do
       alias SymphonyElixir.Workspace
 
       import SymphonyElixir.TestSupport,
-        only: [write_workflow_file!: 1, write_workflow_file!: 2, restore_env: 2, stop_default_http_server: 0]
+        only: [
+          restore_env: 2,
+          stop_default_http_server: 0,
+          write_fake_codex!: 2,
+          write_fake_codex!: 3,
+          write_node_executable!: 2,
+          write_workflow_file!: 1,
+          write_workflow_file!: 2
+        ]
 
       setup do
         workflow_root =
@@ -73,6 +95,129 @@ defmodule SymphonyElixir.TestSupport do
     match?({:win32, _}, :os.type())
   end
 
+  def path_separator, do: if(windows?(), do: ";", else: ":")
+
+  def write_node_executable!(executable, javascript) when is_binary(executable) and is_binary(javascript) do
+    script = executable <> ".js"
+    script_name = Path.basename(script)
+
+    File.write!(script, javascript)
+
+    File.write!(executable, """
+    #!/bin/sh
+    basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+    exec node "$basedir/#{script_name}" "$@"
+    """)
+
+    File.chmod!(executable, 0o755)
+    executable
+  end
+
+  def write_fake_codex!(executable, steps, opts \\ []) when is_binary(executable) and is_list(steps) do
+    trace_env = Keyword.get(opts, :trace_env)
+    default_trace = Keyword.get(opts, :default_trace, "/tmp/symphony-fake-codex.trace")
+    trace_prefix = Keyword.get(opts, :trace_prefix, "JSON:")
+    startup_trace = Keyword.get(opts, :startup_trace, [])
+    steps_json = Jason.encode!(Enum.map(steps, &normalize_fake_codex_step/1))
+    startup_trace_json = Jason.encode!(Enum.map(List.wrap(startup_trace), &to_string/1))
+
+    write_node_executable!(
+      executable,
+      """
+      const fs = require("fs");
+      const readline = require("readline");
+
+      const steps = #{steps_json};
+      const traceEnv = #{Jason.encode!(trace_env)};
+      const defaultTrace = #{Jason.encode!(default_trace)};
+      const tracePrefix = #{Jason.encode!(trace_prefix)};
+      const startupTrace = #{startup_trace_json};
+      const traceFile = traceEnv ? (process.env[traceEnv] || defaultTrace) : null;
+      let count = 0;
+
+      function writeTrace(line) {
+        if (traceFile) {
+          fs.appendFileSync(traceFile, `${tracePrefix}${line}\\n`);
+        }
+      }
+
+      function writeStartupTrace() {
+        if (!traceFile) {
+          return;
+        }
+
+        for (const marker of startupTrace) {
+          if (marker === "argv") {
+            fs.appendFileSync(traceFile, `ARGV:${process.argv.slice(2).join(" ")}\\n`);
+          } else if (marker === "cwd") {
+            fs.appendFileSync(traceFile, `CWD:${process.cwd()}\\n`);
+          } else if (marker === "run") {
+            fs.appendFileSync(traceFile, `RUN:${Date.now()}-${process.pid}\\n`);
+          } else if (marker === "run_marker") {
+            fs.appendFileSync(traceFile, "RUN\\n");
+          }
+        }
+      }
+
+      function writeMany(stream, values) {
+        for (const value of values || []) {
+          stream.write(`${value}\\n`);
+        }
+      }
+
+      function replyToInputId(line, payloadKey, payload) {
+        const request = JSON.parse(line);
+        process.stdout.write(`${JSON.stringify({ id: request.id, [payloadKey]: payload })}\\n`);
+      }
+
+      function applyStep(step, line) {
+        if (step.reply_result !== null && step.reply_result !== undefined) {
+          replyToInputId(line, "result", step.reply_result);
+        }
+
+        if (step.reply_error !== null && step.reply_error !== undefined) {
+          replyToInputId(line, "error", step.reply_error);
+        }
+
+        writeMany(process.stderr, step.stderr);
+        writeMany(process.stdout, step.stdout);
+
+        if (step.exit !== null && step.exit !== undefined) {
+          process.exit(step.exit);
+        }
+
+        if (step.hold) {
+          setInterval(() => {}, 1000);
+        }
+      }
+
+      writeStartupTrace();
+
+      const rl = readline.createInterface({ input: process.stdin, terminal: false });
+
+      rl.on("line", line => {
+        count += 1;
+        writeTrace(line);
+        applyStep(steps[count - 1] || { exit: 0 }, line);
+      });
+      """
+    )
+  end
+
+  defp normalize_fake_codex_step(step) when is_binary(step), do: %{stdout: [step]}
+
+  defp normalize_fake_codex_step(step) when is_list(step) do
+    step
+    |> Map.new()
+    |> normalize_fake_codex_step()
+  end
+
+  defp normalize_fake_codex_step(step) when is_map(step) do
+    step
+    |> Map.update(:stdout, [], &List.wrap/1)
+    |> Map.update(:stderr, [], &List.wrap/1)
+  end
+
   def symlink_skip_reason do
     if windows?() do
       test_root =
@@ -98,23 +243,33 @@ defmodule SymphonyElixir.TestSupport do
   end
 
   def stop_default_http_server do
-    case Enum.find(Supervisor.which_children(SymphonyElixir.Supervisor), fn
-           {SymphonyElixir.HttpServer, _pid, _type, _modules} -> true
-           _child -> false
-         end) do
-      {SymphonyElixir.HttpServer, pid, _type, _modules} when is_pid(pid) ->
-        :ok = Supervisor.terminate_child(SymphonyElixir.Supervisor, SymphonyElixir.HttpServer)
-
-        if Process.alive?(pid) do
-          Process.exit(pid, :normal)
-        end
-
-        :ok
-
-      _ ->
-        :ok
+    case Process.whereis(SymphonyElixir.Supervisor) do
+      nil -> :ok
+      supervisor -> stop_default_http_server(supervisor)
     end
   end
+
+  defp stop_default_http_server(supervisor) when is_pid(supervisor) do
+    supervisor
+    |> Supervisor.which_children()
+    |> Enum.find(fn
+      {SymphonyElixir.HttpServer, _pid, _type, _modules} -> true
+      _child -> false
+    end)
+    |> terminate_default_http_server(supervisor)
+  end
+
+  defp terminate_default_http_server({SymphonyElixir.HttpServer, pid, _type, _modules}, supervisor) when is_pid(pid) do
+    :ok = Supervisor.terminate_child(supervisor, SymphonyElixir.HttpServer)
+
+    if Process.alive?(pid) do
+      Process.exit(pid, :normal)
+    end
+
+    :ok
+  end
+
+  defp terminate_default_http_server(_child, _supervisor), do: :ok
 
   defp workflow_content(overrides) do
     config =

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -1,6 +1,8 @@
 defmodule SymphonyElixir.AppServerTest do
   use SymphonyElixir.TestSupport
 
+  @symlink_skip_reason SymphonyElixir.TestSupport.symlink_skip_reason()
+
   test "app server rejects the workspace root and paths outside workspace root" do
     test_root =
       Path.join(
@@ -38,6 +40,8 @@ defmodule SymphonyElixir.AppServerTest do
       File.rm_rf(test_root)
     end
   end
+
+  if @symlink_skip_reason, do: @tag(skip: @symlink_skip_reason)
 
   test "app server rejects symlink escape cwd paths under the workspace root" do
     test_root =
@@ -101,37 +105,17 @@ defmodule SymphonyElixir.AppServerTest do
       System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-supported-turn-policies.trace}"
-      count=0
-
-      while IFS= read -r line; do
-        count=$((count + 1))
-        printf 'JSON:%s\\n' "$line" >> "$trace_file"
-
-        case "$count" in
-          1)
-            printf '%s\\n' '{"id":1,"result":{}}'
-            ;;
-          2)
-            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-1001"}}}'
-            ;;
-          3)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-1001"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{"method":"turn/completed"}'
-            exit 0
-            ;;
-          *)
-            exit 0
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(
+        codex_binary,
+        [
+          ~s({"id":1,"result":{}}),
+          ~s({"id":2,"result":{"thread":{"id":"thread-1001"}}}),
+          ~s({"id":3,"result":{"turn":{"id":"turn-1001"}}}),
+          %{stdout: ~s({"method":"turn/completed"}), exit: 0}
+        ],
+        trace_env: "SYMP_TEST_CODEx_TRACE",
+        default_trace: "/tmp/codex-supported-turn-policies.trace"
+      )
 
       issue = %Issue{
         id: "issue-supported-turn-policies",
@@ -208,35 +192,17 @@ defmodule SymphonyElixir.AppServerTest do
       System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-input.trace}"
-      count=0
-      while IFS= read -r line; do
-        count=$((count + 1))
-        printf 'JSON:%s\\n' \"$line\" >> \"$trace_file\"
-
-        case \"$count\" in
-          1)
-            printf '%s\\n' '{\"id\":1,\"result\":{}}'
-            ;;
-          2)
-            printf '%s\\n' '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thread-88\"}}}'
-            ;;
-          3)
-            printf '%s\\n' '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-88\"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{\"method\":\"turn/input_required\",\"id\":\"resp-1\",\"params\":{\"requiresInput\":true,\"reason\":\"blocked\"}}'
-            ;;
-          *)
-            exit 0
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(
+        codex_binary,
+        [
+          ~s({"id":1,"result":{}}),
+          ~s({"id":2,"result":{"thread":{"id":"thread-88"}}}),
+          ~s({"id":3,"result":{"turn":{"id":"turn-88"}}}),
+          ~s({"method":"turn/input_required","id":"resp-1","params":{"requiresInput":true,"reason":"blocked"}})
+        ],
+        trace_env: "SYMP_TEST_CODEx_TRACE",
+        default_trace: "/tmp/codex-input.trace"
+      )
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -275,31 +241,17 @@ defmodule SymphonyElixir.AppServerTest do
       codex_binary = Path.join(test_root, "fake-codex")
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      count=0
-      while IFS= read -r _line; do
-        count=$((count + 1))
-
-        case "$count" in
-          1)
-            printf '%s\\n' '{"id":1,"result":{}}'
-            ;;
-          2)
-            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-89"}}}'
-            ;;
-          3)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-89"}}}'
-            printf '%s\\n' '{"id":99,"method":"item/commandExecution/requestApproval","params":{"command":"gh pr view","cwd":"/tmp","reason":"need approval"}}'
-            ;;
-          *)
-            sleep 1
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(codex_binary, [
+        ~s({"id":1,"result":{}}),
+        ~s({"id":2,"result":{"thread":{"id":"thread-89"}}}),
+        %{
+          stdout: [
+            ~s({"id":3,"result":{"turn":{"id":"turn-89"}}}),
+            ~s({"id":99,"method":"item/commandExecution/requestApproval","params":{"command":"gh pr view","cwd":"/tmp","reason":"need approval"}})
+          ]
+        },
+        %{hold: true}
+      ])
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -350,39 +302,23 @@ defmodule SymphonyElixir.AppServerTest do
       System.put_env("SYMP_TEST_CODex_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      trace_file="${SYMP_TEST_CODex_TRACE:-/tmp/codex-auto-approve.trace}"
-      count=0
-      while IFS= read -r line; do
-        count=$((count + 1))
-        printf 'JSON:%s\\n' \"$line\" >> \"$trace_file\"
-
-        case \"$count\" in
-          1)
-            printf '%s\\n' '{\"id\":1,\"result\":{}}'
-            ;;
-          2)
-            ;;
-          3)
-            printf '%s\\n' '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thread-89\"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-89\"}}}'
-            printf '%s\\n' '{\"id\":99,\"method\":\"item/commandExecution/requestApproval\",\"params\":{\"command\":\"gh pr view\",\"cwd\":\"/tmp\",\"reason\":\"need approval\"}}'
-            ;;
-          5)
-            printf '%s\\n' '{\"method\":\"turn/completed\"}'
-            exit 0
-            ;;
-          *)
-            exit 0
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(
+        codex_binary,
+        [
+          ~s({"id":1,"result":{}}),
+          %{},
+          ~s({"id":2,"result":{"thread":{"id":"thread-89"}}}),
+          %{
+            stdout: [
+              ~s({"id":3,"result":{"turn":{"id":"turn-89"}}}),
+              ~s({"id":99,"method":"item/commandExecution/requestApproval","params":{"command":"gh pr view","cwd":"/tmp","reason":"need approval"}})
+            ]
+          },
+          %{stdout: ~s({"method":"turn/completed"}), exit: 0}
+        ],
+        trace_env: "SYMP_TEST_CODex_TRACE",
+        default_trace: "/tmp/codex-auto-approve.trace"
+      )
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -487,39 +423,46 @@ defmodule SymphonyElixir.AppServerTest do
       System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-tool-user-input-auto-approve.trace}"
-      count=0
-      while IFS= read -r line; do
-        count=$((count + 1))
-        printf 'JSON:%s\\n' \"$line\" >> \"$trace_file\"
-
-        case \"$count\" in
-          1)
-            printf '%s\\n' '{\"id\":1,\"result\":{}}'
-            ;;
-          2)
-            ;;
-          3)
-            printf '%s\\n' '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thread-717\"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-717\"}}}'
-            printf '%s\\n' '{\"id\":110,\"method\":\"item/tool/requestUserInput\",\"params\":{\"itemId\":\"call-717\",\"questions\":[{\"header\":\"Approve app tool call?\",\"id\":\"mcp_tool_call_approval_call-717\",\"isOther\":false,\"isSecret\":false,\"options\":[{\"description\":\"Run the tool and continue.\",\"label\":\"Approve Once\"},{\"description\":\"Run the tool and remember this choice for this session.\",\"label\":\"Approve this Session\"},{\"description\":\"Decline this tool call and continue.\",\"label\":\"Deny\"},{\"description\":\"Cancel this tool call\",\"label\":\"Cancel\"}],\"question\":\"The linear MCP server wants to run the tool \\\"Save issue\\\", which may modify or delete data. Allow this action?\"}],\"threadId\":\"thread-717\",\"turnId\":\"turn-717\"}}'
-            ;;
-          5)
-            printf '%s\\n' '{\"method\":\"turn/completed\"}'
-            exit 0
-            ;;
-          *)
-            exit 0
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(
+        codex_binary,
+        [
+          ~s({"id":1,"result":{}}),
+          %{},
+          ~s({"id":2,"result":{"thread":{"id":"thread-717"}}}),
+          %{
+            stdout: [
+              ~s({"id":3,"result":{"turn":{"id":"turn-717"}}}),
+              Jason.encode!(%{
+                id: 110,
+                method: "item/tool/requestUserInput",
+                params: %{
+                  itemId: "call-717",
+                  questions: [
+                    %{
+                      header: "Approve app tool call?",
+                      id: "mcp_tool_call_approval_call-717",
+                      isOther: false,
+                      isSecret: false,
+                      options: [
+                        %{description: "Run the tool and continue.", label: "Approve Once"},
+                        %{description: "Run the tool and remember this choice for this session.", label: "Approve this Session"},
+                        %{description: "Decline this tool call and continue.", label: "Deny"},
+                        %{description: "Cancel this tool call", label: "Cancel"}
+                      ],
+                      question: "The linear MCP server wants to run the tool \"Save issue\", which may modify or delete data. Allow this action?"
+                    }
+                  ],
+                  threadId: "thread-717",
+                  turnId: "turn-717"
+                }
+              })
+            ]
+          },
+          %{stdout: ~s({"method":"turn/completed"}), exit: 0}
+        ],
+        trace_env: "SYMP_TEST_CODEx_TRACE",
+        default_trace: "/tmp/codex-tool-user-input-auto-approve.trace"
+      )
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -574,37 +517,18 @@ defmodule SymphonyElixir.AppServerTest do
       codex_binary = Path.join(test_root, "fake-codex")
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      count=0
-      while IFS= read -r _line; do
-        count=$((count + 1))
-
-        case "$count" in
-          1)
-            printf '%s\\n' '{"id":1,"result":{}}'
-            ;;
-          2)
-            ;;
-          3)
-            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-718"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-718"}}}'
-            printf '%s\\n' '{"id":111,"method":"item/tool/requestUserInput","params":{"itemId":"call-718","questions":[{"header":"Provide context","id":"freeform-718","isOther":false,"isSecret":false,"options":null,"question":"What comment should I post back to the issue?"}],"threadId":"thread-718","turnId":"turn-718"}}'
-            ;;
-          5)
-            printf '%s\\n' '{"method":"turn/completed"}'
-            exit 0
-            ;;
-          *)
-            exit 0
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(codex_binary, [
+        ~s({"id":1,"result":{}}),
+        %{},
+        ~s({"id":2,"result":{"thread":{"id":"thread-718"}}}),
+        %{
+          stdout: [
+            ~s({"id":3,"result":{"turn":{"id":"turn-718"}}}),
+            ~s({"id":111,"method":"item/tool/requestUserInput","params":{"itemId":"call-718","questions":[{"header":"Provide context","id":"freeform-718","isOther":false,"isSecret":false,"options":null,"question":"What comment should I post back to the issue?"}],"threadId":"thread-718","turnId":"turn-718"}})
+          ]
+        },
+        %{stdout: ~s({"method":"turn/completed"}), exit: 0}
+      ])
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -662,39 +586,23 @@ defmodule SymphonyElixir.AppServerTest do
       System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-tool-user-input-options.trace}"
-      count=0
-      while IFS= read -r line; do
-        count=$((count + 1))
-        printf 'JSON:%s\\n' \"$line\" >> \"$trace_file\"
-
-        case \"$count\" in
-          1)
-            printf '%s\\n' '{\"id\":1,\"result\":{}}'
-            ;;
-          2)
-            ;;
-          3)
-            printf '%s\\n' '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thread-719\"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-719\"}}}'
-            printf '%s\\n' '{\"id\":112,\"method\":\"item/tool/requestUserInput\",\"params\":{\"itemId\":\"call-719\",\"questions\":[{\"header\":\"Choose an action\",\"id\":\"options-719\",\"isOther\":false,\"isSecret\":false,\"options\":[{\"description\":\"Use the default behavior.\",\"label\":\"Use default\"},{\"description\":\"Skip this step.\",\"label\":\"Skip\"}],\"question\":\"How should I proceed?\"}],\"threadId\":\"thread-719\",\"turnId\":\"turn-719\"}}'
-            ;;
-          5)
-            printf '%s\\n' '{\"method\":\"turn/completed\"}'
-            exit 0
-            ;;
-          *)
-            exit 0
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(
+        codex_binary,
+        [
+          ~s({"id":1,"result":{}}),
+          %{},
+          ~s({"id":2,"result":{"thread":{"id":"thread-719"}}}),
+          %{
+            stdout: [
+              ~s({"id":3,"result":{"turn":{"id":"turn-719"}}}),
+              ~s({"id":112,"method":"item/tool/requestUserInput","params":{"itemId":"call-719","questions":[{"header":"Choose an action","id":"options-719","isOther":false,"isSecret":false,"options":[{"description":"Use the default behavior.","label":"Use default"},{"description":"Skip this step.","label":"Skip"}],"question":"How should I proceed?"}],"threadId":"thread-719","turnId":"turn-719"}})
+            ]
+          },
+          %{stdout: ~s({"method":"turn/completed"}), exit: 0}
+        ],
+        trace_env: "SYMP_TEST_CODEx_TRACE",
+        default_trace: "/tmp/codex-tool-user-input-options.trace"
+      )
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -738,19 +646,11 @@ defmodule SymphonyElixir.AppServerTest do
   end
 
   test "app server sends manager steer messages to the active turn with expected turn id" do
-    if SymphonyElixir.LocalShell.windows?() do
-      :ok
-    else
-      do_test_app_server_sends_manager_steer_messages_to_the_active_turn()
-    end
+    do_test_app_server_sends_manager_steer_messages_to_the_active_turn()
   end
 
   test "app server records manager steer rejection responses from codex" do
-    if SymphonyElixir.LocalShell.windows?() do
-      :ok
-    else
-      do_test_app_server_records_manager_steer_rejection_response()
-    end
+    do_test_app_server_records_manager_steer_rejection_response()
   end
 
   defp do_test_app_server_records_manager_steer_rejection_response do
@@ -776,38 +676,17 @@ defmodule SymphonyElixir.AppServerTest do
 
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      count=0
-      while IFS= read -r line; do
-        count=$((count + 1))
-
-        case "$count" in
-          1)
-            printf '%s\\n' '{"id":1,"result":{}}'
-            ;;
-          2)
-            ;;
-          3)
-            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-721"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-721"}}}'
-            ;;
-          5)
-            steer_id=$(printf '%s' "$line" | sed -n 's/.*"id":\\([0-9][0-9]*\\).*/\\1/p')
-            printf '{"id":%s,"error":{"code":"turn_not_running","message":"turn stopped"}}\\n' "$steer_id"
-            printf '%s\\n' '{"method":"turn/completed"}'
-            exit 0
-            ;;
-          *)
-            exit 0
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(codex_binary, [
+        ~s({"id":1,"result":{}}),
+        %{},
+        ~s({"id":2,"result":{"thread":{"id":"thread-721"}}}),
+        ~s({"id":3,"result":{"turn":{"id":"turn-721"}}}),
+        %{
+          reply_error: %{"code" => "turn_not_running", "message" => "turn stopped"},
+          stdout: ~s({"method":"turn/completed"}),
+          exit: 0
+        }
+      ])
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -884,40 +763,18 @@ defmodule SymphonyElixir.AppServerTest do
       System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-steer.trace}"
-      count=0
-      while IFS= read -r line; do
-        count=$((count + 1))
-        printf 'JSON:%s\\n' "$line" >> "$trace_file"
-
-        case "$count" in
-          1)
-            printf '%s\\n' '{"id":1,"result":{}}'
-            ;;
-          2)
-            ;;
-          3)
-            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-720"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-720"}}}'
-            ;;
-          5)
-            steer_id=$(printf '%s' "$line" | sed -n 's/.*"id":\\([0-9][0-9]*\\).*/\\1/p')
-            printf '{"id":%s,"result":{"turnId":"turn-720"}}\\n' "$steer_id"
-            printf '%s\\n' '{"method":"turn/completed"}'
-            exit 0
-            ;;
-          *)
-            exit 0
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(
+        codex_binary,
+        [
+          ~s({"id":1,"result":{}}),
+          %{},
+          ~s({"id":2,"result":{"thread":{"id":"thread-720"}}}),
+          ~s({"id":3,"result":{"turn":{"id":"turn-720"}}}),
+          %{reply_result: %{"turnId" => "turn-720"}, stdout: ~s({"method":"turn/completed"}), exit: 0}
+        ],
+        trace_env: "SYMP_TEST_CODEx_TRACE",
+        default_trace: "/tmp/codex-steer.trace"
+      )
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -1017,39 +874,23 @@ defmodule SymphonyElixir.AppServerTest do
       System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-tool-call.trace}"
-      count=0
-      while IFS= read -r line; do
-        count=$((count + 1))
-        printf 'JSON:%s\\n' \"$line\" >> \"$trace_file\"
-
-        case \"$count\" in
-          1)
-            printf '%s\\n' '{\"id\":1,\"result\":{}}'
-            ;;
-          2)
-            ;;
-          3)
-            printf '%s\\n' '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thread-90\"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-90\"}}}'
-            printf '%s\\n' '{\"id\":101,\"method\":\"item/tool/call\",\"params\":{\"tool\":\"some_tool\",\"callId\":\"call-90\",\"threadId\":\"thread-90\",\"turnId\":\"turn-90\",\"arguments\":{}}}'
-            ;;
-          5)
-            printf '%s\\n' '{\"method\":\"turn/completed\"}'
-            exit 0
-            ;;
-          *)
-            exit 0
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(
+        codex_binary,
+        [
+          ~s({"id":1,"result":{}}),
+          %{},
+          ~s({"id":2,"result":{"thread":{"id":"thread-90"}}}),
+          %{
+            stdout: [
+              ~s({"id":3,"result":{"turn":{"id":"turn-90"}}}),
+              ~s({"id":101,"method":"item/tool/call","params":{"tool":"some_tool","callId":"call-90","threadId":"thread-90","turnId":"turn-90","arguments":{}}})
+            ]
+          },
+          %{stdout: ~s({"method":"turn/completed"}), exit: 0}
+        ],
+        trace_env: "SYMP_TEST_CODEx_TRACE",
+        default_trace: "/tmp/codex-tool-call.trace"
+      )
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -1118,39 +959,23 @@ defmodule SymphonyElixir.AppServerTest do
       System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-supported-tool-call.trace}"
-      count=0
-      while IFS= read -r line; do
-        count=$((count + 1))
-        printf 'JSON:%s\\n' \"$line\" >> \"$trace_file\"
-
-        case \"$count\" in
-          1)
-            printf '%s\\n' '{\"id\":1,\"result\":{}}'
-            ;;
-          2)
-            ;;
-          3)
-            printf '%s\\n' '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thread-90a\"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-90a\"}}}'
-            printf '%s\\n' '{\"id\":102,\"method\":\"item/tool/call\",\"params\":{\"name\":\"linear_graphql\",\"callId\":\"call-90a\",\"threadId\":\"thread-90a\",\"turnId\":\"turn-90a\",\"arguments\":{\"query\":\"query Viewer { viewer { id } }\",\"variables\":{\"includeTeams\":false}}}}'
-            ;;
-          5)
-            printf '%s\\n' '{\"method\":\"turn/completed\"}'
-            exit 0
-            ;;
-          *)
-            exit 0
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(
+        codex_binary,
+        [
+          ~s({"id":1,"result":{}}),
+          %{},
+          ~s({"id":2,"result":{"thread":{"id":"thread-90a"}}}),
+          %{
+            stdout: [
+              ~s({"id":3,"result":{"turn":{"id":"turn-90a"}}}),
+              ~s({"id":102,"method":"item/tool/call","params":{"name":"linear_graphql","callId":"call-90a","threadId":"thread-90a","turnId":"turn-90a","arguments":{"query":"query Viewer { viewer { id } }","variables":{"includeTeams":false}}}})
+            ]
+          },
+          %{stdout: ~s({"method":"turn/completed"}), exit: 0}
+        ],
+        trace_env: "SYMP_TEST_CODEx_TRACE",
+        default_trace: "/tmp/codex-supported-tool-call.trace"
+      )
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -1240,39 +1065,23 @@ defmodule SymphonyElixir.AppServerTest do
       System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-tool-call-failed.trace}"
-      count=0
-      while IFS= read -r line; do
-        count=$((count + 1))
-        printf 'JSON:%s\\n' \"$line\" >> \"$trace_file\"
-
-        case \"$count\" in
-          1)
-            printf '%s\\n' '{\"id\":1,\"result\":{}}'
-            ;;
-          2)
-            ;;
-          3)
-            printf '%s\\n' '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thread-90b\"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-90b\"}}}'
-            printf '%s\\n' '{\"id\":103,\"method\":\"item/tool/call\",\"params\":{\"tool\":\"linear_graphql\",\"callId\":\"call-90b\",\"threadId\":\"thread-90b\",\"turnId\":\"turn-90b\",\"arguments\":{\"query\":\"query Viewer { viewer { id } }\"}}}'
-            ;;
-          5)
-            printf '%s\\n' '{\"method\":\"turn/completed\"}'
-            exit 0
-            ;;
-          *)
-            exit 0
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(
+        codex_binary,
+        [
+          ~s({"id":1,"result":{}}),
+          %{},
+          ~s({"id":2,"result":{"thread":{"id":"thread-90b"}}}),
+          %{
+            stdout: [
+              ~s({"id":3,"result":{"turn":{"id":"turn-90b"}}}),
+              ~s({"id":103,"method":"item/tool/call","params":{"tool":"linear_graphql","callId":"call-90b","threadId":"thread-90b","turnId":"turn-90b","arguments":{"query":"query Viewer { viewer { id } }"}}})
+            ]
+          },
+          %{stdout: ~s({"method":"turn/completed"}), exit: 0}
+        ],
+        trace_env: "SYMP_TEST_CODEx_TRACE",
+        default_trace: "/tmp/codex-tool-call-failed.trace"
+      )
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -1334,35 +1143,12 @@ defmodule SymphonyElixir.AppServerTest do
       codex_binary = Path.join(test_root, "fake-codex")
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      count=0
-      while IFS= read -r line; do
-        count=$((count + 1))
-
-        case "$count" in
-          1)
-            padding=$(printf '%*s' 1100000 '' | tr ' ' a)
-            printf '{"id":1,"result":{},"padding":"%s"}\\n' "$padding"
-            ;;
-          2)
-            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-91"}}}'
-            ;;
-          3)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-91"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{"method":"turn/completed"}'
-            exit 0
-            ;;
-          *)
-            exit 0
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(codex_binary, [
+        ~s({"id":1,"result":{},"padding":"#{String.duplicate("a", 1_100_000)}"}),
+        ~s({"id":2,"result":{"thread":{"id":"thread-91"}}}),
+        ~s({"id":3,"result":{"turn":{"id":"turn-91"}}}),
+        %{stdout: ~s({"method":"turn/completed"}), exit: 0}
+      ])
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -1398,35 +1184,12 @@ defmodule SymphonyElixir.AppServerTest do
       codex_binary = Path.join(test_root, "fake-codex")
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      count=0
-      while IFS= read -r line; do
-        count=$((count + 1))
-
-        case "$count" in
-          1)
-            printf '%s\\n' '{"id":1,"result":{}}'
-            ;;
-          2)
-            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-92"}}}'
-            ;;
-          3)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-92"}}}'
-            ;;
-          4)
-            printf '%s\\n' 'warning: this is stderr noise' >&2
-            printf '%s\\n' '{"method":"turn/completed"}'
-            exit 0
-            ;;
-          *)
-            exit 0
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(codex_binary, [
+        ~s({"id":1,"result":{}}),
+        ~s({"id":2,"result":{"thread":{"id":"thread-92"}}}),
+        ~s({"id":3,"result":{"turn":{"id":"turn-92"}}}),
+        %{stderr: "warning: this is stderr noise", stdout: ~s({"method":"turn/completed"}), exit: 0}
+      ])
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -1514,35 +1277,12 @@ defmodule SymphonyElixir.AppServerTest do
       codex_binary = Path.join(test_root, "fake-codex")
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      count=0
-      while IFS= read -r line; do
-        count=$((count + 1))
-
-        case "$count" in
-          1)
-            printf '%s\\n' '{"id":1,"result":{}}'
-            ;;
-          2)
-            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-93"}}}'
-            ;;
-          3)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-93"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{"method":"turn/completed"'
-            printf '%s\\n' '{"method":"turn/completed"}'
-            exit 0
-            ;;
-          *)
-            exit 0
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(codex_binary, [
+        ~s({"id":1,"result":{}}),
+        ~s({"id":2,"result":{"thread":{"id":"thread-93"}}}),
+        ~s({"id":3,"result":{"turn":{"id":"turn-93"}}}),
+        %{stdout: [~s({"method":"turn/completed"), ~s({"method":"turn/completed"})], exit: 0}
+      ])
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -1572,6 +1312,10 @@ defmodule SymphonyElixir.AppServerTest do
     end
   end
 
+  if SymphonyElixir.TestSupport.windows?() do
+    @tag skip: "Remote SSH app-server startup shells through real ssh.exe; this Unix fake exercises argv construction only."
+  end
+
   test "app server launches over ssh for remote workers" do
     test_root =
       Path.join(
@@ -1594,7 +1338,7 @@ defmodule SymphonyElixir.AppServerTest do
 
       File.mkdir_p!(test_root)
       System.put_env("SYMP_TEST_SSH_TRACE", trace_file)
-      System.put_env("PATH", test_root <> ":" <> (previous_path || ""))
+      System.put_env("PATH", test_root <> SymphonyElixir.TestSupport.path_separator() <> (previous_path || ""))
 
       File.write!(fake_ssh, """
       #!/bin/sh

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -1314,32 +1314,12 @@ defmodule SymphonyElixir.CoreTest do
       System.cmd("git", ["-C", template_repo, "add", "README.md"])
       System.cmd("git", ["-C", template_repo, "commit", "-m", "initial"])
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      count=0
-      while IFS= read -r line; do
-        count=$((count + 1))
-        case "$count" in
-          1)
-            printf '%s\\n' '{\"id\":1,\"result\":{}}'
-            ;;
-          2)
-            ;;
-          3)
-            printf '%s\\n' '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thread-1\"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}'
-            printf '%s\\n' '{\"method\":\"turn/completed\"}'
-            exit 0
-            ;;
-          *)
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(codex_binary, [
+        ~s({"id":1,"result":{}}),
+        %{},
+        ~s({"id":2,"result":{"thread":{"id":"thread-1"}}}),
+        %{stdout: [~s({"id":3,"result":{"turn":{"id":"turn-1"}}}), ~s({"method":"turn/completed"})], exit: 0}
+      ])
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -1397,34 +1377,12 @@ defmodule SymphonyElixir.CoreTest do
       System.cmd("git", ["-C", template_repo, "add", "README.md"])
       System.cmd("git", ["-C", template_repo, "commit", "-m", "initial"])
 
-      File.write!(
-        codex_binary,
-        """
-        #!/bin/sh
-        count=0
-        while IFS= read -r line; do
-          count=$((count + 1))
-          case "$count" in
-            1)
-              printf '%s\\n' '{\"id\":1,\"result\":{}}'
-              ;;
-            2)
-              printf '%s\\n' '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thread-live\"}}}'
-              ;;
-            3)
-              printf '%s\\n' '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-live\"}}}'
-              ;;
-            4)
-              printf '%s\\n' '{\"method\":\"turn/completed\"}'
-              ;;
-            *)
-              ;;
-          esac
-        done
-        """
-      )
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(codex_binary, [
+        ~s({"id":1,"result":{}}),
+        ~s({"id":2,"result":{"thread":{"id":"thread-live"}}}),
+        ~s({"id":3,"result":{"turn":{"id":"turn-live"}}}),
+        %{stdout: ~s({"method":"turn/completed"}), exit: 0}
+      ])
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -1465,6 +1423,10 @@ defmodule SymphonyElixir.CoreTest do
     end
   end
 
+  if SymphonyElixir.TestSupport.windows?() do
+    @tag skip: "Fake ssh startup failure fixture is a Unix script; production Windows path launches real ssh.exe."
+  end
+
   test "agent runner surfaces ssh startup failures instead of silently hopping hosts" do
     test_root =
       Path.join(
@@ -1486,7 +1448,7 @@ defmodule SymphonyElixir.CoreTest do
 
       File.mkdir_p!(test_root)
       System.put_env("SYMP_TEST_SSH_TRACE", trace_file)
-      System.put_env("PATH", test_root <> ":" <> (previous_path || ""))
+      System.put_env("PATH", test_root <> SymphonyElixir.TestSupport.path_separator() <> (previous_path || ""))
 
       File.write!(fake_ssh, """
       #!/bin/sh
@@ -1556,38 +1518,20 @@ defmodule SymphonyElixir.CoreTest do
       System.cmd("git", ["-C", template_repo, "add", "README.md"])
       System.cmd("git", ["-C", template_repo, "commit", "-m", "initial"])
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex.trace}"
-      run_id="$(date +%s%N)-$$"
-      printf 'RUN:%s\\n' "$run_id" >> "$trace_file"
-      count=0
+      write_fake_codex!(
+        codex_binary,
+        [
+          ~s({"id":1,"result":{}}),
+          %{},
+          ~s({"id":2,"result":{"thread":{"id":"thread-cont"}}}),
+          %{stdout: [~s({"id":3,"result":{"turn":{"id":"turn-cont-1"}}}), ~s({"method":"turn/completed"})]},
+          %{stdout: [~s({"id":3,"result":{"turn":{"id":"turn-cont-2"}}}), ~s({"method":"turn/completed"})]}
+        ],
+        trace_env: "SYMP_TEST_CODEx_TRACE",
+        default_trace: "/tmp/codex.trace",
+        startup_trace: [:run]
+      )
 
-      while IFS= read -r line; do
-        count=$((count + 1))
-        printf 'JSON:%s\\n' "$line" >> "$trace_file"
-        case "$count" in
-          1)
-            printf '%s\\n' '{"id":1,"result":{}}'
-            ;;
-          2)
-            ;;
-          3)
-            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-cont"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-cont-1"}}}'
-            printf '%s\\n' '{"method":"turn/completed"}'
-            ;;
-          5)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-cont-2"}}}'
-            printf '%s\\n' '{"method":"turn/completed"}'
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
       System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
 
       on_exit(fn -> System.delete_env("SYMP_TEST_CODEx_TRACE") end)
@@ -1687,37 +1631,20 @@ defmodule SymphonyElixir.CoreTest do
       System.cmd("git", ["-C", template_repo, "add", "README.md"])
       System.cmd("git", ["-C", template_repo, "commit", "-m", "initial"])
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex.trace}"
-      printf 'RUN\\n' >> "$trace_file"
-      count=0
+      write_fake_codex!(
+        codex_binary,
+        [
+          ~s({"id":1,"result":{}}),
+          %{},
+          ~s({"id":2,"result":{"thread":{"id":"thread-max"}}}),
+          %{stdout: [~s({"id":3,"result":{"turn":{"id":"turn-max-1"}}}), ~s({"method":"turn/completed"})]},
+          %{stdout: [~s({"id":3,"result":{"turn":{"id":"turn-max-2"}}}), ~s({"method":"turn/completed"})]}
+        ],
+        trace_env: "SYMP_TEST_CODEx_TRACE",
+        default_trace: "/tmp/codex.trace",
+        startup_trace: [:run_marker]
+      )
 
-      while IFS= read -r line; do
-        count=$((count + 1))
-        printf 'JSON:%s\\n' "$line" >> "$trace_file"
-        case "$count" in
-          1)
-            printf '%s\\n' '{"id":1,"result":{}}'
-            ;;
-          2)
-            ;;
-          3)
-            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-max"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-max-1"}}}'
-            printf '%s\\n' '{"method":"turn/completed"}'
-            ;;
-          5)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-max-2"}}}'
-            printf '%s\\n' '{"method":"turn/completed"}'
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
       System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
 
       on_exit(fn -> System.delete_env("SYMP_TEST_CODEx_TRACE") end)
@@ -1788,38 +1715,18 @@ defmodule SymphonyElixir.CoreTest do
       System.put_env("SYMP_TEST_CODex_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      trace_file="${SYMP_TEST_CODex_TRACE:-/tmp/codex-args.trace}"
-      count=0
-      printf 'ARGV:%s\\n' \"$*\" >> \"$trace_file\"
-      printf 'CWD:%s\\n' \"$PWD\" >> \"$trace_file\"
-
-      while IFS= read -r line; do
-        count=$((count + 1))
-        printf 'JSON:%s\\n' \"$line\" >> \"$trace_file\"
-        case \"$count\" in
-          1)
-            printf '%s\\n' '{\"id\":1,\"result\":{}}'
-            ;;
-          2)
-            printf '%s\\n' '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thread-77\"}}}'
-            ;;
-          3)
-            printf '%s\\n' '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-77\"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{\"method\":\"turn/completed\"}'
-            exit 0
-            ;;
-          *)
-            exit 0
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(
+        codex_binary,
+        [
+          ~s({"id":1,"result":{}}),
+          ~s({"id":2,"result":{"thread":{"id":"thread-77"}}}),
+          ~s({"id":3,"result":{"turn":{"id":"turn-77"}}}),
+          %{stdout: ~s({"method":"turn/completed"}), exit: 0}
+        ],
+        trace_env: "SYMP_TEST_CODex_TRACE",
+        default_trace: "/tmp/codex-args.trace",
+        startup_trace: [:argv, :cwd]
+      )
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -1934,36 +1841,18 @@ defmodule SymphonyElixir.CoreTest do
       System.put_env("SYMP_TEST_CODex_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      trace_file="${SYMP_TEST_CODex_TRACE:-/tmp/codex-custom-args.trace}"
-      count=0
-      printf 'ARGV:%s\\n' \"$*\" >> \"$trace_file\"
-
-      while IFS= read -r line; do
-        count=$((count + 1))
-        case \"$count\" in
-          1)
-            printf '%s\\n' '{\"id\":1,\"result\":{}}'
-            ;;
-          2)
-            printf '%s\\n' '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thread-88\"}}}'
-            ;;
-          3)
-            printf '%s\\n' '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-88\"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{\"method\":\"turn/completed\"}'
-            exit 0
-            ;;
-          *)
-            exit 0
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(
+        codex_binary,
+        [
+          ~s({"id":1,"result":{}}),
+          ~s({"id":2,"result":{"thread":{"id":"thread-88"}}}),
+          ~s({"id":3,"result":{"turn":{"id":"turn-88"}}}),
+          %{stdout: ~s({"method":"turn/completed"}), exit: 0}
+        ],
+        trace_env: "SYMP_TEST_CODex_TRACE",
+        default_trace: "/tmp/codex-custom-args.trace",
+        startup_trace: [:argv]
+      )
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
@@ -2019,37 +1908,17 @@ defmodule SymphonyElixir.CoreTest do
       System.put_env("SYMP_TEST_CODex_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
-      #!/bin/sh
-      trace_file="${SYMP_TEST_CODex_TRACE:-/tmp/codex-policy-overrides.trace}"
-      count=0
-
-      while IFS= read -r line; do
-        count=$((count + 1))
-        printf 'JSON:%s\\n' "$line" >> "$trace_file"
-
-        case "$count" in
-          1)
-            printf '%s\\n' '{"id":1,"result":{}}'
-            ;;
-          2)
-            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-99"}}}'
-            ;;
-          3)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-99"}}}'
-            ;;
-          4)
-            printf '%s\\n' '{"method":"turn/completed"}'
-            exit 0
-            ;;
-          *)
-            exit 0
-            ;;
-        esac
-      done
-      """)
-
-      File.chmod!(codex_binary, 0o755)
+      write_fake_codex!(
+        codex_binary,
+        [
+          ~s({"id":1,"result":{}}),
+          ~s({"id":2,"result":{"thread":{"id":"thread-99"}}}),
+          ~s({"id":3,"result":{"turn":{"id":"turn-99"}}}),
+          %{stdout: ~s({"method":"turn/completed"}), exit: 0}
+        ],
+        trace_env: "SYMP_TEST_CODex_TRACE",
+        default_trace: "/tmp/codex-policy-overrides.trace"
+      )
 
       workspace_cache = Path.join(Path.expand(workspace), ".cache")
       File.mkdir_p!(workspace_cache)

--- a/elixir/test/symphony_elixir/ssh_test.exs
+++ b/elixir/test/symphony_elixir/ssh_test.exs
@@ -3,6 +3,13 @@ defmodule SymphonyElixir.SSHTest do
 
   alias SymphonyElixir.SSH
 
+  @fake_ssh_skip if(SymphonyElixir.TestSupport.windows?(),
+                   do: "Fake ssh tests use a Unix executable script; Windows coverage for remote SSH uses real ssh.exe.",
+                   else: nil
+                 )
+
+  if @fake_ssh_skip, do: @tag(skip: @fake_ssh_skip)
+
   test "run/3 keeps bracketed IPv6 host:port targets intact" do
     test_root = Path.join(System.tmp_dir!(), "symphony-ssh-ipv6-test-#{System.unique_integer([:positive])}")
     trace_file = Path.join(test_root, "ssh.trace")
@@ -23,6 +30,8 @@ defmodule SymphonyElixir.SSHTest do
     assert trace =~ "printf ok"
   end
 
+  if @fake_ssh_skip, do: @tag(skip: @fake_ssh_skip)
+
   test "run/3 leaves unbracketed IPv6-style targets unchanged" do
     test_root = Path.join(System.tmp_dir!(), "symphony-ssh-ipv6-raw-test-#{System.unique_integer([:positive])}")
     trace_file = Path.join(test_root, "ssh.trace")
@@ -42,6 +51,8 @@ defmodule SymphonyElixir.SSHTest do
     assert trace =~ "-T ::1:2200 bash -lc"
     refute trace =~ "-p 2200"
   end
+
+  if @fake_ssh_skip, do: @tag(skip: @fake_ssh_skip)
 
   test "run/3 passes host:port targets through ssh -p" do
     test_root = Path.join(System.tmp_dir!(), "symphony-ssh-test-#{System.unique_integer([:positive])}")
@@ -66,6 +77,8 @@ defmodule SymphonyElixir.SSHTest do
     assert trace =~ "-T -p 2222 localhost bash -lc"
     assert trace =~ "echo ready"
   end
+
+  if @fake_ssh_skip, do: @tag(skip: @fake_ssh_skip)
 
   test "run/3 keeps the user prefix when parsing user@host:port targets" do
     test_root = Path.join(System.tmp_dir!(), "symphony-ssh-user-test-#{System.unique_integer([:positive])}")
@@ -102,6 +115,8 @@ defmodule SymphonyElixir.SSHTest do
     assert {:error, :ssh_not_found} = SSH.run("localhost", "printf ok")
   end
 
+  if @fake_ssh_skip, do: @tag(skip: @fake_ssh_skip)
+
   test "start_port/3 supports binary output without line mode" do
     test_root = Path.join(System.tmp_dir!(), "symphony-ssh-port-test-#{System.unique_integer([:positive])}")
     trace_file = Path.join(test_root, "ssh.trace")
@@ -131,6 +146,8 @@ defmodule SymphonyElixir.SSHTest do
     assert trace =~ "-T localhost bash -lc"
     refute trace =~ " -F "
   end
+
+  if @fake_ssh_skip, do: @tag(skip: @fake_ssh_skip)
 
   test "start_port/3 supports line mode" do
     test_root = Path.join(System.tmp_dir!(), "symphony-ssh-line-port-test-#{System.unique_integer([:positive])}")
@@ -179,7 +196,7 @@ defmodule SymphonyElixir.SSHTest do
     )
 
     File.chmod!(fake_ssh, 0o755)
-    System.put_env("PATH", fake_bin_dir <> ":" <> (System.get_env("PATH") || ""))
+    System.put_env("PATH", fake_bin_dir <> SymphonyElixir.TestSupport.path_separator() <> (System.get_env("PATH") || ""))
   end
 
   defp wait_for_trace!(trace_file, attempts \\ 20)


### PR DESCRIPTION
#### Context

GH #2 needs fake app-server, SSH, and GitHub CLI fixtures that do not accidentally depend on Unix shell execution when tests run on Windows.

#### TL;DR

*Add a shared Node-backed fake Codex fixture and mark Unix-only CLI fakes clearly.*

#### Summary

- Add shared test helpers for Node-backed fake Codex executables.
- Replace app-server and core protocol shell fakes with the shared helper.
- Keep direct fake SSH and gh/git shell-script tests Unix-only on Windows.
- Make shared test setup tolerate absent app supervisor during coverage.
- Document when to use app-server fixtures vs direct executable fakes.

#### Alternatives

- Add `.cmd` fixtures for every fake, but app-server already supports Node shims.
- Change production SSH/GitHub CLI launch paths, but this issue only covers tests.

#### Test Plan

- [ ] `make -C elixir all` (not run locally: `make` is not installed on this Windows worker)
- [x] `mix test test/support/test_support.exs test/symphony_elixir/app_server_test.exs test/symphony_elixir/core_test.exs test/symphony_elixir/ssh_test.exs test/mix/tasks/workspace_before_remove_test.exs`
- [x] `mix test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs`
- [x] `mix format --check-formatted test/support/test_support.exs test/symphony_elixir/app_server_test.exs test/symphony_elixir/core_test.exs test/symphony_elixir/ssh_test.exs test/mix/tasks/workspace_before_remove_test.exs`
- [x] `mix credo --strict test/support/test_support.exs`
- [x] `git diff --check`

Review loop: Subagent review found no blocking issues. It suggested replacing one remaining hardcoded PATH separator in a fake gh/git helper; fixed before commit.

Known local gate note: repository-wide `mix format --check-formatted` fails on untouched `elixir/lib/symphony_elixir/orchestrator.ex` line-ending/format churn. Local `mix test --cover` also exposes existing Windows-only failures in `SpecsCheckTest` and `PrBody.CheckTest`; CI runs this gate on Linux.

Links: Linear ALB-9, GitHub issue #2.