### PR TITLE
Stabilize Windows hook timeout test

### DIFF
--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -356,7 +356,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     workspace_root =
       Path.join(
         System.tmp_dir!(),
-        "symphony-elixir-workspace-hook-timeout-#{System.unique_integer([:positive])}"
+        "symphony-elixir-workspace-hook-timeout-#{System.os_time(:nanosecond)}-#{System.unique_integer([:positive])}"
       )
 
     try do
@@ -364,11 +364,11 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        hook_timeout_ms: 100,
+        hook_timeout_ms: 10,
         hook_after_create: hook_sleep_command()
       )
 
-      assert {:error, {:workspace_hook_timeout, "after_create", 100}} =
+      assert {:error, {:workspace_hook_timeout, "after_create", 10}} =
                Workspace.create_for_issue("MT-TIMEOUT")
     after
       if windows?(), do: Process.sleep(1_100)


### PR DESCRIPTION
#### Context

GH #40 reports the Windows after_create timeout test can pass after a stale workspace skips the hook.

#### TL;DR

*Make the timeout fixture cross-process unique and keep the strict 10 ms assertion.*

#### Summary

- Add wall-clock time to the timeout test workspace root to avoid stale reuse.
- Keep the existing stale-root cleanup before writing the test workflow.
- Restore the expected after_create timeout from 100 ms to 10 ms.

#### Alternatives

- Leave the 100 ms assertion, but that weakens the GH #40 timeout contract.
- Only delete the root, but locked Windows cleanup can still leave stale paths.

#### Test Plan

- [x] `mix format test/symphony_elixir/workspace_and_config_test.exs`
- [x] `mise exec -- mix test test/symphony_elixir/workspace_and_config_test.exs:355` passed 3 local runs
- [x] `mise exec -- mix test --trace test/symphony_elixir/workspace_and_config_test.exs`
- [x] `mise exec -- cmd /c make.cmd windows-native-test`
- [x] Independent SubAgent review: no findings
- [ ] `make -C elixir all` not run: GNU make is not installed in this Windows shell
- [ ] `mise exec -- cmd /c make.cmd all` did not complete: coverage/full `mix test` exits 1 after about 60s with no captured output

Fixes #40
