### PR TITLE
fix(windows): warn on stale noncanonical main tracking

### DIFF
--- a/elixir/WORKFLOW.optimization.windows.example.md
+++ b/elixir/WORKFLOW.optimization.windows.example.md
@@ -23,6 +23,8 @@ hooks:
   after_create: |
     $ErrorActionPreference = "Stop"
     git clone --depth 1 https://github.com/albert-zen/symphony-windows-native.git .
+    git remote set-url origin https://github.com/albert-zen/symphony-windows-native.git
+    git fetch origin main
     git config user.email "codex-symphony@example.invalid"
     git config user.name "Codex Symphony"
     Set-Location elixir
@@ -103,6 +105,9 @@ Operating model:
 Quality bar:
 
 - Prefer small, reviewable changes.
+- Treat `origin/main` in `albert-zen/symphony-windows-native` as the canonical
+  GitHub base ref for manager-side stale-base checks unless the workflow
+  explicitly configures another trusted remote.
 - Run `mix format` for touched Elixir files.
 - Follow `docs/agent-quality-flywheel.md` for PR quality gates, review loop rules, and defect
   protocol.

--- a/elixir/docs/windows-native.md
+++ b/elixir/docs/windows-native.md
@@ -185,8 +185,9 @@ not fail preflight. It verifies:
 - `LINEAR_API_KEY` is available and Linear GraphQL is reachable.
 - `git`, `gh`, `node`, and the configured Codex app-server command resolve on `PATH`.
 - `gh auth status` succeeds for GitHub operations.
-- The local checkout's `main` branch does not hide a newer `origin/main` behind
-  a stale noncanonical upstream such as `windows/main`.
+- After refreshing `origin/main`, the local checkout's `main` branch does not
+  hide a newer canonical base behind a stale noncanonical upstream such as
+  `windows/main`.
 - `codex app-server` can start without non-JSON startup output on stdio.
 - The repository URL in `hooks.after_create` can be cloned by Git.
 - `workspace.root` is writable.

--- a/elixir/docs/windows-native.md
+++ b/elixir/docs/windows-native.md
@@ -76,6 +76,13 @@ Symphony:
 gh auth login
 ```
 
+For the open-source Windows-native distribution, treat
+`https://github.com/albert-zen/symphony-windows-native.git` as the canonical
+repository and `origin/main` as the canonical base ref unless your workflow
+explicitly configures another trusted remote. Manager-side stale-base checks
+should compare PR branches to `origin/main` directly instead of assuming the
+local `main` branch tracks the canonical remote.
+
 ## Configure a workflow
 
 Start from the profile that matches the trust boundary for the run:
@@ -171,12 +178,15 @@ Before starting an unattended run, execute the Windows preflight from `elixir/`:
 mise exec -- mix symphony.preflight.windows .\WORKFLOW.windows.md
 ```
 
-The command reports `PASS`, `FAIL`, or `SKIP` for each dependency and exits
-non-zero when a required check fails. It verifies:
+The command reports `PASS`, `WARN`, `FAIL`, or `SKIP` for each dependency and
+exits non-zero when a required check fails. Warnings are operator-visible but do
+not fail preflight. It verifies:
 
 - `LINEAR_API_KEY` is available and Linear GraphQL is reachable.
 - `git`, `gh`, `node`, and the configured Codex app-server command resolve on `PATH`.
 - `gh auth status` succeeds for GitHub operations.
+- The local checkout's `main` branch does not hide a newer `origin/main` behind
+  a stale noncanonical upstream such as `windows/main`.
 - `codex app-server` can start without non-JSON startup output on stdio.
 - The repository URL in `hooks.after_create` can be cloned by Git.
 - `workspace.root` is writable.
@@ -187,6 +197,18 @@ If preflight reports the workspace root as writable but Codex later prints a
 project trust warning for `.codex`, trust the configured `workspace.root` used
 for Symphony issue workspaces. The workspace root should be a dedicated
 automation directory, not your everyday development checkout.
+
+If preflight prints `WARN` for `Git main remote`, update the manager checkout
+or make stale-base checks explicit:
+
+```powershell
+git fetch origin main
+git branch --set-upstream-to=origin/main main
+git status --short --branch
+```
+
+When intentionally using a fork or mirror, keep the workflow and manager runbook
+explicit about that remote and compare against its fully qualified remote ref.
 
 ### Optimization flywheel routing
 

--- a/elixir/lib/symphony_elixir/windows_preflight.ex
+++ b/elixir/lib/symphony_elixir/windows_preflight.ex
@@ -238,6 +238,7 @@ defmodule SymphonyElixir.WindowsPreflight do
     local_shell_run = Map.get(deps, :local_shell_run, &LocalShell.run/2)
 
     with {:ok, repo_root} <- git_output(local_shell_run, "git rev-parse --show-toplevel", File.cwd!()),
+         {:ok, _fetch_output} <- git_output(local_shell_run, "git -C #{shell_quote(repo_root)} fetch origin main", repo_root),
          {:ok, main_sha} <- git_output(local_shell_run, "git -C #{shell_quote(repo_root)} rev-parse --verify main", repo_root),
          {:ok, origin_main_sha} <-
            git_output(local_shell_run, "git -C #{shell_quote(repo_root)} rev-parse --verify origin/main", repo_root),

--- a/elixir/lib/symphony_elixir/windows_preflight.ex
+++ b/elixir/lib/symphony_elixir/windows_preflight.ex
@@ -10,7 +10,7 @@ defmodule SymphonyElixir.WindowsPreflight do
     defstruct [:name, :status, :message, :remediation]
   end
 
-  @type check_status :: :pass | :fail | :skip
+  @type check_status :: :pass | :fail | :skip | :warn
   @type check :: %Check{
           name: String.t(),
           status: check_status(),
@@ -51,6 +51,7 @@ defmodule SymphonyElixir.WindowsPreflight do
             linear_check(settings, deps),
             path_tools_check(settings, deps),
             github_cli_check(deps),
+            git_main_tracking_check(deps),
             codex_app_server_check(settings, deps),
             workspace_root_check(settings),
             git_clone_check(settings, deps),
@@ -230,6 +231,73 @@ defmodule SymphonyElixir.WindowsPreflight do
           "Could not run gh auth status: #{inspect(reason)}",
           "Install GitHub CLI and make sure gh.exe is on PATH."
         )
+    end
+  end
+
+  defp git_main_tracking_check(deps) do
+    local_shell_run = Map.get(deps, :local_shell_run, &LocalShell.run/2)
+
+    with {:ok, repo_root} <- git_output(local_shell_run, "git rev-parse --show-toplevel", File.cwd!()),
+         {:ok, main_sha} <- git_output(local_shell_run, "git -C #{shell_quote(repo_root)} rev-parse --verify main", repo_root),
+         {:ok, origin_main_sha} <-
+           git_output(local_shell_run, "git -C #{shell_quote(repo_root)} rev-parse --verify origin/main", repo_root),
+         {:ok, upstream} <-
+           git_output(local_shell_run, "git -C #{shell_quote(repo_root)} rev-parse --abbrev-ref main@{upstream}", repo_root) do
+      cond do
+        upstream == "origin/main" ->
+          pass("Git main remote", "Local main tracks canonical origin/main.")
+
+        main_sha != origin_main_sha and git_ancestor?(local_shell_run, repo_root, "main", "origin/main") ->
+          warn(
+            "Git main remote",
+            "Local main tracks #{upstream}, but canonical origin/main is newer.",
+            "Run manager-side stale-base checks against origin/main or reconfigure local main with `git branch --set-upstream-to=origin/main main`."
+          )
+
+        true ->
+          pass(
+            "Git main remote",
+            "Canonical GitHub ref is origin/main; local main currently tracks #{upstream}."
+          )
+      end
+    else
+      {:missing_ref, ref} ->
+        skip("Git main remote", "Could not inspect #{ref}; run preflight from a checkout with local main and origin/main.")
+
+      {:error, reason} ->
+        skip("Git main remote", "Could not inspect local main tracking: #{inspect(reason)}.")
+    end
+  end
+
+  defp git_output(local_shell_run, command, cwd) do
+    case local_shell_run.(command, cd: cwd) do
+      {:ok, {output, 0}} ->
+        {:ok, String.trim(output)}
+
+      {:ok, {output, status}} ->
+        cond do
+          String.contains?(command, "rev-parse --verify main") ->
+            {:missing_ref, "main"}
+
+          String.contains?(command, "rev-parse --verify origin/main") ->
+            {:missing_ref, "origin/main"}
+
+          true ->
+            {:error, {command, status, sanitize_command_output(output)}}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp git_ancestor?(local_shell_run, repo_root, ancestor, descendant) do
+    command = "git -C #{shell_quote(repo_root)} merge-base --is-ancestor #{ancestor} #{descendant}"
+
+    case local_shell_run.(command, cd: repo_root) do
+      {:ok, {_output, 0}} -> true
+      {:ok, {_output, _status}} -> false
+      {:error, _reason} -> false
     end
   end
 
@@ -427,6 +495,7 @@ defmodule SymphonyElixir.WindowsPreflight do
 
   defp pass(name, message), do: %Check{name: name, status: :pass, message: message}
   defp skip(name, message), do: %Check{name: name, status: :skip, message: message}
+  defp warn(name, message, remediation), do: %Check{name: name, status: :warn, message: message, remediation: remediation}
 
   defp fail(name, message, remediation) do
     %Check{name: name, status: :fail, message: message, remediation: remediation}
@@ -435,4 +504,5 @@ defmodule SymphonyElixir.WindowsPreflight do
   defp status_label(:pass), do: "PASS"
   defp status_label(:fail), do: "FAIL"
   defp status_label(:skip), do: "SKIP"
+  defp status_label(:warn), do: "WARN"
 end

--- a/elixir/test/symphony_elixir/windows_preflight_test.exs
+++ b/elixir/test/symphony_elixir/windows_preflight_test.exs
@@ -15,6 +15,9 @@ defmodule SymphonyElixir.WindowsPreflightTest do
       local_shell_run: fn
         hook_probe, _opts when is_binary(hook_probe) ->
           cond do
+            git_main_tracking_command?(hook_probe) ->
+              ready_git_main_tracking_response(hook_probe)
+
             String.contains?(hook_probe, "[scriptblock]::Create") ->
               {:ok, {"hook after_create parsed\n7.5.0\n", 0}}
 
@@ -60,10 +63,20 @@ defmodule SymphonyElixir.WindowsPreflightTest do
       local_shell_run: fn
         hook_probe, _opts when is_binary(hook_probe) ->
           cond do
-            String.contains?(hook_probe, "[scriptblock]::Create") -> {:ok, {"blocked", 1}}
-            String.starts_with?(hook_probe, "git clone --depth 1") -> {:ok, {"denied", 128}}
-            hook_probe == "gh auth status" -> {:ok, {"not logged in", 1}}
-            true -> flunk("unexpected command: #{hook_probe}")
+            git_main_tracking_command?(hook_probe) ->
+              ready_git_main_tracking_response(hook_probe)
+
+            String.contains?(hook_probe, "[scriptblock]::Create") ->
+              {:ok, {"blocked", 1}}
+
+            String.starts_with?(hook_probe, "git clone --depth 1") ->
+              {:ok, {"denied", 128}}
+
+            hook_probe == "gh auth status" ->
+              {:ok, {"not logged in", 1}}
+
+            true ->
+              flunk("unexpected command: #{hook_probe}")
           end
       end,
       port_available?: fn 4011 -> false end,
@@ -92,6 +105,9 @@ defmodule SymphonyElixir.WindowsPreflightTest do
       local_shell_run: fn
         hook_probe, _opts when is_binary(hook_probe) ->
           cond do
+            git_main_tracking_command?(hook_probe) ->
+              ready_git_main_tracking_response(hook_probe)
+
             String.contains?(hook_probe, "[scriptblock]::Create") ->
               {:ok, {"hook after_create parsed\n7.5.0\n", 0}}
 
@@ -130,6 +146,9 @@ defmodule SymphonyElixir.WindowsPreflightTest do
         local_shell_run: fn
           command, _opts when is_binary(command) ->
             cond do
+              git_main_tracking_command?(command) ->
+                ready_git_main_tracking_response(command)
+
               String.contains?(command, "[scriptblock]::Create") ->
                 {:ok, {"hook after_create parsed\n7.5.0\n", 0}}
 
@@ -166,6 +185,9 @@ defmodule SymphonyElixir.WindowsPreflightTest do
         local_shell_run: fn
           command, _opts when is_binary(command) ->
             cond do
+              git_main_tracking_command?(command) ->
+                ready_git_main_tracking_response(command)
+
               String.contains?(command, "[scriptblock]::Create") ->
                 {:ok, {"At line:1 char:1 git clone https://token:secret@github.com/albert-zen/symphony-windows-native.git", 1}}
 
@@ -210,6 +232,9 @@ defmodule SymphonyElixir.WindowsPreflightTest do
         local_shell_run: fn
           command, _opts when is_binary(command) ->
             cond do
+              git_main_tracking_command?(command) ->
+                ready_git_main_tracking_response(command)
+
               String.contains?(command, "[scriptblock]::Create") ->
                 {:ok, {"hook after_create parsed\n7.5.0\n", 0}}
 
@@ -229,6 +254,55 @@ defmodule SymphonyElixir.WindowsPreflightTest do
     assert {:ok, checks} = WindowsPreflight.run(workflow_path, deps)
     assert %WindowsPreflight.Check{status: :pass} = Enum.find(checks, &(&1.name == "Workspace root"))
     assert %WindowsPreflight.Check{status: :pass} = Enum.find(checks, &(&1.name == "Git repository"))
+  end
+
+  test "warns when local main tracks a noncanonical stale remote while origin main is newer" do
+    workflow_path = workflow_with_preflight_config()
+
+    deps =
+      ready_deps(%{
+        local_shell_run: fn
+          command, _opts when is_binary(command) ->
+            cond do
+              command == "git rev-parse --show-toplevel" ->
+                {:ok, {"C:/repo/symphony-windows-native\n", 0}}
+
+              String.contains?(command, "rev-parse --verify main") ->
+                {:ok, {"local-main-sha\n", 0}}
+
+              String.contains?(command, "rev-parse --verify origin/main") ->
+                {:ok, {"origin-main-sha\n", 0}}
+
+              String.contains?(command, "rev-parse --abbrev-ref main@{upstream}") ->
+                {:ok, {"windows/main\n", 0}}
+
+              String.contains?(command, "merge-base --is-ancestor main origin/main") ->
+                {:ok, {"", 0}}
+
+              String.contains?(command, "[scriptblock]::Create") ->
+                {:ok, {"hook after_create parsed\n7.5.0\n", 0}}
+
+              String.starts_with?(command, "git clone --depth 1") ->
+                {:ok, {"Cloning into preflight\n", 0}}
+
+              command == "gh auth status" ->
+                {:ok, {"Logged in\n", 0}}
+
+              true ->
+                flunk("unexpected command: #{command}")
+            end
+        end
+      })
+
+    assert {:ok, checks} = WindowsPreflight.run(workflow_path, deps)
+
+    assert %WindowsPreflight.Check{status: :warn, message: message, remediation: remediation} =
+             Enum.find(checks, &(&1.name == "Git main remote"))
+
+    assert message =~ "tracks windows/main"
+    assert message =~ "origin/main is newer"
+    assert remediation =~ "git branch --set-upstream-to=origin/main main"
+    assert WindowsPreflight.format(checks) =~ "[WARN] Git main remote"
   end
 
   defp workflow_with_preflight_config(overrides \\ []) do
@@ -278,5 +352,33 @@ defmodule SymphonyElixir.WindowsPreflightTest do
       },
       overrides
     )
+  end
+
+  defp git_main_tracking_command?(command) do
+    command == "git rev-parse --show-toplevel" or
+      String.contains?(command, "rev-parse --verify main") or
+      String.contains?(command, "rev-parse --verify origin/main") or
+      String.contains?(command, "rev-parse --abbrev-ref main@{upstream}") or
+      String.contains?(command, "merge-base --is-ancestor main origin/main")
+  end
+
+  defp ready_git_main_tracking_response("git rev-parse --show-toplevel") do
+    {:ok, {"C:/repo/symphony-windows-native\n", 0}}
+  end
+
+  defp ready_git_main_tracking_response(command) do
+    cond do
+      String.contains?(command, "rev-parse --verify main") ->
+        {:ok, {"main-sha\n", 0}}
+
+      String.contains?(command, "rev-parse --verify origin/main") ->
+        {:ok, {"main-sha\n", 0}}
+
+      String.contains?(command, "rev-parse --abbrev-ref main@{upstream}") ->
+        {:ok, {"origin/main\n", 0}}
+
+      String.contains?(command, "merge-base --is-ancestor main origin/main") ->
+        {:ok, {"", 1}}
+    end
   end
 end

--- a/elixir/test/symphony_elixir/windows_preflight_test.exs
+++ b/elixir/test/symphony_elixir/windows_preflight_test.exs
@@ -258,6 +258,7 @@ defmodule SymphonyElixir.WindowsPreflightTest do
 
   test "warns when local main tracks a noncanonical stale remote while origin main is newer" do
     workflow_path = workflow_with_preflight_config()
+    Process.put(:fetched_origin_main, false)
 
     deps =
       ready_deps(%{
@@ -267,10 +268,15 @@ defmodule SymphonyElixir.WindowsPreflightTest do
               command == "git rev-parse --show-toplevel" ->
                 {:ok, {"C:/repo/symphony-windows-native\n", 0}}
 
+              String.contains?(command, "fetch origin main") ->
+                Process.put(:fetched_origin_main, true)
+                {:ok, {"From https://github.com/albert-zen/symphony-windows-native\n", 0}}
+
               String.contains?(command, "rev-parse --verify main") ->
                 {:ok, {"local-main-sha\n", 0}}
 
               String.contains?(command, "rev-parse --verify origin/main") ->
+                assert Process.get(:fetched_origin_main)
                 {:ok, {"origin-main-sha\n", 0}}
 
               String.contains?(command, "rev-parse --abbrev-ref main@{upstream}") ->
@@ -356,6 +362,7 @@ defmodule SymphonyElixir.WindowsPreflightTest do
 
   defp git_main_tracking_command?(command) do
     command == "git rev-parse --show-toplevel" or
+      String.contains?(command, "fetch origin main") or
       String.contains?(command, "rev-parse --verify main") or
       String.contains?(command, "rev-parse --verify origin/main") or
       String.contains?(command, "rev-parse --abbrev-ref main@{upstream}") or
@@ -368,6 +375,9 @@ defmodule SymphonyElixir.WindowsPreflightTest do
 
   defp ready_git_main_tracking_response(command) do
     cond do
+      String.contains?(command, "fetch origin main") ->
+        {:ok, {"From https://github.com/albert-zen/symphony-windows-native\n", 0}}
+
       String.contains?(command, "rev-parse --verify main") ->
         {:ok, {"main-sha\n", 0}}
 


### PR DESCRIPTION
#### Context

Windows manager checkouts can track a noncanonical remote while origin/main has newer GitHub merges. A follow-up review found the first pass still trusted a cached `origin/main`, so this branch now refreshes the canonical ref before comparing it.

#### TL;DR

*Warn when local main tracks stale noncanonical remote while refreshed origin/main is newer.*

#### Summary

- Add a Windows preflight `WARN` for stale noncanonical local `main` upstreams.
- Fetch `origin main` before resolving `origin/main` for the stale-base comparison.
- Document `origin/main` as the default canonical base ref for manager checks.
- Normalize the optimization workflow clone remote and fetch `origin/main`.
- Cover the warning path and fetch-before-compare behavior in focused Windows preflight tests.

#### Alternatives

- Failing preflight was avoided because the condition is operator-visible drift, not a hard dependency failure.
- Forcing all checkouts to reset tracking was avoided to keep intentional fork or mirror workflows explicit.
- Trusting cached `origin/main` was rejected after review because manager checkouts may not have fetched recently.

#### Test Plan

- [ ] `make all` (failed locally at repo-wide `mix format --check-formatted`; unrelated Windows line-ending formatter defect filed as #42 / ALB-29)
- [x] `mise exec -- mix format lib/symphony_elixir/windows_preflight.ex test/symphony_elixir/windows_preflight_test.exs`
- [x] `mise exec -- mix format --check-formatted lib/symphony_elixir/windows_preflight.ex test/symphony_elixir/windows_preflight_test.exs`
- [x] `mise exec -- mix test test/symphony_elixir/windows_preflight_test.exs` (7 tests, 0 failures)
- [x] `git diff --check origin/main...HEAD`
- [x] `make windows-native-test` (104 tests, 0 failures, 14 skipped)
- [x] `./make.cmd windows-native-test` (104 tests, 0 failures, 14 skipped)

Review:
- First independent SubAgent review blocked on cached `origin/main`; fixed by fetching `origin main` before comparison.
- Follow-up independent SubAgent review found no blockers and confirmed the regression test catches fetch removal or reordering.

Closes #38.