### PR TITLE
fix(quality): require unambiguous linked issue closure

### DIFF
--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -32,6 +32,7 @@ codex:
   command: codex --config shell_environment_policy.inherit=all --config 'model="gpt-5.5"' --config model_reasoning_effort=xhigh app-server
   approval_policy: never
   thread_sandbox: workspace-write
+  review_readiness_repository: albert-zen/symphony-windows-native
   turn_sandbox_policy:
     type: workspaceWrite
 ---

--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -32,7 +32,6 @@ codex:
   command: codex --config shell_environment_policy.inherit=all --config 'model="gpt-5.5"' --config model_reasoning_effort=xhigh app-server
   approval_policy: never
   thread_sandbox: workspace-write
-  review_readiness_repository: albert-zen/symphony-windows-native
   turn_sandbox_policy:
     type: workspaceWrite
 ---

--- a/elixir/WORKFLOW.optimization.windows.example.md
+++ b/elixir/WORKFLOW.optimization.windows.example.md
@@ -90,6 +90,8 @@ Operating model:
    `docs(quality): add agent PR quality policy`, and push the branch to
    the configured GitHub repository.
 9. Open a GitHub pull request against `main` and link it in the Linear workpad.
+   If the Linear issue has one unambiguous origin GitHub issue, include a supported closing keyword
+   in the PR body, for example `Fixes #NN`.
 10. Wait for required GitHub checks to complete before moving the Linear issue to `In Review`.
     If checks cannot be verified, record the exact reason in the workpad and PR, then keep the
     issue in `In Progress` or return it to `Todo`; only a manager may explicitly override this.

--- a/elixir/docs/agent-quality-flywheel.md
+++ b/elixir/docs/agent-quality-flywheel.md
@@ -9,6 +9,8 @@ leave active work.
 Every agent PR must record these checks in the PR body and the Linear `## Codex Workpad`:
 
 - `validate-pr-description`: the PR body follows `.github/pull_request_template.md`.
+- `linked-issue-close`: when the Linear issue has one unambiguous origin GitHub issue in the
+  trusted repository, the PR body includes a GitHub closing keyword such as `Fixes #NN`.
 - `make-all`: the repository gate runs `make all` from `elixir/`.
 - `diff-check`: the repository gate runs `git diff --check` through `make all`. In CI it
   must check the committed PR diff with `DIFF_RANGE=<base>...HEAD`; locally, set
@@ -73,6 +75,12 @@ Agents must not move a Linear issue to `In Review` solely because a branch was p
 means a PR exists, required checks have completed and passed, and required manager/subagent review
 findings have been addressed, unless a manager explicitly moves the issue there.
 
+When a Linear issue has one unambiguous origin GitHub issue in the trusted repository, the linked PR
+must close that GitHub issue through the PR body before review handoff. Use a supported closing
+keyword such as `Fixes #NN`, `Closes #NN`, or `Resolves #NN`. Do not infer origins from reference-only
+links, unrelated attachments, or multiple trusted issue URLs. Do not use a closing keyword for an
+unrelated or still-active GitHub issue.
+
 Pending, failing, or unverifiable required checks are not review-ready. The agent must write the
 failure or blocker to the workpad and/or linked GitHub issue or PR, then keep the issue in
 `In Progress` or return it to `Todo`. If a true blocker prevents completion, the agent should move
@@ -94,6 +102,20 @@ If a required gate fails, the agent must summarize the failure in the workpad or
 and keep the Linear issue in `In Progress` or return it to `Todo` for repair. Failures discovered by
 automation should create a GitHub issue with the `symphony-optimization` label when they describe a
 system defect outside the current PR.
+
+## GitHub issue reconciliation
+
+Use this manager-run path only for already completed work:
+
+1. Query Done Linear issues and inspect each issue's linked GitHub issue and merged PR.
+2. Confirm the Linear issue is terminal `Done`, the PR is merged, and the PR or Workpad clearly
+   matches exactly one GitHub issue.
+3. Close the GitHub issue with a comment linking the merged PR and Linear issue.
+4. Skip any item whose Linear issue is not Done, whose PR is unmerged, or whose mapping is ambiguous.
+5. Record permission failures in the Linear Workpad or manager notes instead of guessing.
+
+This reconciliation is intentionally explicit. Agents should prevent new stale issues with PR closing
+keywords; they should not bulk-close GitHub issues for active or ambiguous Linear work.
 
 ## Problem comment scope
 

--- a/elixir/docs/small-team-agentic-flywheel.md
+++ b/elixir/docs/small-team-agentic-flywheel.md
@@ -117,6 +117,8 @@ base for later agents. These guardrails are the minimum bar:
   status, and any CI/runtime failures.
 - The PR body follows the repository template and includes concrete validation
   evidence.
+- PRs for Linear issues with one unambiguous origin GitHub issue include a closing
+  keyword such as `Fixes #NN` in the PR body.
 - `make all` is the repository gate when the local environment supports it.
 - `windows-native-test` runs for Windows shell, workspace/config, workflow, or
   path-handling changes.

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -15,6 +15,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
       id
       identifier
       url
+      description
       team {
         states(first: 250) {
           nodes {
@@ -25,6 +26,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
       }
       attachments {
         nodes {
+          sourceType
           title
           url
         }
@@ -381,6 +383,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   defp required_checks_passed?(issue, %{owner: owner, repo: repo, number: number}, github_client) do
     with {:ok, pr} <- github_json(github_client, "#{@github_api}/repos/#{owner}/#{repo}/pulls/#{number}"),
          :ok <- pull_request_matches_issue?(issue, owner, repo, pr),
+         :ok <- pull_request_closes_origin_issue?(issue, owner, repo, pr),
          {:ok, head_sha} <- required_string(pr, ["head", "sha"], :review_readiness_missing_pr_head_sha),
          {:ok, base_ref} <- required_string(pr, ["base", "ref"], :review_readiness_missing_pr_base_ref),
          :ok <- pull_request_file_count_fetchable?(pr),
@@ -469,6 +472,99 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
       _ -> nil
     end
   end
+
+  defp pull_request_closes_origin_issue?(issue, owner, repo, pr) do
+    case origin_github_issue(issue, owner, repo) do
+      nil ->
+        :ok
+
+      %{owner: issue_owner, repo: issue_repo, number: issue_number} ->
+        body = Map.get(pr, "body")
+
+        if closing_keyword_for_issue?(body, issue_owner, issue_repo, issue_number) do
+          :ok
+        else
+          {:error, {:review_readiness_missing_closing_keyword, issue_owner, issue_repo, issue_number}}
+        end
+    end
+  end
+
+  defp origin_github_issue(issue, owner, repo) do
+    issue
+    |> origin_github_issues(owner, repo)
+    |> case do
+      [origin_issue] -> origin_issue
+      _ambiguous_or_absent -> nil
+    end
+  end
+
+  defp origin_github_issues(issue, owner, repo) do
+    description_issues =
+      issue
+      |> Map.get("description")
+      |> description_origin_github_issue_urls()
+      |> Enum.map(&parse_issue_url(&1, owner, repo))
+      |> Enum.reject(&is_nil/1)
+
+    attachment_issues =
+      issue
+      |> get_in(["attachments", "nodes"])
+      |> case do
+        attachments when is_list(attachments) ->
+          attachments
+          |> Enum.filter(&origin_github_issue_attachment?/1)
+          |> Enum.map(&parse_issue_url(Map.get(&1, "url"), owner, repo))
+          |> Enum.reject(&is_nil/1)
+
+        _ ->
+          []
+      end
+
+    Enum.uniq_by(description_issues ++ attachment_issues, &{normalize_repo_name("#{&1.owner}/#{&1.repo}"), &1.number})
+  end
+
+  defp description_origin_github_issue_urls(text) when is_binary(text) do
+    ~r/(?:^|\R)\s*GitHub(?:\s+issue)?\s*:\s*(?:\[[^\]]+\]\(<)?(https:\/\/github\.com\/[^\s\]\)>]+)/i
+    |> Regex.scan(text)
+    |> Enum.map(fn [_match, url] -> url end)
+  end
+
+  defp description_origin_github_issue_urls(_text), do: []
+
+  defp origin_github_issue_attachment?(%{"url" => url} = attachment) when is_binary(url) do
+    github_source? = normalize(Map.get(attachment, "sourceType") || "") == "github"
+
+    github_source? and Regex.match?(~r/^https:\/\/github\.com\/[^\/]+\/[^\/]+\/issues\/\d+/, url)
+  end
+
+  defp origin_github_issue_attachment?(_attachment), do: false
+
+  defp parse_issue_url(url, expected_owner, expected_repo) when is_binary(url) do
+    expected_repository = normalize_repo_name("#{expected_owner}/#{expected_repo}")
+
+    case Regex.run(~r/^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/issues\/(\d+)/, url) do
+      [_, owner, repo, number] ->
+        if normalize_repo_name("#{owner}/#{repo}") == expected_repository do
+          %{owner: owner, repo: repo, number: number}
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp closing_keyword_for_issue?(body, owner, repo, number) when is_binary(body) do
+    owner = Regex.escape(owner)
+    repo = Regex.escape(repo)
+    number = Regex.escape(to_string(number))
+
+    Regex.match?(
+      ~r/\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+(?:#{owner}\/#{repo})?##{number}\b/i,
+      body
+    )
+  end
+
+  defp closing_keyword_for_issue?(_body, _owner, _repo, _number), do: false
 
   defp normalize_repo_name(nil), do: nil
 
@@ -1194,6 +1290,9 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
 
   defp rejection_message({:review_readiness_pr_branch_mismatch, head_ref, identifier}),
     do: "linked PR branch #{head_ref} does not match Linear issue #{identifier}."
+
+  defp rejection_message({:review_readiness_missing_closing_keyword, owner, repo, number}),
+    do: "linked PR body is missing a closing keyword for GitHub issue #{owner}/#{repo}##{number}. Add `Fixes ##{number}` or another GitHub-supported closing keyword before review handoff."
 
   defp rejection_message({:review_readiness_required_checks_not_passing, failures}),
     do: "required GitHub checks are not passing: #{format_failures(failures)}."

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -474,27 +474,21 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   end
 
   defp pull_request_closes_origin_issue?(issue, owner, repo, pr) do
-    case origin_github_issue(issue, owner, repo) do
-      nil ->
-        :ok
+    body = Map.get(pr, "body")
 
-      %{owner: issue_owner, repo: issue_repo, number: issue_number} ->
-        body = Map.get(pr, "body")
+    case origin_github_issues(issue, owner, repo) do
+      [] ->
+        reject_unmapped_closing_keyword(body, owner, repo)
 
+      [%{owner: issue_owner, repo: issue_repo, number: issue_number}] ->
         if closing_keyword_for_issue?(body, issue_owner, issue_repo, issue_number) do
           :ok
         else
           {:error, {:review_readiness_missing_closing_keyword, issue_owner, issue_repo, issue_number}}
         end
-    end
-  end
 
-  defp origin_github_issue(issue, owner, repo) do
-    issue
-    |> origin_github_issues(owner, repo)
-    |> case do
-      [origin_issue] -> origin_issue
-      _ambiguous_or_absent -> nil
+      _ambiguous ->
+        reject_unmapped_closing_keyword(body, owner, repo)
     end
   end
 
@@ -565,6 +559,33 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   end
 
   defp closing_keyword_for_issue?(_body, _owner, _repo, _number), do: false
+
+  defp reject_unmapped_closing_keyword(body, owner, repo) do
+    if closing_keyword_for_trusted_repo?(body, owner, repo) do
+      {:error, {:review_readiness_unmapped_closing_keyword, owner, repo}}
+    else
+      :ok
+    end
+  end
+
+  defp closing_keyword_for_trusted_repo?(body, owner, repo) when is_binary(body) do
+    trusted_repository = normalize_repo_name("#{owner}/#{repo}")
+
+    ~r/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+))?#(\d+)\b/i
+    |> Regex.scan(body)
+    |> Enum.any?(fn
+      [_match, "", _number] ->
+        true
+
+      [_match, repository, _number] ->
+        normalize_repo_name(repository) == trusted_repository
+
+      _ ->
+        false
+    end)
+  end
+
+  defp closing_keyword_for_trusted_repo?(_body, _owner, _repo), do: false
 
   defp normalize_repo_name(nil), do: nil
 
@@ -1293,6 +1314,10 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
 
   defp rejection_message({:review_readiness_missing_closing_keyword, owner, repo, number}),
     do: "linked PR body is missing a closing keyword for GitHub issue #{owner}/#{repo}##{number}. Add `Fixes ##{number}` or another GitHub-supported closing keyword before review handoff."
+
+  defp rejection_message({:review_readiness_unmapped_closing_keyword, owner, repo}),
+    do:
+      "linked PR body contains a GitHub closing keyword for #{owner}/#{repo}, but the Linear issue does not have exactly one unambiguous origin GitHub issue. Remove the closing keyword or add explicit origin metadata before review handoff."
 
   defp rejection_message({:review_readiness_required_checks_not_passing, failures}),
     do: "required GitHub checks are not passing: #{format_failures(failures)}."

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -610,8 +610,6 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     end)
   end
 
-  defp trusted_repo_closing_keyword_numbers(_body, _owner, _repo), do: []
-
   defp normalize_repo_name(nil), do: nil
 
   defp normalize_repo_name(repo) when is_binary(repo) do

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -481,10 +481,15 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
         reject_unmapped_closing_keyword(body, owner, repo)
 
       [%{owner: issue_owner, repo: issue_repo, number: issue_number}] ->
-        if closing_keyword_for_issue?(body, issue_owner, issue_repo, issue_number) do
-          :ok
-        else
-          {:error, {:review_readiness_missing_closing_keyword, issue_owner, issue_repo, issue_number}}
+        cond do
+          extra_closing_keyword_for_trusted_repo?(body, owner, repo, issue_number) ->
+            {:error, {:review_readiness_unmapped_closing_keyword, owner, repo}}
+
+          closing_keyword_for_issue?(body, issue_owner, issue_repo, issue_number) ->
+            :ok
+
+          true ->
+            {:error, {:review_readiness_missing_closing_keyword, issue_owner, issue_repo, issue_number}}
         end
 
       _ambiguous ->
@@ -553,12 +558,20 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     number = Regex.escape(to_string(number))
 
     Regex.match?(
-      ~r/\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+(?:#{owner}\/#{repo})?##{number}\b/i,
+      ~r/\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s*:?\s+(?:#{owner}\/#{repo})?##{number}\b/i,
       body
     )
   end
 
   defp closing_keyword_for_issue?(_body, _owner, _repo, _number), do: false
+
+  defp extra_closing_keyword_for_trusted_repo?(body, owner, repo, allowed_number) when is_binary(body) do
+    body
+    |> trusted_repo_closing_keyword_numbers(owner, repo)
+    |> Enum.any?(&(&1 != to_string(allowed_number)))
+  end
+
+  defp extra_closing_keyword_for_trusted_repo?(_body, _owner, _repo, _allowed_number), do: false
 
   defp reject_unmapped_closing_keyword(body, owner, repo) do
     if closing_keyword_for_trusted_repo?(body, owner, repo) do
@@ -569,23 +582,35 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   end
 
   defp closing_keyword_for_trusted_repo?(body, owner, repo) when is_binary(body) do
-    trusted_repository = normalize_repo_name("#{owner}/#{repo}")
-
-    ~r/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+))?#(\d+)\b/i
-    |> Regex.scan(body)
-    |> Enum.any?(fn
-      [_match, "", _number] ->
-        true
-
-      [_match, repository, _number] ->
-        normalize_repo_name(repository) == trusted_repository
-
-      _ ->
-        false
-    end)
+    body
+    |> trusted_repo_closing_keyword_numbers(owner, repo)
+    |> Enum.any?()
   end
 
   defp closing_keyword_for_trusted_repo?(_body, _owner, _repo), do: false
+
+  defp trusted_repo_closing_keyword_numbers(body, owner, repo) when is_binary(body) do
+    trusted_repository = normalize_repo_name("#{owner}/#{repo}")
+
+    ~r/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+(?:([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+))?#(\d+)\b/i
+    |> Regex.scan(body)
+    |> Enum.flat_map(fn
+      [_match, "", number] ->
+        [number]
+
+      [_match, repository, number] ->
+        if normalize_repo_name(repository) == trusted_repository do
+          [number]
+        else
+          []
+        end
+
+      _ ->
+        []
+    end)
+  end
+
+  defp trusted_repo_closing_keyword_numbers(_body, _owner, _repo), do: []
 
   defp normalize_repo_name(nil), do: nil
 

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -313,7 +313,7 @@ defmodule SymphonyElixir.TestSupport do
           codex_command_watchdog_stalled_ms: 300_000,
           codex_command_watchdog_repeated_output_limit: 20,
           codex_command_watchdog_block_on_stall: false,
-          codex_review_readiness_repository: "albert-zen/symphony-windows-native",
+          codex_review_readiness_repository: nil,
           codex_review_readiness_required_checks: [],
           hook_after_create: nil,
           hook_before_run: nil,

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -26,7 +26,7 @@ defmodule SymphonyElixir.CoreTest do
     assert config.tracker.terminal_states == ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]
     assert config.tracker.assignee == nil
     assert config.agent.max_turns == 20
-    assert config.codex.review_readiness_repository == "albert-zen/symphony-windows-native"
+    assert config.codex.review_readiness_repository == nil
     assert config.codex.review_readiness_required_checks == []
 
     write_workflow_file!(Workflow.workflow_file_path(), poll_interval_ms: "invalid")

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -87,6 +87,228 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     refute_received {:workpad_recorded, _}
   end
 
+  test "linear_graphql allows In Review transition when PR body closes the originating GitHub issue" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_origin_github_issue()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{
+              "body" => "#### Context\n\nImplements the linked spec.\n\nFixes #46",
+              "head" => %{"sha" => "abc123"},
+              "base" => %{"ref" => "main"}
+            },
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{"check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]}
+          })
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
+    refute_received {:workpad_recorded, _}
+  end
+
+  test "linear_graphql recognizes current Linear GitHub origin markdown" do
+    test_pid = self()
+
+    issue =
+      issue_with_origin_github_issue()
+      |> Map.put("description", "GitHub: [https://github.com/albert-zen/symphony-windows-native/issues/46](<https://github.com/albert-zen/symphony-windows-native/issues/46>)")
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{
+              "body" => "#### Context\n\nImplements the linked spec without a closing keyword.",
+              "head" => %{"sha" => "abc123"},
+              "base" => %{"ref" => "main"}
+            }
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "missing a closing keyword for GitHub issue albert-zen/symphony-windows-native#46"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "Fixes #46"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql rejects In Review transition when PR body does not close the originating GitHub issue" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_origin_github_issue()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{
+              "body" => "#### Context\n\nImplements the linked spec without a closing keyword.",
+              "head" => %{"sha" => "abc123"},
+              "base" => %{"ref" => "main"}
+            }
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "missing a closing keyword for GitHub issue albert-zen/symphony-windows-native#46"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "Fixes #46"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql rejects In Review transition when attachment origin issue lacks closing keyword" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_origin_github_issue_attachment()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{
+              "body" => "#### Context\n\nImplements the linked spec without a closing keyword.",
+              "head" => %{"sha" => "abc123"},
+              "base" => %{"ref" => "main"}
+            }
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "missing a closing keyword for GitHub issue albert-zen/symphony-windows-native#46"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "Fixes #46"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql ignores non-trusted repository issue origins" do
+    test_pid = self()
+
+    issue =
+      issue_with_pr()
+      |> Map.put("description", "GitHub issue: https://github.com/elsewhere/symphony-windows-native/issues/46")
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue),
+        github_client: github_client(passing_review_readiness_responses(%{"body" => "#### Context\n\nNo closing keyword."}))
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
+    refute_received {:workpad_recorded, _}
+  end
+
+  test "linear_graphql ignores non-GitHub origin attachments" do
+    test_pid = self()
+
+    issue =
+      issue_with_pr()
+      |> update_in(["attachments", "nodes"], fn attachments ->
+        attachments ++ [%{"sourceType" => "url", "url" => "https://example.com/issues/46"}]
+      end)
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue),
+        github_client: github_client(passing_review_readiness_responses(%{"body" => "#### Context\n\nNo closing keyword."}))
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
+    refute_received {:workpad_recorded, _}
+  end
+
+  test "linear_graphql skips closing keyword enforcement for ambiguous origin issue links" do
+    test_pid = self()
+
+    issue =
+      issue_with_pr()
+      |> Map.put(
+        "description",
+        """
+        GitHub issue: https://github.com/albert-zen/symphony-windows-native/issues/46
+        GitHub issue: https://github.com/albert-zen/symphony-windows-native/issues/47
+        """
+      )
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue),
+        github_client: github_client(passing_review_readiness_responses(%{"body" => "#### Context\n\nNo closing keyword."}))
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
+    refute_received {:workpad_recorded, _}
+  end
+
+  test "linear_graphql skips closing keyword enforcement for cross-source origin ambiguity" do
+    test_pid = self()
+
+    issue =
+      issue_with_origin_github_issue()
+      |> update_in(["attachments", "nodes"], fn attachments ->
+        attachments ++
+          [
+            %{
+              "sourceType" => "github",
+              "title" => "GH #47",
+              "url" => "https://github.com/albert-zen/symphony-windows-native/issues/47"
+            }
+          ]
+      end)
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue),
+        github_client: github_client(passing_review_readiness_responses(%{"body" => "#### Context\n\nNo closing keyword."}))
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
+    refute_received {:workpad_recorded, _}
+  end
+
+  test "linear_graphql does not treat reference-only trusted issue links as origins" do
+    test_pid = self()
+
+    issue =
+      issue_with_pr()
+      |> Map.put("description", "Related reference: https://github.com/albert-zen/symphony-windows-native/issues/46")
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue),
+        github_client: github_client(passing_review_readiness_responses(%{"body" => "#### Context\n\nNo closing keyword."}))
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
+    refute_received {:workpad_recorded, _}
+  end
+
   test "linear_graphql rejects ambiguous multiple issueUpdate mutations" do
     test_pid = self()
 
@@ -1492,6 +1714,28 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     }
   end
 
+  defp issue_with_origin_github_issue do
+    Map.put(
+      issue_with_pr(),
+      "description",
+      "GitHub issue: https://github.com/albert-zen/symphony-windows-native/issues/46"
+    )
+  end
+
+  defp issue_with_origin_github_issue_attachment do
+    issue_with_pr()
+    |> update_in(["attachments", "nodes"], fn attachments ->
+      attachments ++
+        [
+          %{
+            "sourceType" => "github",
+            "title" => "GH #46",
+            "url" => "https://github.com/albert-zen/symphony-windows-native/issues/46"
+          }
+        ]
+    end)
+  end
+
   defp issue_without_pr do
     put_in(issue_with_pr(), ["attachments", "nodes"], [])
   end
@@ -1543,6 +1787,21 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
         nil -> default_github_response(url)
       end
     end
+  end
+
+  defp passing_review_readiness_responses(pr_payload) do
+    %{
+      "pulls/42" =>
+        Map.merge(
+          %{"head" => %{"sha" => "abc123"}, "base" => %{"ref" => "main"}},
+          pr_payload
+        ),
+      "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+      "commits/abc123/status" => %{"statuses" => []},
+      "commits/abc123/check-runs" => %{
+        "check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]
+      }
+    }
   end
 
   defp default_pr_payload(url, %{"head" => head} = payload) when is_map(head) do

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -113,6 +113,34 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     refute_received {:workpad_recorded, _}
   end
 
+  test "linear_graphql allows In Review transition when PR body uses a fully qualified closing keyword" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_origin_github_issue()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{
+              "body" => "#### Context\n\nImplements the linked spec.\n\nFixes albert-zen/symphony-windows-native#46",
+              "head" => %{"sha" => "abc123"},
+              "base" => %{"ref" => "main"}
+            },
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{
+              "check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]
+            }
+          })
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
+    refute_received {:workpad_recorded, _}
+  end
+
   test "linear_graphql recognizes current Linear GitHub origin markdown" do
     test_pid = self()
 
@@ -260,6 +288,34 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     refute_received {:workpad_recorded, _}
   end
 
+  test "linear_graphql rejects closing keywords for ambiguous origin issue links" do
+    test_pid = self()
+
+    issue =
+      issue_with_pr()
+      |> Map.put(
+        "description",
+        """
+        GitHub issue: https://github.com/albert-zen/symphony-windows-native/issues/46
+        GitHub issue: https://github.com/albert-zen/symphony-windows-native/issues/47
+        """
+      )
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue),
+        github_client: github_client(passing_review_readiness_responses(%{"body" => "#### Context\n\nFixes #46"}))
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "does not have exactly one unambiguous origin GitHub issue"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "Remove the closing keyword"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
   test "linear_graphql skips closing keyword enforcement for cross-source origin ambiguity" do
     test_pid = self()
 
@@ -287,6 +343,28 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     assert response["success"] == true
     assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
     refute_received {:workpad_recorded, _}
+  end
+
+  test "linear_graphql rejects closing keywords for reference-only trusted issue links" do
+    test_pid = self()
+
+    issue =
+      issue_with_pr()
+      |> Map.put("description", "Related reference: https://github.com/albert-zen/symphony-windows-native/issues/46")
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue),
+        github_client: github_client(passing_review_readiness_responses(%{"body" => "#### Context\n\nFixes #46"}))
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "does not have exactly one unambiguous origin GitHub issue"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "Remove the closing keyword"
+    refute_received {:linear_mutation_allowed, _, _}
   end
 
   test "linear_graphql does not treat reference-only trusted issue links as origins" do

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -3,6 +3,14 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
 
   alias SymphonyElixir.Codex.DynamicTool
 
+  setup do
+    write_workflow_file!(Workflow.workflow_file_path(),
+      codex_review_readiness_repository: "albert-zen/symphony-windows-native"
+    )
+
+    :ok
+  end
+
   test "tool_specs advertises the linear_graphql input contract" do
     assert [
              %{
@@ -139,6 +147,57 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     assert response["success"] == true
     assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
     refute_received {:workpad_recorded, _}
+  end
+
+  test "linear_graphql allows In Review transition when PR body uses colon-form closing keyword" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_origin_github_issue()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{
+              "body" => "#### Context\n\nImplements the linked spec.\n\nFixes: #46",
+              "head" => %{"sha" => "abc123"},
+              "base" => %{"ref" => "main"}
+            },
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{
+              "check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]
+            }
+          })
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
+    refute_received {:workpad_recorded, _}
+  end
+
+  test "linear_graphql rejects extra trusted repository closing keywords" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_origin_github_issue()),
+        github_client:
+          github_client(
+            passing_review_readiness_responses(%{
+              "body" => "#### Context\n\nImplements the linked spec.\n\nFixes #46\nFixes #47"
+            })
+          )
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "does not have exactly one unambiguous origin GitHub issue"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "Remove the closing keyword"
+    refute_received {:linear_mutation_allowed, _, _}
   end
 
   test "linear_graphql recognizes current Linear GitHub origin markdown" do
@@ -316,6 +375,34 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     refute_received {:linear_mutation_allowed, _, _}
   end
 
+  test "linear_graphql rejects colon-form closing keywords for ambiguous origin issue links" do
+    test_pid = self()
+
+    issue =
+      issue_with_pr()
+      |> Map.put(
+        "description",
+        """
+        GitHub issue: https://github.com/albert-zen/symphony-windows-native/issues/46
+        GitHub issue: https://github.com/albert-zen/symphony-windows-native/issues/47
+        """
+      )
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue),
+        github_client: github_client(passing_review_readiness_responses(%{"body" => "#### Context\n\nFixes: #46"}))
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "does not have exactly one unambiguous origin GitHub issue"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "Remove the closing keyword"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
   test "linear_graphql skips closing keyword enforcement for cross-source origin ambiguity" do
     test_pid = self()
 
@@ -358,6 +445,28 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
         review_transition_arguments(),
         linear_client: review_linear_client(test_pid, issue),
         github_client: github_client(passing_review_readiness_responses(%{"body" => "#### Context\n\nFixes #46"}))
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "does not have exactly one unambiguous origin GitHub issue"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "Remove the closing keyword"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql rejects colon-form closing keywords for reference-only trusted issue links" do
+    test_pid = self()
+
+    issue =
+      issue_with_pr()
+      |> Map.put("description", "Related reference: https://github.com/albert-zen/symphony-windows-native/issues/46")
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue),
+        github_client: github_client(passing_review_readiness_responses(%{"body" => "#### Context\n\nFixes: #46"}))
       )
 
     assert response["success"] == false
@@ -1163,7 +1272,11 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
 
   test "linear_graphql uses configured required checks when branch protection is unavailable" do
     test_pid = self()
-    write_workflow_file!(Workflow.workflow_file_path(), codex_review_readiness_required_checks: ["make-all"])
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      codex_review_readiness_repository: "albert-zen/symphony-windows-native",
+      codex_review_readiness_required_checks: ["make-all"]
+    )
 
     response =
       DynamicTool.execute(


### PR DESCRIPTION
#### Context

GH #46 reported stale open GitHub issues after Done Linear work and merged PRs. The repair tightens closing-keyword enforcement so PRs cannot close unrelated trusted-repo issues.

Fixes #46

#### TL;DR

*Require exactly one safe origin issue before a PR body can close a trusted GitHub issue.*

#### Summary

- Require a closing keyword when Linear has one unambiguous trusted origin GitHub issue
- Reject extra trusted-repo closing keywords, even when the expected origin closer is present
- Recognize GitHub colon-form closing keywords such as `Fixes: #46`
- Keep ambiguous, absent, or reference-only trusted issue links from closing GitHub issues
- Keep the tracked workflow pluggable; deployments configure their trusted repository locally
- Document worker guidance and a manager reconciliation path for already stale Done issues

#### Alternatives

- A post-merge bulk close step was avoided because it risks closing active or ambiguous work.
- Broad URL inference was avoided; only explicit origin signals or GitHub issue attachments count.
- The safe reconciliation path remains manager-driven for already Done and merged items.

#### Test Plan

- [x] `mise exec -- mix test test/symphony_elixir/dynamic_tool_test.exs` (68 tests, 0 failures)
- [x] `mise exec -- mix test test/symphony_elixir/core_test.exs` (48 tests, 0 failures, 1 skipped)
- [x] `mise exec -- mix specs.check` (passes; Phoenix LiveView symlink warning only)
- [x] `mise exec -- mix dialyzer --format short` (passes)
- [x] `make windows-native-test` (105 tests, 0 failures, 14 skipped; Git LF/CRLF warning only)
- [x] `make all` with `SYMPHONY_DISABLE_TERMINAL_DASHBOARD` unset: tests pass, then local coverage reports 93.94% against 100.00%; GitHub coverage for PR merge ref reports 100.00%
- [x] Independent SubAgent review for current repair: no blocking findings
- [ ] Required GitHub checks for current head `ca610af` pending