### PR TITLE
Harden review readiness gates

### DIFF
--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -199,9 +199,18 @@ When a ticket has an attached PR, run this protocol before moving to `Human Revi
 3. Treat every actionable reviewer comment (human or bot), including inline review comments, as blocking until one of these is true:
    - code/test/docs updated to address it, or
    - explicit, justified pushback reply is posted on that thread.
-4. Update the workpad plan/checklist to include each feedback item and its resolution status.
-5. Re-run validation after feedback-driven changes and push updates.
-6. Repeat this sweep until there are no outstanding actionable comments.
+4. Explicitly check for gate weakening and stale-base regressions:
+   - coverage-ignore additions must not include modules changed in the same PR unless a manager
+     audits and approves the exception outside the agent session.
+   - CI, lint, formatter, test, review, and readiness gates must not be skipped, disabled, relaxed,
+     or made non-blocking.
+   - if the PR branch is behind current `main` and touches files changed by newer merged work, merge
+     current `main`, resolve the overlap, and rerun validation before review handoff.
+   - deleted tests or removed public message handlers must be in scope for the issue and backed by
+     replacement coverage or explicit manager approval.
+5. Update the workpad plan/checklist to include each feedback item and its resolution status.
+6. Re-run validation after feedback-driven changes and push updates.
+7. Repeat this sweep until there are no outstanding actionable comments.
 
 ## Blocked-access escape hatch (required behavior)
 

--- a/elixir/docs/agent-quality-flywheel.md
+++ b/elixir/docs/agent-quality-flywheel.md
@@ -25,6 +25,16 @@ Agents must not weaken, skip, disable, or relax CI, lint, formatter, or test gat
 work. If a gate is wrong or flaky, file or link a follow-up defect and keep the current issue out of
 `In Review` until the required checks pass or a manager explicitly overrides the state transition.
 
+Coverage ignore changes are gate changes. A PR must not add a production module to
+`test_coverage.ignore_modules` when that same module is changed in the PR. The review-readiness
+gate rejects that overlap before an agent can move the Linear issue to review. If a manager believes
+an exception is justified, the manager must audit it outside the agent session and leave an explicit
+approval note; the agent cannot self-approve the transition.
+
+Stale-base overlap is also not review-ready. When the PR's recorded base SHA is behind the current
+base branch and files changed on current base overlap files changed in the PR, the agent must merge
+current base, resolve the overlap, and rerun validation before handoff.
+
 ## Review loop
 
 Request an independent SubAgent review pass for meaningful changes before handoff. A change is
@@ -37,6 +47,11 @@ The review pass should check:
 
 - The implementation is scoped to the linked Linear/GitHub issue.
 - The validation evidence matches the touched risk.
+- The PR does not weaken coverage, CI, lint, formatter, review, or readiness gates.
+- The PR branch is current enough for the touched files, with no stale-base overlap against newer
+  merged work.
+- Deleted tests or removed public message handlers are in scope for the issue and backed by clear
+  replacement coverage or explicit manager approval.
 - CI failures and runtime defects are written back to GitHub or Linear before state changes.
 - Follow-up work is filed instead of being left only in logs.
 

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -570,9 +570,9 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
       patch = Map.get(file, "patch")
 
       if production_elixir_file?(filename) and status != "removed" do
-        acc
-        |> MapSet.put(module_name_from_path(filename))
-        |> MapSet.union(module_names_from_patch(patch))
+        patch
+        |> module_names_from_patch()
+        |> Enum.reduce(MapSet.put(acc, module_name_from_path(filename)), &MapSet.put(&2, &1))
       else
         acc
       end
@@ -598,10 +598,9 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   defp module_names_from_patch(patch) when is_binary(patch) do
     Regex.scan(~r/^[ +]\s*defmodule\s+([A-Z][A-Za-z0-9_.]*)\s+do/m, patch)
     |> Enum.map(fn [_, module] -> module end)
-    |> MapSet.new()
   end
 
-  defp module_names_from_patch(_patch), do: MapSet.new()
+  defp module_names_from_patch(_patch), do: []
 
   defp added_coverage_ignore_modules(files) do
     files

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -385,7 +385,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
          {:ok, base_ref} <- required_string(pr, ["base", "ref"], :review_readiness_missing_pr_base_ref),
          :ok <- pull_request_file_count_fetchable?(pr),
          {:ok, pr_files} <- pull_request_files(owner, repo, number, github_client),
-         :ok <- coverage_ignore_ready?(pr_files),
+         :ok <- coverage_ignore_ready?(owner, repo, head_sha, pr_files, github_client),
          {:ok, merge_base_sha} <- merge_base_sha(owner, repo, base_ref, head_sha, github_client),
          :ok <- stale_base_ready?(owner, repo, base_ref, merge_base_sha, pr_files, github_client),
          {:ok, required_checks} <-
@@ -534,20 +534,22 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
 
   defp pull_request_file_count_fetchable?(_pr), do: :ok
 
-  defp coverage_ignore_ready?(files) do
+  defp coverage_ignore_ready?(owner, repo, head_sha, files, github_client) do
     changed_modules = changed_production_modules(files)
-    ignored_modules = added_coverage_ignore_modules(files)
-    changed_module_keys = normalized_module_set(changed_modules)
 
-    overlap =
-      ignored_modules
-      |> Enum.filter(&(normalize_module_name(&1) in changed_module_keys))
-      |> Enum.sort()
+    with {:ok, ignored_modules} <- added_coverage_ignore_modules(owner, repo, head_sha, files, github_client) do
+      changed_module_keys = normalized_module_set(changed_modules)
 
-    if overlap == [] do
-      :ok
-    else
-      {:error, {:review_readiness_coverage_ignore_changed_modules, overlap}}
+      overlap =
+        ignored_modules
+        |> Enum.filter(&changed_module_ignored?(&1, changed_module_keys))
+        |> Enum.sort()
+
+      if overlap == [] do
+        :ok
+      else
+        {:error, {:review_readiness_coverage_ignore_changed_modules, overlap}}
+      end
     end
   end
 
@@ -563,6 +565,14 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     |> String.downcase()
   end
 
+  defp changed_module_ignored?(ignored_module, changed_module_keys) do
+    ignored_key = normalize_module_name(ignored_module)
+
+    Enum.any?(changed_module_keys, fn changed_key ->
+      ignored_key == changed_key or String.starts_with?(ignored_key, changed_key <> ".")
+    end)
+  end
+
   defp changed_production_modules(files) do
     Enum.reduce(files, MapSet.new(), fn file, acc ->
       filename = Map.get(file, "filename")
@@ -570,9 +580,11 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
       patch = Map.get(file, "patch")
 
       if production_elixir_file?(filename) and status != "removed" do
+        path_module = module_name_from_path(filename)
+
         patch
-        |> module_names_from_patch()
-        |> Enum.reduce(MapSet.put(acc, module_name_from_path(filename)), &MapSet.put(&2, &1))
+        |> module_names_from_patch(path_module)
+        |> Enum.reduce(MapSet.put(acc, path_module), &MapSet.put(&2, &1))
       else
         acc
       end
@@ -595,31 +607,210 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     |> Enum.map_join(".", &Macro.camelize/1)
   end
 
-  defp module_names_from_patch(patch) when is_binary(patch) do
+  defp module_names_from_patch(patch, path_module) when is_binary(patch) do
     Regex.scan(~r/^[ +]\s*defmodule\s+([A-Z][A-Za-z0-9_.]*)\s+do/m, patch)
-    |> Enum.map(fn [_, module] -> module end)
+    |> Enum.flat_map(fn [_, module] -> changed_module_names(module, path_module) end)
   end
 
-  defp module_names_from_patch(_patch), do: []
+  defp module_names_from_patch(_patch, _path_module), do: []
 
-  defp added_coverage_ignore_modules(files) do
+  defp changed_module_names(module, path_module) do
+    if String.contains?(module, ".") do
+      [module]
+    else
+      [module, path_module <> "." <> module]
+    end
+  end
+
+  defp added_coverage_ignore_modules(owner, repo, head_sha, files, github_client) do
     files
     |> Enum.filter(&(Map.get(&1, "filename") == "mix.exs" or String.ends_with?(Map.get(&1, "filename") || "", "/mix.exs")))
-    |> Enum.reduce(MapSet.new(), fn file, acc ->
-      file
-      |> Map.get("patch", "")
-      |> added_elixir_module_lines()
-      |> MapSet.new()
-      |> MapSet.union(acc)
+    |> Enum.reduce_while({:ok, MapSet.new()}, fn file, {:ok, acc} ->
+      added_coverage_ignore_modules_for_file(owner, repo, head_sha, file, github_client, acc)
     end)
   end
 
-  defp added_elixir_module_lines(patch) when is_binary(patch) do
-    Regex.scan(~r/^\+\s*([A-Z][A-Za-z0-9_.]*)\s*,?\s*$/m, patch)
-    |> Enum.map(fn [_, module] -> module end)
+  defp added_coverage_ignore_modules_for_file(owner, repo, head_sha, file, github_client, acc) do
+    candidates =
+      file
+      |> Map.get("patch", "")
+      |> added_elixir_module_candidates()
+
+    case candidates do
+      [] ->
+        {:cont, {:ok, acc}}
+
+      candidates ->
+        add_coverage_ignore_candidates(owner, repo, head_sha, file, github_client, acc, candidates)
+    end
   end
 
-  defp added_elixir_module_lines(_patch), do: []
+  defp add_coverage_ignore_candidates(owner, repo, head_sha, file, github_client, acc, candidates) do
+    case github_file_lines(owner, repo, Map.fetch!(file, "filename"), head_sha, github_client) do
+      {:ok, lines} -> {:cont, {:ok, MapSet.union(acc, coverage_ignore_modules_at_lines(candidates, lines))}}
+      {:error, reason} -> {:halt, {:error, reason}}
+    end
+  end
+
+  defp coverage_ignore_modules_at_lines(candidates, lines) do
+    ranges = coverage_ignore_line_ranges(lines)
+
+    candidates
+    |> Enum.filter(fn {_module, line_number} -> line_in_ranges?(line_number, ranges) end)
+    |> Enum.map(fn {module, _line_number} -> module end)
+    |> MapSet.new()
+  end
+
+  defp added_elixir_module_candidates(patch) when is_binary(patch) do
+    patch
+    |> String.split("\n")
+    |> Enum.reduce(%{line_number: nil, modules: []}, &added_elixir_module_candidate/2)
+    |> Map.fetch!(:modules)
+    |> Enum.reverse()
+  end
+
+  defp added_elixir_module_candidates(_patch), do: []
+
+  defp added_elixir_module_candidate(line, state) do
+    cond do
+      hunk_start = hunk_new_start(line) ->
+        %{state | line_number: hunk_start - 1}
+
+      state.line_number == nil ->
+        state
+
+      deleted_line?(line) ->
+        state
+
+      added_line?(line) ->
+        state
+        |> increment_line_number()
+        |> maybe_add_candidate(line)
+
+      true ->
+        increment_line_number(state)
+    end
+  end
+
+  defp hunk_new_start(line) do
+    case Regex.run(~r/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/, line) do
+      [_, start] -> String.to_integer(start)
+      _ -> nil
+    end
+  end
+
+  defp increment_line_number(%{line_number: line_number} = state) when is_integer(line_number),
+    do: %{state | line_number: line_number + 1}
+
+  defp increment_line_number(state), do: state
+
+  defp maybe_add_candidate(%{line_number: line_number, modules: modules} = state, line) do
+    case added_module_from_line(line) do
+      nil -> state
+      module -> %{state | modules: [{module, line_number} | modules]}
+    end
+  end
+
+  defp github_file_lines(owner, repo, filename, ref, github_client) do
+    path = filename |> String.split("/") |> Enum.map_join("/", fn segment -> URI.encode(segment, &URI.char_unreserved?/1) end)
+    encoded_ref = URI.encode(ref, &URI.char_unreserved?/1)
+
+    with {:ok, content} <- github_json(github_client, "#{@github_api}/repos/#{owner}/#{repo}/contents/#{path}?ref=#{encoded_ref}"),
+         {:ok, decoded} <- decode_github_content(content) do
+      {:ok, String.split(decoded, ~r/\R/)}
+    end
+  end
+
+  defp decode_github_content(%{"encoding" => "base64", "content" => content}) when is_binary(content) do
+    content
+    |> String.replace(~r/\s+/, "")
+    |> Base.decode64()
+    |> case do
+      {:ok, decoded} -> {:ok, decoded}
+      :error -> {:error, :review_readiness_github_content_unreadable}
+    end
+  end
+
+  defp decode_github_content(_content), do: {:error, :review_readiness_github_content_unreadable}
+
+  defp coverage_ignore_line_ranges(lines) do
+    lines
+    |> Enum.with_index(1)
+    |> Enum.reduce(%{test_coverage_depth: 0, ignore_start: nil, ranges: []}, &coverage_ignore_line_range/2)
+    |> Map.fetch!(:ranges)
+    |> Enum.reverse()
+  end
+
+  defp coverage_ignore_line_range({line, line_number}, state) do
+    state =
+      if state.test_coverage_depth > 0 and state.ignore_start == nil and opens_ignore_modules?(line) do
+        %{state | ignore_start: line_number}
+      else
+        state
+      end
+
+    state = track_test_coverage_depth(state, line)
+
+    cond do
+      state.ignore_start != nil and closes_list?(line) ->
+        %{state | ignore_start: nil, ranges: [{state.ignore_start, line_number} | state.ranges]}
+
+      state.test_coverage_depth == 0 ->
+        %{state | ignore_start: nil}
+
+      true ->
+        state
+    end
+  end
+
+  defp track_test_coverage_depth(state, line) do
+    depth =
+      case state.test_coverage_depth do
+        0 ->
+          if String.match?(line, ~r/\btest_coverage:\s*\[/), do: bracket_delta(line), else: 0
+
+        depth ->
+          depth + bracket_delta(line)
+      end
+
+    %{state | test_coverage_depth: max(depth, 0)}
+  end
+
+  defp bracket_delta(content) do
+    uncommented = content |> String.split("#", parts: 2) |> hd()
+    length(Regex.scan(~r/\[/, uncommented)) - length(Regex.scan(~r/\]/, uncommented))
+  end
+
+  defp line_in_ranges?(line_number, ranges) do
+    Enum.any?(ranges, fn {first, last} -> line_number >= first and line_number <= last end)
+  end
+
+  defp added_line?(line), do: String.starts_with?(line, "+") and not String.starts_with?(line, "+++")
+  defp deleted_line?(line), do: String.starts_with?(line, "-")
+
+  defp opens_ignore_modules?(line) do
+    patch_line_content(line)
+    |> String.match?(~r/\bignore_modules:\s*\[/)
+  end
+
+  defp closes_list?(line) do
+    patch_line_content(line)
+    |> String.match?(~r/^\s*\]/)
+  end
+
+  defp added_module_from_line("+" <> rest) do
+    case Regex.run(~r/^\s*([A-Z][A-Za-z0-9_.]*)\s*,?\s*(?:#.*)?$/, rest) do
+      [_, module] -> module
+      _ -> nil
+    end
+  end
+
+  defp added_module_from_line(_line), do: nil
+
+  defp patch_line_content("+" <> rest), do: rest
+  defp patch_line_content("-" <> rest), do: rest
+  defp patch_line_content(" " <> rest), do: rest
+  defp patch_line_content(line), do: line
 
   defp merge_base_sha(owner, repo, base_ref, head_sha, github_client) do
     encoded_base_ref = URI.encode(base_ref, &URI.char_unreserved?/1)
@@ -938,6 +1129,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   defp rejection_message(:review_readiness_missing_pr_head_sha), do: "the linked PR head SHA could not be verified."
   defp rejection_message(:review_readiness_missing_pr_base_ref), do: "the linked PR base branch could not be verified."
   defp rejection_message(:review_readiness_missing_pr_merge_base_sha), do: "the linked PR merge-base SHA could not be verified."
+  defp rejection_message(:review_readiness_github_content_unreadable), do: "GitHub file content could not be decoded for review readiness."
 
   defp rejection_message(:review_readiness_agent_override_not_allowed),
     do: "manager override cannot be authorized by an agent tool call; a manager must move the issue outside the agent session and leave an audit note."

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -383,6 +383,11 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
          :ok <- pull_request_matches_issue?(issue, owner, repo, pr),
          {:ok, head_sha} <- required_string(pr, ["head", "sha"], :review_readiness_missing_pr_head_sha),
          {:ok, base_ref} <- required_string(pr, ["base", "ref"], :review_readiness_missing_pr_base_ref),
+         :ok <- pull_request_file_count_fetchable?(pr),
+         {:ok, pr_files} <- pull_request_files(owner, repo, number, github_client),
+         :ok <- coverage_ignore_ready?(pr_files),
+         {:ok, merge_base_sha} <- merge_base_sha(owner, repo, base_ref, head_sha, github_client),
+         :ok <- stale_base_ready?(owner, repo, base_ref, merge_base_sha, pr_files, github_client),
          {:ok, required_checks} <-
            required_checks(owner, repo, base_ref, github_client),
          {:ok, statuses} <- github_json(github_client, "#{@github_api}/repos/#{owner}/#{repo}/commits/#{head_sha}/status"),
@@ -504,6 +509,163 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
         {:error, {:review_readiness_github_unverifiable, reason}}
     end
   end
+
+  defp github_json_list(github_client, url) do
+    case github_client.(url, []) do
+      {:ok, %{status: status, body: body}} when status in 200..299 and is_list(body) ->
+        {:ok, body}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, {:review_readiness_github_unverifiable, status, summarize_body(body)}}
+
+      {:error, reason} ->
+        {:error, {:review_readiness_github_unverifiable, reason}}
+    end
+  end
+
+  defp pull_request_files(owner, repo, number, github_client) do
+    github_json_list(github_client, "#{@github_api}/repos/#{owner}/#{repo}/pulls/#{number}/files?per_page=100")
+  end
+
+  defp pull_request_file_count_fetchable?(%{"changed_files" => changed_files})
+       when is_integer(changed_files) and changed_files > 100 do
+    {:error, {:review_readiness_pr_file_list_too_large, changed_files}}
+  end
+
+  defp pull_request_file_count_fetchable?(_pr), do: :ok
+
+  defp coverage_ignore_ready?(files) do
+    changed_modules = changed_production_modules(files)
+    ignored_modules = added_coverage_ignore_modules(files)
+    changed_module_keys = normalized_module_set(changed_modules)
+
+    overlap =
+      ignored_modules
+      |> Enum.filter(&(normalize_module_name(&1) in changed_module_keys))
+      |> Enum.sort()
+
+    if overlap == [] do
+      :ok
+    else
+      {:error, {:review_readiness_coverage_ignore_changed_modules, overlap}}
+    end
+  end
+
+  defp normalized_module_set(modules) do
+    modules
+    |> Enum.map(&normalize_module_name/1)
+    |> MapSet.new()
+  end
+
+  defp normalize_module_name(module) do
+    module
+    |> String.trim()
+    |> String.downcase()
+  end
+
+  defp changed_production_modules(files) do
+    Enum.reduce(files, MapSet.new(), fn file, acc ->
+      filename = Map.get(file, "filename")
+      status = Map.get(file, "status")
+      patch = Map.get(file, "patch")
+
+      if production_elixir_file?(filename) and status != "removed" do
+        acc
+        |> MapSet.put(module_name_from_path(filename))
+        |> MapSet.union(module_names_from_patch(patch))
+      else
+        acc
+      end
+    end)
+  end
+
+  defp production_elixir_file?(filename) when is_binary(filename) do
+    (String.starts_with?(filename, "lib/") or String.starts_with?(filename, "elixir/lib/")) and
+      String.ends_with?(filename, ".ex")
+  end
+
+  defp production_elixir_file?(_filename), do: false
+
+  defp module_name_from_path(filename) do
+    filename
+    |> String.trim_leading("elixir/")
+    |> String.trim_leading("lib/")
+    |> String.trim_trailing(".ex")
+    |> String.split("/", trim: true)
+    |> Enum.map_join(".", &Macro.camelize/1)
+  end
+
+  defp module_names_from_patch(patch) when is_binary(patch) do
+    Regex.scan(~r/^[ +]\s*defmodule\s+([A-Z][A-Za-z0-9_.]*)\s+do/m, patch)
+    |> Enum.map(fn [_, module] -> module end)
+    |> MapSet.new()
+  end
+
+  defp module_names_from_patch(_patch), do: MapSet.new()
+
+  defp added_coverage_ignore_modules(files) do
+    files
+    |> Enum.filter(&(Map.get(&1, "filename") == "mix.exs" or String.ends_with?(Map.get(&1, "filename") || "", "/mix.exs")))
+    |> Enum.reduce(MapSet.new(), fn file, acc ->
+      file
+      |> Map.get("patch", "")
+      |> added_elixir_module_lines()
+      |> MapSet.new()
+      |> MapSet.union(acc)
+    end)
+  end
+
+  defp added_elixir_module_lines(patch) when is_binary(patch) do
+    Regex.scan(~r/^\+\s*([A-Z][A-Za-z0-9_.]*)\s*,?\s*$/m, patch)
+    |> Enum.map(fn [_, module] -> module end)
+  end
+
+  defp added_elixir_module_lines(_patch), do: []
+
+  defp merge_base_sha(owner, repo, base_ref, head_sha, github_client) do
+    encoded_base_ref = URI.encode(base_ref, &URI.char_unreserved?/1)
+    compare_url = "#{@github_api}/repos/#{owner}/#{repo}/compare/#{encoded_base_ref}...#{head_sha}"
+
+    with {:ok, comparison} <- github_json(github_client, compare_url),
+         {:ok, merge_base_sha} <-
+           required_string(comparison, ["merge_base_commit", "sha"], :review_readiness_missing_pr_merge_base_sha) do
+      {:ok, merge_base_sha}
+    end
+  end
+
+  defp stale_base_ready?(owner, repo, base_ref, merge_base_sha, pr_files, github_client) do
+    compare_url = "#{@github_api}/repos/#{owner}/#{repo}/compare/#{merge_base_sha}...#{URI.encode(base_ref, &URI.char_unreserved?/1)}"
+
+    with {:ok, comparison} <- github_json(github_client, compare_url) do
+      stale_base_overlap(comparison, pr_files)
+    end
+  end
+
+  defp stale_base_overlap(%{"ahead_by" => ahead_by, "files" => base_files}, pr_files)
+       when is_integer(ahead_by) and ahead_by > 0 and is_list(base_files) do
+    pr_filenames = changed_filenames(pr_files)
+    base_filenames = changed_filenames(base_files)
+    overlap = MapSet.intersection(pr_filenames, base_filenames)
+
+    if MapSet.size(overlap) == 0 do
+      :ok
+    else
+      {:error, {:review_readiness_stale_base_overlap, Enum.sort(overlap)}}
+    end
+  end
+
+  defp stale_base_overlap(_comparison, _pr_files), do: :ok
+
+  defp changed_filenames(files) do
+    Enum.reduce(files, MapSet.new(), fn file, acc ->
+      acc
+      |> maybe_put_filename(Map.get(file, "filename"))
+      |> maybe_put_filename(Map.get(file, "previous_filename"))
+    end)
+  end
+
+  defp maybe_put_filename(filenames, filename) when is_binary(filename), do: MapSet.put(filenames, filename)
+  defp maybe_put_filename(filenames, _filename), do: filenames
 
   defp required_string(payload, path, error) do
     case get_in(payload, path) do
@@ -778,6 +940,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   defp rejection_message(:review_readiness_required_checks_unverifiable), do: "required GitHub checks could not be verified."
   defp rejection_message(:review_readiness_missing_pr_head_sha), do: "the linked PR head SHA could not be verified."
   defp rejection_message(:review_readiness_missing_pr_base_ref), do: "the linked PR base branch could not be verified."
+  defp rejection_message(:review_readiness_missing_pr_merge_base_sha), do: "the linked PR merge-base SHA could not be verified."
 
   defp rejection_message(:review_readiness_agent_override_not_allowed),
     do: "manager override cannot be authorized by an agent tool call; a manager must move the issue outside the agent session and leave an audit note."
@@ -805,6 +968,15 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
 
   defp rejection_message({:review_readiness_required_checks_not_passing, failures}),
     do: "required GitHub checks are not passing: #{format_failures(failures)}."
+
+  defp rejection_message({:review_readiness_pr_file_list_too_large, changed_files}),
+    do: "the linked PR changes #{changed_files} files; review readiness only verifies the first 100 GitHub PR files. Split the PR or get manager review outside the agent session."
+
+  defp rejection_message({:review_readiness_coverage_ignore_changed_modules, modules}),
+    do: "coverage ignore additions include modules changed in this PR: #{Enum.join(modules, ", ")}. Remove the ignore entry or get a manager to audit and move the issue outside the agent session."
+
+  defp rejection_message({:review_readiness_stale_base_overlap, filenames}),
+    do: "the PR base is stale and current base branch changes overlap PR files: #{Enum.join(filenames, ", ")}. Merge current base, resolve the overlap, and rerun validation."
 
   defp format_failures(failures) do
     Enum.map_join(failures, ", ", fn

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -626,10 +626,8 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     encoded_base_ref = URI.encode(base_ref, &URI.char_unreserved?/1)
     compare_url = "#{@github_api}/repos/#{owner}/#{repo}/compare/#{encoded_base_ref}...#{head_sha}"
 
-    with {:ok, comparison} <- github_json(github_client, compare_url),
-         {:ok, merge_base_sha} <-
-           required_string(comparison, ["merge_base_commit", "sha"], :review_readiness_missing_pr_merge_base_sha) do
-      {:ok, merge_base_sha}
+    with {:ok, comparison} <- github_json(github_client, compare_url) do
+      required_string(comparison, ["merge_base_commit", "sha"], :review_readiness_missing_pr_merge_base_sha)
     end
   end
 

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -705,10 +705,12 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   defp increment_line_number(state), do: state
 
   defp maybe_add_candidate(%{line_number: line_number, modules: modules} = state, line) do
-    case added_module_from_line(line) do
-      nil -> state
-      module -> %{state | modules: [{module, line_number} | modules]}
-    end
+    line_modules =
+      line
+      |> added_modules_from_line()
+      |> Enum.map(&{&1, line_number})
+
+    %{state | modules: line_modules ++ modules}
   end
 
   defp github_file_lines(owner, repo, filename, ref, github_client) do
@@ -736,32 +738,55 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   defp coverage_ignore_line_ranges(lines) do
     lines
     |> Enum.with_index(1)
-    |> Enum.reduce(%{test_coverage_depth: 0, ignore_start: nil, ranges: []}, &coverage_ignore_line_range/2)
+    |> Enum.reduce(
+      %{test_coverage_depth: 0, ignore_start: nil, ignore_depth: 0, ranges: []},
+      &coverage_ignore_line_range/2
+    )
     |> Map.fetch!(:ranges)
     |> Enum.reverse()
   end
 
   defp coverage_ignore_line_range({line, line_number}, state) do
-    state =
-      if state.test_coverage_depth > 0 and state.ignore_start == nil and opens_ignore_modules?(line) do
-        %{state | ignore_start: line_number}
-      else
-        state
-      end
-
+    state = maybe_open_coverage_ignore_range(state, line, line_number)
+    state = track_coverage_ignore_depth(state, line, line_number)
     state = track_test_coverage_depth(state, line)
 
-    cond do
-      state.ignore_start != nil and closes_list?(line) ->
-        %{state | ignore_start: nil, ranges: [{state.ignore_start, line_number} | state.ranges]}
-
-      state.test_coverage_depth == 0 ->
-        %{state | ignore_start: nil}
-
-      true ->
-        state
+    if state.test_coverage_depth == 0 and state.ignore_start != nil do
+      %{state | ignore_start: nil, ignore_depth: 0}
+    else
+      state
     end
   end
+
+  defp maybe_open_coverage_ignore_range(%{ignore_start: nil} = state, line, line_number) do
+    if in_test_coverage?(state, line) and opens_ignore_modules?(line) do
+      %{state | ignore_start: line_number, ignore_depth: ignore_modules_bracket_delta(line)}
+    else
+      state
+    end
+  end
+
+  defp maybe_open_coverage_ignore_range(state, _line, _line_number), do: state
+
+  defp track_coverage_ignore_depth(%{ignore_start: nil} = state, _line, _line_number), do: state
+
+  defp track_coverage_ignore_depth(state, line, line_number) do
+    ignore_depth =
+      if state.ignore_start == line_number do
+        state.ignore_depth
+      else
+        state.ignore_depth + bracket_delta(line)
+      end
+
+    if ignore_depth <= 0 do
+      %{state | ignore_start: nil, ignore_depth: 0, ranges: [{state.ignore_start, line_number} | state.ranges]}
+    else
+      %{state | ignore_depth: ignore_depth}
+    end
+  end
+
+  defp in_test_coverage?(%{test_coverage_depth: depth}, _line) when depth > 0, do: true
+  defp in_test_coverage?(_state, line), do: String.match?(line, ~r/\btest_coverage:\s*\[/)
 
   defp track_test_coverage_depth(state, line) do
     depth =
@@ -793,19 +818,25 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     |> String.match?(~r/\bignore_modules:\s*\[/)
   end
 
-  defp closes_list?(line) do
-    patch_line_content(line)
-    |> String.match?(~r/^\s*\]/)
+  defp added_modules_from_line("+" <> rest) do
+    rest
+    |> String.split("#", parts: 2)
+    |> hd()
+    |> then(&Regex.scan(~r/\b([A-Z][A-Za-z0-9_]*(?:\.[A-Z][A-Za-z0-9_]*)*)\b/, &1))
+    |> Enum.map(fn [_, module] -> module end)
   end
 
-  defp added_module_from_line("+" <> rest) do
-    case Regex.run(~r/^\s*([A-Z][A-Za-z0-9_.]*)\s*,?\s*(?:#.*)?$/, rest) do
-      [_, module] -> module
-      _ -> nil
+  defp added_modules_from_line(_line), do: []
+
+  defp ignore_modules_bracket_delta(line) do
+    line
+    |> patch_line_content()
+    |> String.split(~r/\bignore_modules:\s*/, parts: 2)
+    |> case do
+      [_before, ignore_modules] -> bracket_delta(ignore_modules)
+      _ -> 0
     end
   end
-
-  defp added_module_from_line(_line), do: nil
 
   defp patch_line_content("+" <> rest), do: rest
   defp patch_line_content("-" <> rest), do: rest

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -562,6 +562,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   defp normalize_module_name(module) do
     module
     |> String.trim()
+    |> String.trim_leading("Elixir.")
     |> String.downcase()
   end
 
@@ -862,18 +863,26 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
 
   defp stale_base_overlap(%{"ahead_by" => ahead_by, "files" => base_files}, pr_files)
        when is_integer(ahead_by) and ahead_by > 0 and is_list(base_files) do
-    pr_filenames = changed_filenames(pr_files)
-    base_filenames = changed_filenames(base_files)
-    overlap = MapSet.intersection(pr_filenames, base_filenames)
+    with :ok <- stale_base_file_list_fetchable?(base_files) do
+      pr_filenames = changed_filenames(pr_files)
+      base_filenames = changed_filenames(base_files)
+      overlap = MapSet.intersection(pr_filenames, base_filenames)
 
-    if MapSet.size(overlap) == 0 do
-      :ok
-    else
-      {:error, {:review_readiness_stale_base_overlap, Enum.sort(overlap)}}
+      if MapSet.size(overlap) == 0 do
+        :ok
+      else
+        {:error, {:review_readiness_stale_base_overlap, Enum.sort(overlap)}}
+      end
     end
   end
 
   defp stale_base_overlap(_comparison, _pr_files), do: :ok
+
+  defp stale_base_file_list_fetchable?(base_files) when length(base_files) >= 300 do
+    {:error, {:review_readiness_stale_base_file_list_too_large, length(base_files)}}
+  end
+
+  defp stale_base_file_list_fetchable?(_base_files), do: :ok
 
   defp changed_filenames(files) do
     Enum.reduce(files, MapSet.new(), fn file, acc ->
@@ -1197,6 +1206,10 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
 
   defp rejection_message({:review_readiness_stale_base_overlap, filenames}),
     do: "the PR base is stale and current base branch changes overlap PR files: #{Enum.join(filenames, ", ")}. Merge current base, resolve the overlap, and rerun validation."
+
+  defp rejection_message({:review_readiness_stale_base_file_list_too_large, changed_files}),
+    do:
+      "the PR base is stale and current base branch compare returns #{changed_files} files; review readiness cannot verify stale-base overlap from a capped GitHub compare file list. Merge current base and rerun validation."
 
   defp format_failures(failures) do
     Enum.map_join(failures, ", ", fn

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -354,6 +354,142 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     refute_received {:workpad_recorded, _}
   end
 
+  test "linear_graphql rejects coverage ignore additions for modules changed in the PR" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main", "sha" => "base123"}},
+            "pulls/42/files?per_page=100" => [
+              %{
+                "filename" => "elixir/lib/symphony_elixir/codex/review_readiness.ex",
+                "status" => "modified",
+                "patch" => "@@ -550,6 +550,7 @@\n+  def changed, do: :ok"
+              },
+              %{
+                "filename" => "elixir/mix.exs",
+                "status" => "modified",
+                "patch" => "+          SymphonyElixir.Codex.ReviewReadiness,"
+              }
+            ],
+            "compare/base123...main" => %{"ahead_by" => 0, "files" => []},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{
+              "check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]
+            }
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "coverage ignore additions include modules changed in this PR"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "SymphonyElixir.Codex.ReviewReadiness"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql matches coverage ignore additions for acronym modules without defmodule patch context" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "pulls/42/files?per_page=100" => [
+              %{
+                "filename" => "elixir/lib/symphony_elixir/cli.ex",
+                "status" => "modified",
+                "patch" => "@@ -90,6 +90,7 @@\n+  def changed, do: :ok"
+              },
+              %{
+                "filename" => "elixir/mix.exs",
+                "status" => "modified",
+                "patch" => "+          SymphonyElixir.CLI,"
+              }
+            ],
+            "compare/base123...main" => %{"ahead_by" => 0, "files" => []},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{
+              "check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]
+            }
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "SymphonyElixir.CLI"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "SymphonyElixir.CLI"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql rejects stale PR bases when current base changes overlap PR files" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main", "sha" => "base123"}},
+            "pulls/42/files?per_page=100" => [
+              %{"filename" => "lib/symphony_elixir/codex/app_server.ex", "status" => "modified", "patch" => ""}
+            ],
+            "compare/base123...main" => %{
+              "ahead_by" => 1,
+              "files" => [%{"filename" => "lib/symphony_elixir/codex/app_server.ex", "status" => "modified"}]
+            },
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{
+              "check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]
+            }
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "PR base is stale"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "lib/symphony_elixir/codex/app_server.ex"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql rejects oversized PR file lists instead of partially checking guardrails" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{
+              "changed_files" => 101,
+              "head" => %{"sha" => "abc123"},
+              "base" => %{"ref" => "main", "sha" => "base123"}
+            }
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "only verifies the first 100 GitHub PR files"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "changes 101 files"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
   test "linear_graphql uses configured required checks when branch protection is unavailable" do
     test_pid = self()
     write_workflow_file!(Workflow.workflow_file_path(), codex_review_readiness_required_checks: ["make-all"])
@@ -1033,7 +1169,7 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     fn url, _opts ->
       case github_response(responses, url) do
         {_suffix, payload} -> {:ok, %{status: 200, body: default_pr_payload(url, payload)}}
-        nil -> {:ok, %{status: 404, body: %{"message" => "not found"}}}
+        nil -> default_github_response(url)
       end
     end
   end
@@ -1045,13 +1181,37 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
         |> Map.put_new("ref", "codex/ALB-19-review-readiness")
         |> Map.put_new("repo", %{"full_name" => "albert-zen/symphony-windows-native"})
 
-      put_in(payload, ["head"], default_head)
+      default_base =
+        payload
+        |> Map.get("base", %{})
+        |> Map.put_new("ref", "main")
+        |> Map.put_new("sha", "base123")
+
+      payload
+      |> put_in(["head"], default_head)
+      |> put_in(["base"], default_base)
     else
       payload
     end
   end
 
   defp default_pr_payload(_url, payload), do: payload
+
+  defp default_github_response(url) do
+    cond do
+      String.ends_with?(url, "/files?per_page=100") ->
+        {:ok, %{status: 200, body: []}}
+
+      Regex.match?(~r/\/compare\/[^\/]+\.{3}abc123$/, url) ->
+        {:ok, %{status: 200, body: %{"merge_base_commit" => %{"sha" => "base123"}, "files" => []}}}
+
+      String.contains?(url, "/compare/") ->
+        {:ok, %{status: 200, body: %{"ahead_by" => 0, "files" => []}}}
+
+      true ->
+        {:ok, %{status: 404, body: %{"message" => "not found"}}}
+    end
+  end
 
   defp github_response(responses, url) do
     Enum.find(responses, fn {suffix, _payload} -> String.ends_with?(url, suffix) end)

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -586,6 +586,96 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     refute_received {:linear_mutation_allowed, _, _}
   end
 
+  test "linear_graphql rejects inline coverage ignore additions" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "pulls/42/files?per_page=100" => [
+              %{
+                "filename" => "elixir/lib/symphony_elixir/codex/review_readiness.ex",
+                "status" => "modified",
+                "patch" => "@@ -22,6 +22,7 @@\n+  def hardened?, do: true"
+              },
+              %{
+                "filename" => "elixir/mix.exs",
+                "status" => "modified",
+                "patch" => """
+                @@ -1,1 +1,1 @@
+                +test_coverage: [
+                +  ignore_modules: [SymphonyElixir.Codex.ReviewReadiness]
+                +]
+                """
+              }
+            ],
+            "contents/elixir/mix.exs?ref=abc123" =>
+              github_content("""
+              test_coverage: [
+                ignore_modules: [SymphonyElixir.Codex.ReviewReadiness]
+              ]
+              """),
+            "compare/base123...main" => %{"ahead_by" => 0, "files" => []},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{
+              "check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]
+            }
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "SymphonyElixir.Codex.ReviewReadiness"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "SymphonyElixir.Codex.ReviewReadiness"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql rejects one-line test coverage ignore additions" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "pulls/42/files?per_page=100" => [
+              %{
+                "filename" => "elixir/lib/symphony_elixir/codex/review_readiness.ex",
+                "status" => "modified",
+                "patch" => "@@ -22,6 +22,7 @@\n+  def hardened?, do: true"
+              },
+              %{
+                "filename" => "elixir/mix.exs",
+                "status" => "modified",
+                "patch" => "@@ -1,1 +1,1 @@\n+test_coverage: [ignore_modules: [SymphonyElixir.Codex.ReviewReadiness]]"
+              }
+            ],
+            "contents/elixir/mix.exs?ref=abc123" => github_content("test_coverage: [ignore_modules: [SymphonyElixir.Codex.ReviewReadiness]]"),
+            "compare/base123...main" => %{"ahead_by" => 0, "files" => []},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{
+              "check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]
+            }
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "SymphonyElixir.Codex.ReviewReadiness"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "SymphonyElixir.Codex.ReviewReadiness"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
   test "linear_graphql ignores unrelated mix ignore_modules additions outside test coverage" do
     test_pid = self()
 

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -586,6 +586,53 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     refute_received {:linear_mutation_allowed, _, _}
   end
 
+  test "linear_graphql rejects quoted Elixir module atoms in coverage ignore additions" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "pulls/42/files?per_page=100" => [
+              %{
+                "filename" => "elixir/lib/symphony_elixir/codex/review_readiness.ex",
+                "status" => "modified",
+                "patch" => "@@ -22,6 +22,7 @@\n+  def hardened?, do: true"
+              },
+              %{
+                "filename" => "elixir/mix.exs",
+                "status" => "modified",
+                "patch" => """
+                @@ -14,6 +14,7 @@
+                 test_coverage: [
+                   ignore_modules: [
+                     SymphonyElixir.Codex.AppServer,
+                +    :"Elixir.SymphonyElixir.Codex.ReviewReadiness",
+                     SymphonyElixir.Codex.DynamicTool
+                   ]
+                """
+              }
+            ],
+            "compare/base123...main" => %{"ahead_by" => 0, "files" => []},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{
+              "check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]
+            }
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "Elixir.SymphonyElixir.Codex.ReviewReadiness"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "Elixir.SymphonyElixir.Codex.ReviewReadiness"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
   test "linear_graphql rejects inline coverage ignore additions" do
     test_pid = self()
 
@@ -750,6 +797,42 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     assert Jason.decode!(response["output"])["error"]["message"] =~ "PR base is stale"
     assert_received {:workpad_recorded, body}
     assert body =~ "lib/symphony_elixir/codex/app_server.ex"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql rejects stale PR bases when base compare file list may be capped" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main", "sha" => "base123"}},
+            "pulls/42/files?per_page=100" => [
+              %{"filename" => "lib/symphony_elixir/codex/app_server.ex", "status" => "modified", "patch" => ""}
+            ],
+            "compare/base123...main" => %{
+              "ahead_by" => 12,
+              "files" =>
+                Enum.map(1..300, fn index ->
+                  %{"filename" => "lib/current_main/file_#{index}.ex", "status" => "modified"}
+                end)
+            },
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{
+              "check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]
+            }
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "capped GitHub compare file list"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "current base branch compare returns 300 files"
     refute_received {:linear_mutation_allowed, _, _}
   end
 

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -374,7 +374,15 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
               %{
                 "filename" => "elixir/mix.exs",
                 "status" => "modified",
-                "patch" => "+          SymphonyElixir.Codex.ReviewReadiness,"
+                "patch" => """
+                @@ -14,6 +14,7 @@
+                 test_coverage: [
+                   ignore_modules: [
+                     SymphonyElixir.Codex.AppServer,
+                +    SymphonyElixir.Codex.ReviewReadiness,
+                     SymphonyElixir.Codex.DynamicTool
+                   ]
+                """
               }
             ],
             "compare/base123...main" => %{"ahead_by" => 0, "files" => []},
@@ -413,7 +421,15 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
               %{
                 "filename" => "elixir/mix.exs",
                 "status" => "modified",
-                "patch" => "+          SymphonyElixir.CLI,"
+                "patch" => """
+                @@ -14,6 +14,7 @@
+                 test_coverage: [
+                   ignore_modules: [
+                     SymphonyElixir.Codex.AppServer,
+                +    SymphonyElixir.CLI,
+                     SymphonyElixir.Codex.DynamicTool
+                   ]
+                """
               }
             ],
             "compare/base123...main" => %{"ahead_by" => 0, "files" => []},
@@ -430,6 +446,188 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     assert_received {:workpad_recorded, body}
     assert body =~ "SymphonyElixir.CLI"
     refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql rejects coverage ignore additions for nested modules changed in the same source file" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "pulls/42/files?per_page=100" => [
+              %{
+                "filename" => "elixir/lib/symphony_elixir/codex/review_readiness.ex",
+                "status" => "modified",
+                "patch" => "@@ -22,6 +22,7 @@\n+  def hardened?, do: true"
+              },
+              %{
+                "filename" => "elixir/mix.exs",
+                "status" => "modified",
+                "patch" => """
+                @@ -14,6 +14,7 @@
+                 test_coverage: [
+                   ignore_modules: [
+                     SymphonyElixir.Codex.AppServer,
+                +    SymphonyElixir.Codex.ReviewReadiness.Nested,
+                     SymphonyElixir.Codex.DynamicTool
+                   ]
+                """
+              }
+            ],
+            "compare/base123...main" => %{"ahead_by" => 0, "files" => []},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{
+              "check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]
+            }
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "SymphonyElixir.Codex.ReviewReadiness.Nested"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "SymphonyElixir.Codex.ReviewReadiness.Nested"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql rejects coverage ignore additions when hunk omits test coverage context" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "pulls/42/files?per_page=100" => [
+              %{
+                "filename" => "elixir/lib/symphony_elixir/codex/review_readiness.ex",
+                "status" => "modified",
+                "patch" => "@@ -22,6 +22,7 @@\n+  def hardened?, do: true"
+              },
+              %{
+                "filename" => "elixir/mix.exs",
+                "status" => "modified",
+                "patch" => """
+                @@ -16,2 +16,3 @@
+                     SymphonyElixir.Codex.AppServer,
+                +    SymphonyElixir.Codex.ReviewReadiness,
+                     SymphonyElixir.Codex.DynamicTool
+                """
+              }
+            ],
+            "compare/base123...main" => %{"ahead_by" => 0, "files" => []},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{
+              "check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]
+            }
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "SymphonyElixir.Codex.ReviewReadiness"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "SymphonyElixir.Codex.ReviewReadiness"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql rejects coverage ignore additions with trailing inline comments" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "pulls/42/files?per_page=100" => [
+              %{
+                "filename" => "elixir/lib/symphony_elixir/codex/review_readiness.ex",
+                "status" => "modified",
+                "patch" => "@@ -22,6 +22,7 @@\n+  def hardened?, do: true"
+              },
+              %{
+                "filename" => "elixir/mix.exs",
+                "status" => "modified",
+                "patch" => """
+                @@ -14,6 +14,7 @@
+                 test_coverage: [
+                   ignore_modules: [
+                     SymphonyElixir.Codex.AppServer,
+                +    SymphonyElixir.Codex.ReviewReadiness, # audited later
+                     SymphonyElixir.Codex.DynamicTool
+                   ]
+                """
+              }
+            ],
+            "compare/base123...main" => %{"ahead_by" => 0, "files" => []},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{
+              "check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]
+            }
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "SymphonyElixir.Codex.ReviewReadiness"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "SymphonyElixir.Codex.ReviewReadiness"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql ignores unrelated mix ignore_modules additions outside test coverage" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+            "pulls/42/files?per_page=100" => [
+              %{
+                "filename" => "elixir/lib/symphony_elixir/codex/review_readiness.ex",
+                "status" => "modified",
+                "patch" => "@@ -22,6 +22,7 @@\n+  def hardened?, do: true"
+              },
+              %{
+                "filename" => "elixir/mix.exs",
+                "status" => "modified",
+                "patch" => """
+                @@ -80,6 +80,7 @@
+                 custom_lint: [
+                   ignore_modules: [
+                +    SymphonyElixir.Codex.ReviewReadiness,
+                     Some.Other.Module
+                   ]
+                """
+              }
+            ],
+            "compare/base123...main" => %{"ahead_by" => 0, "files" => []},
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{
+              "check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]
+            }
+          })
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
+    refute_received {:workpad_recorded, _}
   end
 
   test "linear_graphql rejects stale PR bases when current base changes overlap PR files" do
@@ -1202,6 +1400,9 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
       String.ends_with?(url, "/files?per_page=100") ->
         {:ok, %{status: 200, body: []}}
 
+      String.contains?(url, "/contents/elixir/mix.exs?") or String.contains?(url, "/contents/mix.exs?") ->
+        {:ok, %{status: 200, body: github_content(mix_exs_head_content())}}
+
       Regex.match?(~r/\/compare\/[^\/]+\.{3}abc123$/, url) ->
         {:ok, %{status: 200, body: %{"merge_base_commit" => %{"sha" => "base123"}, "files" => []}}}
 
@@ -1211,6 +1412,44 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
       true ->
         {:ok, %{status: 404, body: %{"message" => "not found"}}}
     end
+  end
+
+  defp github_content(content) do
+    %{"encoding" => "base64", "content" => Base.encode64(content)}
+  end
+
+  defp mix_exs_head_content do
+    """
+    defmodule SymphonyElixir.MixProject do
+      use Mix.Project
+
+      def project do
+        [
+          app: :symphony_elixir,
+          version: "0.1.0",
+          elixir: "~> 1.19",
+          test_coverage: [
+            summary: [
+              threshold: 100
+            ],
+            ignore_modules: [
+              SymphonyElixir.Codex.AppServer,
+              SymphonyElixir.Codex.ReviewReadiness,
+              SymphonyElixir.Codex.ReviewReadiness.Nested,
+              SymphonyElixir.Codex.DynamicTool,
+              SymphonyElixir.CLI
+            ]
+          ],
+          custom_lint: [
+            ignore_modules: [
+              SymphonyElixir.Codex.ReviewReadiness,
+              Some.Other.Module
+            ]
+          ]
+        ]
+      end
+    end
+    """
   end
 
   defp github_response(responses, url) do


### PR DESCRIPTION
#### Context

ALB-26 / GH #35 exposed two review gate risks: coverage-ignore bypasses and stale-base regressions.

#### TL;DR

Harden Linear review readiness so risky PRs are rejected before agent handoff.

#### Summary

- Reject changed production modules added to `test_coverage.ignore_modules`.
- Normalize `Elixir.`-prefixed quoted module atom ignore entries so they cannot bypass changed-module matching.
- Detect stale PR bases when current base changes overlap files touched by the PR.
- Fail closed on PRs over 100 changed files so pagination cannot hide risky PR changes.
- Fail closed when a stale-base compare reaches GitHub's 300-file compare cap, because overlap can no longer be trusted.
- Resolve coverage-ignore edge cases for nested modules, trailing inline comments, long `ignore_modules` hunks where GitHub omits `test_coverage` context, and inline `ignore_modules: [...]` forms.
- Document gate-weakening, stale-base, deleted-test, and handler-removal review checks.
- Merged current `origin/main` (`5c3a472`) and preserved ALB-27 Windows preflight plus ALB-8 Windows shebang behavior.

#### Alternatives

- Only document reviewer duties; rejected because ALB-26 needs mechanical readiness gates.
- Use PR `base.sha` for stale checks; rejected because GitHub reports current base there.
- Trust patch context alone for `test_coverage.ignore_modules`; rejected because long lists and inline forms can omit the context needed to classify the addition safely.
- Trust GitHub compare file lists at their cap; rejected because stale-base overlap outside the returned list would be missed.

#### Test Plan

- [x] `mix test test/symphony_elixir/dynamic_tool_test.exs` -> 52 tests, 0 failures on head `937cd9d`.
- [x] `mix format --check-formatted lib/symphony_elixir/codex/review_readiness.ex test/symphony_elixir/dynamic_tool_test.exs` -> passed on head `937cd9d`.
- [x] `git diff --check origin/main...HEAD` -> passed on head `937cd9d`.
- [x] `elixir/make.cmd windows-native-test` -> 104 tests, 0 failures, 14 skipped on head `937cd9d`.
- [x] `mix test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs test/symphony_elixir/windows_lifecycle_scripts_test.exs` -> 63 tests, 0 failures, 2 skipped on head `eac55e6` after merging current main.
- [x] `MIX_OS_CONCURRENCY_LOCK=0 mix lint` -> exit 0 on head `937cd9d`; reports known repo-wide Windows line-ending consistency warnings only.
- [x] `mix dialyzer --format short` -> passed on head `937cd9d`.
- [x] Independent SubAgent review after latest blocker fixes -> no blocking findings; reviewer reran `mix test test/symphony_elixir/dynamic_tool_test.exs` with 52 tests, 0 failures, and touched-file format check passed.
- [x] GitHub `make-all` -> passed on head `937cd9d`.
- [x] GitHub `windows-native-test` -> passed on head `937cd9d`.
- [x] GitHub `validate-pr-description` -> passed on head `937cd9d`.

Local note: repo-wide `elixir/make.cmd all` is blocked by unrelated pre-existing format/line-ending drift beginning at `elixir/lib/symphony_elixir/status_dashboard.ex`; focused touched-file format check and GitHub `make-all` passed.