### PR TITLE
test(app-server): isolate workflow path cleanup

### DIFF
--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -15,9 +15,9 @@ defmodule SymphonyElixir.TestSupport do
 
   @workflow_prompt "You are an agent for this repository."
 
-  defmacro __using__(_opts) do
+  defmacro __using__(opts) do
     quote do
-      use ExUnit.Case
+      use ExUnit.Case, unquote(opts)
       import ExUnit.CaptureLog
 
       alias SymphonyElixir.AgentRunner
@@ -61,7 +61,7 @@ defmodule SymphonyElixir.TestSupport do
         stop_default_http_server()
 
         on_exit(fn ->
-          Application.delete_env(:symphony_elixir, :workflow_file_path)
+          Workflow.clear_workflow_file_path()
           Application.delete_env(:symphony_elixir, :server_port_override)
           Application.delete_env(:symphony_elixir, :memory_tracker_issues)
           Application.delete_env(:symphony_elixir, :memory_tracker_recipient)
@@ -77,6 +77,16 @@ defmodule SymphonyElixir.TestSupport do
     workflow = workflow_content(overrides)
     File.write!(path, workflow)
 
+    if path == SymphonyElixir.Workflow.workflow_file_path() do
+      SymphonyElixir.Workflow.set_workflow_file_path(path)
+    else
+      reload_workflow_store()
+    end
+
+    :ok
+  end
+
+  defp reload_workflow_store do
     if Process.whereis(SymphonyElixir.WorkflowStore) do
       try do
         SymphonyElixir.WorkflowStore.force_reload()

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -41,6 +41,51 @@ defmodule SymphonyElixir.AppServerTest do
     end
   end
 
+  test "app server setup replaces stale global workflow env with the test-local workflow path" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-app-server-stale-global-workflow-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workflow_file = Workflow.workflow_file_path()
+      workspace_root = Path.join(test_root, "workspaces")
+      outside_workspace = Path.join(test_root, "outside")
+      stale_workflow_file = Path.join([test_root, "removed", "WORKFLOW.md"])
+
+      File.mkdir_p!(workspace_root)
+      File.mkdir_p!(outside_workspace)
+
+      Application.put_env(:symphony_elixir, :workflow_file_path, stale_workflow_file)
+      Workflow.set_workflow_file_path(workflow_file)
+
+      write_workflow_file!(workflow_file,
+        workspace_root: workspace_root
+      )
+
+      assert Application.get_env(:symphony_elixir, :workflow_file_path) == workflow_file
+      assert Config.settings!().workspace.root == workspace_root
+
+      issue = %Issue{
+        id: "issue-stale-workflow-guard",
+        identifier: "MT-998",
+        title: "Validate stale workflow isolation",
+        description: "Ensure app-server uses the test-local workspace root",
+        state: "In Progress",
+        url: "https://example.org/issues/MT-998",
+        labels: ["backend"]
+      }
+
+      assert {:error, {:invalid_workspace_cwd, :outside_workspace_root, _path, root}} =
+               AppServer.run(outside_workspace, "guard", issue)
+
+      assert root == Path.expand(workspace_root)
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
   if @symlink_skip_reason, do: @tag(skip: @symlink_skip_reason)
 
   test "app server rejects symlink escape cwd paths under the workspace root" do

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -114,8 +114,6 @@ defmodule SymphonyElixir.CoreTest do
   end
 
   test "current WORKFLOW.md file is valid and complete" do
-    original_workflow_path = Workflow.workflow_file_path()
-    on_exit(fn -> Workflow.set_workflow_file_path(original_workflow_path) end)
     Workflow.clear_workflow_file_path()
 
     assert {:ok, %{config: config, prompt: prompt}} = Workflow.load()
@@ -193,12 +191,6 @@ defmodule SymphonyElixir.CoreTest do
   end
 
   test "workflow file path defaults to WORKFLOW.md in the current working directory when app env is unset" do
-    original_workflow_path = Workflow.workflow_file_path()
-
-    on_exit(fn ->
-      Workflow.set_workflow_file_path(original_workflow_path)
-    end)
-
     Workflow.clear_workflow_file_path()
 
     assert Workflow.workflow_file_path() == Path.join(File.cwd!(), "WORKFLOW.md")
@@ -1191,11 +1183,10 @@ defmodule SymphonyElixir.CoreTest do
   end
 
   test "prompt builder reports workflow load failures separately from template parse errors" do
-    original_workflow_path = Workflow.workflow_file_path()
     workflow_store_pid = Process.whereis(SymphonyElixir.WorkflowStore)
 
     on_exit(fn ->
-      Workflow.set_workflow_file_path(original_workflow_path)
+      Workflow.clear_workflow_file_path()
 
       if is_pid(workflow_store_pid) and is_nil(Process.whereis(SymphonyElixir.WorkflowStore)) do
         Supervisor.restart_child(SymphonyElixir.Supervisor, SymphonyElixir.WorkflowStore)
@@ -1221,7 +1212,6 @@ defmodule SymphonyElixir.CoreTest do
   end
 
   test "in-repo WORKFLOW.md renders correctly" do
-    workflow_path = Workflow.workflow_file_path()
     Workflow.set_workflow_file_path(Path.expand("WORKFLOW.md", File.cwd!()))
 
     issue = %Issue{
@@ -1233,7 +1223,7 @@ defmodule SymphonyElixir.CoreTest do
       labels: ["templating", "workflow"]
     }
 
-    on_exit(fn -> Workflow.set_workflow_file_path(workflow_path) end)
+    on_exit(fn -> Workflow.clear_workflow_file_path() end)
 
     prompt =
       PromptBuilder.build_prompt(issue,

--- a/elixir/test/symphony_elixir/live_e2e_test.exs
+++ b/elixir/test/symphony_elixir/live_e2e_test.exs
@@ -442,7 +442,6 @@ defmodule SymphonyElixir.LiveE2ETest do
     workflow_file = Path.join(workflow_root, "WORKFLOW.md")
     worker_setup = live_worker_setup!(backend, run_id, test_root)
     team_key = System.get_env("SYMPHONY_LIVE_LINEAR_TEAM_KEY") || @default_team_key
-    original_workflow_path = Workflow.workflow_file_path()
     orchestrator_pid = Process.whereis(SymphonyElixir.Orchestrator)
 
     File.mkdir_p!(workflow_root)
@@ -513,7 +512,7 @@ defmodule SymphonyElixir.LiveE2ETest do
     after
       restart_orchestrator_if_needed()
       cleanup_live_worker_setup(worker_setup)
-      Workflow.set_workflow_file_path(original_workflow_path)
+      Workflow.clear_workflow_file_path()
       File.rm_rf(test_root)
     end
   end


### PR DESCRIPTION
#### Context

Fix GH #43 / ALB-30 app-server coverage failures from stale global workflow path cleanup.

#### TL;DR

*Keep app-server tests on their test-local WORKFLOW.md during full coverage runs.*

#### Summary

- Honor `use SymphonyElixir.TestSupport, async: ...` options in shared test support.
- Clear workflow path through `Workflow.clear_workflow_file_path/0` during shared cleanup.
- Republish active workflow paths before forcing `WorkflowStore` reloads after helper writes.
- Avoid restoring deleted setup temp workflow paths in teardown callbacks.
- Add an app-server regression test for stale global workflow env replacement.

#### Alternatives

- Considered a process-local production workflow path override, but review found it did not isolate `WorkflowStore`.
- Did not change coverage policy or skip tests; a local Windows coverage-threshold discrepancy is tracked in GH #47 / ALB-32.

#### Test Plan

- [x] `make-all` GitHub check passed on PR #48.
- [x] `windows-native-test` GitHub check passed on PR #48.
- [x] `validate-pr-description` GitHub check passed on PR #48.
- [x] `mix test test/symphony_elixir/app_server_test.exs test/symphony_elixir/core_test.exs test/symphony_elixir/live_e2e_test.exs` (70 tests, 0 failures, 5 skipped)
- [x] `make windows-native-test` (104 tests, 0 failures, 14 skipped)
- [x] Local `make coverage` reached full suite with 335 tests, 0 failures, 19 skipped and no app-server isolation failures; local Windows shell then exited 1 on aggregate threshold at 93.94% vs 100%, tracked separately in GH #47 / ALB-32.
- [x] `git diff --check`
- [x] SubAgent review: first pass found blocking process-local WorkflowStore issue; revised patch second pass had no blocking findings.