### PR TITLE
fix(windows): normalize formatter checkout line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+
+elixir/test/fixtures/status_dashboard_snapshots/* linguist-generated=true

--- a/elixir/Makefile
+++ b/elixir/Makefile
@@ -38,7 +38,7 @@ test:
 	$(MIX) test
 
 windows-native-test:
-	$(MIX) test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs test/symphony_elixir/windows_lifecycle_scripts_test.exs test/symphony_elixir/ssh_test.exs test/mix/tasks/workspace_before_remove_test.exs test/mix/tasks/pr_body_check_test.exs test/symphony_elixir/specs_check_test.exs
+	$(MIX) test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs test/symphony_elixir/windows_lifecycle_scripts_test.exs test/symphony_elixir/repository_line_endings_test.exs test/symphony_elixir/ssh_test.exs test/mix/tasks/workspace_before_remove_test.exs test/mix/tasks/pr_body_check_test.exs test/symphony_elixir/specs_check_test.exs
 
 dialyzer:
 	$(MIX) deps.get

--- a/elixir/make.cmd
+++ b/elixir/make.cmd
@@ -74,7 +74,7 @@ exit /b %ERRORLEVEL%
 exit /b %ERRORLEVEL%
 
 :windows_native_test
-"%MIX_CMD%" test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs test/symphony_elixir/windows_lifecycle_scripts_test.exs test/symphony_elixir/ssh_test.exs test/mix/tasks/workspace_before_remove_test.exs test/mix/tasks/pr_body_check_test.exs test/symphony_elixir/specs_check_test.exs
+"%MIX_CMD%" test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs test/symphony_elixir/windows_lifecycle_scripts_test.exs test/symphony_elixir/repository_line_endings_test.exs test/symphony_elixir/ssh_test.exs test/mix/tasks/workspace_before_remove_test.exs test/mix/tasks/pr_body_check_test.exs test/symphony_elixir/specs_check_test.exs
 exit /b %ERRORLEVEL%
 
 :coverage

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -586,15 +586,17 @@ defmodule SymphonyElixir.CoreTest do
       |> Map.put(:retry_attempts, %{})
     end)
 
+    before_down_ms = System.monotonic_time(:millisecond)
     send(pid, {:DOWN, ref, :process, self(), :normal})
     Process.sleep(50)
     state = :sys.get_state(pid)
+    after_state_ms = System.monotonic_time(:millisecond)
 
     refute Map.has_key?(state.running, issue_id)
     assert MapSet.member?(state.completed, issue_id)
     assert %{attempt: 1, due_at_ms: due_at_ms} = state.retry_attempts[issue_id]
     assert is_integer(due_at_ms)
-    assert_due_in_range(due_at_ms, 500, 1_100)
+    assert_due_in_range(due_at_ms, before_down_ms, after_state_ms, 1_000, 1_100)
   end
 
   test "abnormal worker exit increments retry attempt progressively" do
@@ -627,14 +629,16 @@ defmodule SymphonyElixir.CoreTest do
       |> Map.put(:retry_attempts, %{})
     end)
 
+    before_down_ms = System.monotonic_time(:millisecond)
     send(pid, {:DOWN, ref, :process, self(), :boom})
     Process.sleep(50)
     state = :sys.get_state(pid)
+    after_state_ms = System.monotonic_time(:millisecond)
 
     assert %{attempt: 3, due_at_ms: due_at_ms, identifier: "MT-559", error: "agent exited: :boom"} =
              state.retry_attempts[issue_id]
 
-    assert_due_in_range(due_at_ms, 39_500, 40_500)
+    assert_due_in_range(due_at_ms, before_down_ms, after_state_ms, 40_000, 40_500)
   end
 
   test "first abnormal worker exit waits before retrying" do
@@ -666,14 +670,16 @@ defmodule SymphonyElixir.CoreTest do
       |> Map.put(:retry_attempts, %{})
     end)
 
+    before_down_ms = System.monotonic_time(:millisecond)
     send(pid, {:DOWN, ref, :process, self(), :boom})
     Process.sleep(50)
     state = :sys.get_state(pid)
+    after_state_ms = System.monotonic_time(:millisecond)
 
     assert %{attempt: 1, due_at_ms: due_at_ms, identifier: "MT-560", error: "agent exited: :boom"} =
              state.retry_attempts[issue_id]
 
-    assert_due_in_range(due_at_ms, 9_000, 10_500)
+    assert_due_in_range(due_at_ms, before_down_ms, after_state_ms, 10_000, 10_500)
   end
 
   test "stale retry timer messages do not consume newer retry entries" do
@@ -1027,11 +1033,9 @@ defmodule SymphonyElixir.CoreTest do
     assert Orchestrator.select_worker_host_for_test(state, "worker-a") == "worker-a"
   end
 
-  defp assert_due_in_range(due_at_ms, min_remaining_ms, max_remaining_ms) do
-    remaining_ms = due_at_ms - System.monotonic_time(:millisecond)
-
-    assert remaining_ms >= min_remaining_ms
-    assert remaining_ms <= max_remaining_ms
+  defp assert_due_in_range(due_at_ms, earliest_ms, latest_ms, min_delay_ms, max_delay_ms) do
+    assert due_at_ms >= earliest_ms + min_delay_ms
+    assert due_at_ms <= latest_ms + max_delay_ms
   end
 
   defp restore_app_env(key, nil), do: Application.delete_env(:symphony_elixir, key)

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -1413,9 +1413,11 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       |> Map.put(:claimed, MapSet.put(initial_state.claimed, issue_id))
     end)
 
+    before_restart_ms = System.monotonic_time(:millisecond)
     send(pid, :tick)
     Process.sleep(100)
     state = :sys.get_state(pid)
+    after_restart_ms = System.monotonic_time(:millisecond)
 
     refute Process.alive?(worker_pid)
     refute Map.has_key?(state.running, issue_id)
@@ -1428,9 +1430,8 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
            } = state.retry_attempts[issue_id]
 
     assert is_integer(due_at_ms)
-    remaining_ms = due_at_ms - System.monotonic_time(:millisecond)
-    assert remaining_ms >= 9_500
-    assert remaining_ms <= 10_500
+    assert due_at_ms >= before_restart_ms + 10_000
+    assert due_at_ms <= after_restart_ms + 10_000
   end
 
   test "status dashboard renders offline marker to terminal" do

--- a/elixir/test/symphony_elixir/repository_line_endings_test.exs
+++ b/elixir/test/symphony_elixir/repository_line_endings_test.exs
@@ -1,0 +1,32 @@
+defmodule SymphonyElixir.RepositoryLineEndingsTest do
+  use ExUnit.Case, async: true
+
+  @repo_root Path.expand("../../..", __DIR__)
+
+  @lf_paths [
+    ".gitattributes",
+    ".github/workflows/make-all.yml",
+    "elixir/.formatter.exs",
+    "elixir/.gitattributes",
+    "elixir/mix.exs",
+    "elixir/lib/symphony_elixir/orchestrator.ex",
+    "elixir/test/symphony_elixir/orchestrator_status_test.exs",
+    "elixir/test/support/test_support.exs"
+  ]
+
+  test "Git attributes keep formatter inputs LF-normalized on Windows checkouts" do
+    {output, 0} = System.cmd("git", ["-C", @repo_root, "check-attr", "eol", "--" | @lf_paths], stderr_to_stdout: true)
+
+    attributes =
+      output
+      |> String.split("\n", trim: true)
+      |> Map.new(fn line ->
+        [path, " eol", value] = String.split(line, ":", parts: 3)
+        {path, String.trim(value)}
+      end)
+
+    for path <- @lf_paths do
+      assert attributes[path] == "lf"
+    end
+  end
+end


### PR DESCRIPTION
#### Context

GH #42: Windows clean checkouts can fail repo-wide `mix format --check-formatted` when checkout line endings drift under `core.autocrlf=true`.

#### TL;DR

*Pin text checkouts to LF and verify formatter paths in Windows-native tests.*

#### Summary

- Add a repo-root `.gitattributes` so clean checkouts normalize text files to LF.
- Add a regression test that verifies LF attributes for formatter and workflow paths.
- Include the regression test in both native Windows validation entrypoints.
- Make retry-backoff timing tests assert scheduled deadlines instead of elapsed remaining time.

#### Alternatives

- Keep only `elixir/.gitattributes`, but it does not cover repo-root files and stale Windows worktrees.
- Narrow formatter scope, but that would weaken the repo-wide formatting gate.
- Leave retry timing tests unchanged, but they block `make all` on slower Windows scheduling.

#### Test Plan

- [x] `mise exec -- mix format --check-formatted`
- [x] `git diff --check`
- [x] `mise exec -- mix test test/symphony_elixir/core_test.exs:600 test/symphony_elixir/core_test.exs:640 test/symphony_elixir/core_test.exs:680 test/symphony_elixir/orchestrator_status_test.exs:1372 test/symphony_elixir/repository_line_endings_test.exs`
- [x] `make windows-native-test`
- [x] GitHub Actions `validate-pr-description`, `make-all`, and `windows-native-test`
- [ ] Local `make all` reached `coverage` after `fmt-check`, `diff-check`, and `lint`; blocked by GH #43 / ALB-30 app-server isolation failures.

Review: SubAgent review found no blocking issues; residual risk is the intentional repo-wide LF policy for future clean checkouts.