### PR TITLE
test(coverage): restore Windows coverage gate

### DIFF
--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -72,5 +72,8 @@ jobs:
         run: |
           mix local.hex --force
           mix local.rebar --force
-          mix deps.get
-          mix test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs
+          .\make.cmd deps
+          .\make.cmd windows-native-test
+
+      - name: Verify Windows coverage gate
+        run: .\make.cmd coverage

--- a/elixir/lib/symphony_elixir/path_safety.ex
+++ b/elixir/lib/symphony_elixir/path_safety.ex
@@ -1,12 +1,14 @@
 defmodule SymphonyElixir.PathSafety do
   @moduledoc false
 
-  @spec canonicalize(Path.t()) :: {:ok, Path.t()} | {:error, term()}
-  def canonicalize(path) when is_binary(path) do
+  @spec canonicalize(Path.t(), keyword()) :: {:ok, Path.t()} | {:error, term()}
+  def canonicalize(path, opts \\ []) when is_binary(path) do
+    file_module = Keyword.get(opts, :file_module, File)
+    read_link_fun = Keyword.get(opts, :read_link_fun, &:file.read_link_all/1)
     expanded_path = Path.expand(path)
     {root, segments} = split_absolute_path(expanded_path)
 
-    case resolve_segments(root, [], segments) do
+    case resolve_segments(root, [], segments, file_module, read_link_fun) do
       {:ok, canonical_path} ->
         {:ok, canonical_path}
 
@@ -20,21 +22,22 @@ defmodule SymphonyElixir.PathSafety do
     {root, segments}
   end
 
-  defp resolve_segments(root, resolved_segments, []), do: {:ok, join_path(root, resolved_segments)}
+  defp resolve_segments(root, resolved_segments, [], _file_module, _read_link_fun),
+    do: {:ok, join_path(root, resolved_segments)}
 
-  defp resolve_segments(root, resolved_segments, [segment | rest]) do
+  defp resolve_segments(root, resolved_segments, [segment | rest], file_module, read_link_fun) do
     candidate_path = join_path(root, resolved_segments ++ [segment])
 
-    case File.lstat(candidate_path) do
+    case file_module.lstat(candidate_path) do
       {:ok, %File.Stat{type: :symlink}} ->
-        with {:ok, target} <- :file.read_link_all(String.to_charlist(candidate_path)) do
+        with {:ok, target} <- read_link_fun.(String.to_charlist(candidate_path)) do
           resolved_target = Path.expand(IO.chardata_to_string(target), join_path(root, resolved_segments))
           {target_root, target_segments} = split_absolute_path(resolved_target)
-          resolve_segments(target_root, [], target_segments ++ rest)
+          resolve_segments(target_root, [], target_segments ++ rest, file_module, read_link_fun)
         end
 
       {:ok, _stat} ->
-        resolve_segments(root, resolved_segments ++ [segment], rest)
+        resolve_segments(root, resolved_segments ++ [segment], rest, file_module, read_link_fun)
 
       {:error, :enoent} ->
         {:ok, join_path(root, resolved_segments ++ [segment | rest])}

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -17,6 +17,9 @@ defmodule SymphonyElixir.MixProject do
           SymphonyElixir.Config,
           SymphonyElixir.Linear.Client,
           SymphonyElixir.LocalShell,
+          # Symlink and filesystem-error branches are OS/privilege dependent on
+          # Windows. Portable behavior is covered by direct tests and callers.
+          SymphonyElixir.PathSafety,
           SymphonyElixir.SpecsCheck,
           SymphonyElixir.Orchestrator,
           SymphonyElixir.Orchestrator.State,

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -17,9 +17,6 @@ defmodule SymphonyElixir.MixProject do
           SymphonyElixir.Config,
           SymphonyElixir.Linear.Client,
           SymphonyElixir.LocalShell,
-          # Symlink and filesystem-error branches are OS/privilege dependent on
-          # Windows. Portable behavior is covered by direct tests and callers.
-          SymphonyElixir.PathSafety,
           SymphonyElixir.SpecsCheck,
           SymphonyElixir.Orchestrator,
           SymphonyElixir.Orchestrator.State,

--- a/elixir/test/mix/tasks/workspace_before_remove_test.exs
+++ b/elixir/test/mix/tasks/workspace_before_remove_test.exs
@@ -5,11 +5,6 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
 
   import ExUnit.CaptureIO
 
-  @fake_cli_skip if(SymphonyElixir.TestSupport.windows?(),
-                   do: "Fake gh/git fixtures are Unix scripts; Windows coverage for gh uses real gh.exe availability checks.",
-                   else: nil
-                 )
-
   setup do
     Mix.Task.reenable("workspace.before_remove")
     :ok
@@ -53,8 +48,6 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
       assert output == ""
     end)
   end
-
-  if @fake_cli_skip, do: @tag(skip: @fake_cli_skip)
 
   test "uses current branch for lookup when branch option is omitted" do
     with_fake_gh_and_git(
@@ -107,8 +100,6 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
     )
   end
 
-  if @fake_cli_skip, do: @tag(skip: @fake_cli_skip)
-
   test "closes open pull requests for the branch and tolerates close failures" do
     with_fake_gh(fn log_path ->
       File.write!(log_path, "")
@@ -138,8 +129,6 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
       assert error_output =~ "Failed to close PR #102 for branch feature/workpad"
     end)
   end
-
-  if @fake_cli_skip, do: @tag(skip: @fake_cli_skip)
 
   test "formats close failures without command stderr output" do
     with_fake_gh(
@@ -177,8 +166,6 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
       end
     )
   end
-
-  if @fake_cli_skip, do: @tag(skip: @fake_cli_skip)
 
   test "no-ops when PR list fails for current branch" do
     with_fake_gh(
@@ -302,8 +289,6 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
     end
   end
 
-  if @fake_cli_skip, do: @tag(skip: @fake_cli_skip)
-
   test "no-ops when git current branch is blank" do
     with_fake_gh_and_git(
       """
@@ -335,8 +320,6 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
       end
     )
   end
-
-  if @fake_cli_skip, do: @tag(skip: @fake_cli_skip)
 
   test "no-ops when gh auth is unavailable" do
     with_fake_gh(

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -336,7 +336,7 @@ defmodule SymphonyElixir.TestSupport do
           codex_thread_sandbox: "workspace-write",
           codex_turn_sandbox_policy: nil,
           codex_turn_timeout_ms: 3_600_000,
-          codex_read_timeout_ms: 15_000,
+          codex_read_timeout_ms: 30_000,
           codex_stall_timeout_ms: 300_000,
           codex_command_watchdog_long_running_ms: 300_000,
           codex_command_watchdog_idle_ms: 120_000,

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -97,6 +97,46 @@ defmodule SymphonyElixir.TestSupport do
 
   def path_separator, do: if(windows?(), do: ";", else: ":")
 
+  def normalize_path_for_assertion(path) do
+    path
+    |> Path.expand()
+    |> String.replace("\\", "/")
+    |> then(fn expanded ->
+      if windows?() do
+        expanded
+        |> String.downcase()
+        |> normalize_windows_temp_root_for_assertion()
+      else
+        expanded
+      end
+    end)
+  end
+
+  defp normalize_windows_temp_root_for_assertion(path) do
+    windows_temp_roots_for_assertion()
+    |> Enum.reduce(path, fn root, normalized ->
+      String.replace(normalized, root, "<windows-temp-root>")
+    end)
+  end
+
+  defp windows_temp_roots_for_assertion do
+    [
+      System.tmp_dir!(),
+      System.get_env("TEMP"),
+      System.get_env("TMP"),
+      System.get_env("USERPROFILE") && Path.join(System.get_env("USERPROFILE"), "AppData/Local/Temp")
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(fn path ->
+      path
+      |> Path.expand()
+      |> String.replace("\\", "/")
+      |> String.downcase()
+    end)
+    |> Enum.uniq()
+    |> Enum.sort_by(&byte_size/1, :desc)
+  end
+
   def write_node_executable!(executable, javascript) when is_binary(executable) and is_binary(javascript) do
     script = executable <> ".js"
     script_name = Path.basename(script)

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -336,7 +336,7 @@ defmodule SymphonyElixir.TestSupport do
           codex_thread_sandbox: "workspace-write",
           codex_turn_sandbox_policy: nil,
           codex_turn_timeout_ms: 3_600_000,
-          codex_read_timeout_ms: 5_000,
+          codex_read_timeout_ms: 15_000,
           codex_stall_timeout_ms: 300_000,
           codex_command_watchdog_long_running_ms: 300_000,
           codex_command_watchdog_idle_ms: 120_000,

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -73,8 +73,11 @@ defmodule SymphonyElixir.AppServerTest do
         labels: ["backend"]
       }
 
-      assert {:error, {:invalid_workspace_cwd, :symlink_escape, ^symlink_workspace, _root}} =
+      assert {:error, {:invalid_workspace_cwd, :symlink_escape, rejected_path, _root}} =
                AppServer.run(symlink_workspace, "guard", issue)
+
+      assert SymphonyElixir.TestSupport.normalize_path_for_assertion(rejected_path) ==
+               SymphonyElixir.TestSupport.normalize_path_for_assertion(symlink_workspace)
     after
       File.rm_rf(test_root)
     end

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -766,7 +766,7 @@ defmodule SymphonyElixir.AppServerTest do
         end)
 
       assert_receive {:app_server_message, %{event: :session_started, session_id: "thread-721-turn-721"}},
-                     1_000
+                     5_000
 
       request_ref = make_ref()
       send(task.pid, {:codex_steer, self(), request_ref, "thread-721-turn-721", "Retry the focused test."})

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -1686,7 +1686,9 @@ defmodule SymphonyElixir.CoreTest do
       assert :ok = AgentRunner.run(issue, nil, issue_state_fetcher: state_fetcher)
 
       trace = File.read!(trace_file)
-      assert length(String.split(trace, "RUN", trim: true)) == 1
+      lines = String.split(trace, "\n", trim: true)
+
+      assert Enum.count(lines, &(&1 == "RUN")) == 1
       assert length(Regex.scan(~r/"method":"turn\/start"/, trace)) == 2
     after
       System.delete_env("SYMP_TEST_CODEx_TRACE")

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -644,6 +644,13 @@ defmodule SymphonyElixir.ExtensionsTest do
   end
 
   test "linear adapter can sign test lease bodies without a configured api token" do
+    previous_linear_api_key = System.get_env("LINEAR_API_KEY")
+
+    on_exit(fn ->
+      restore_env("LINEAR_API_KEY", previous_linear_api_key)
+    end)
+
+    System.delete_env("LINEAR_API_KEY")
     write_workflow_file!(Workflow.workflow_file_path(), tracker_api_token: nil)
 
     body =

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -366,7 +366,7 @@ defmodule SymphonyElixir.ExtensionsTest do
 
   test "linear adapter acquires visible claim when this worker owns the oldest active lease" do
     Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
-    now = ~U[2026-05-02 00:00:00Z]
+    now = DateTime.utc_now()
 
     Process.put({FakeLinearClient, :graphql_result}, fn query, variables ->
       cond do

--- a/elixir/test/symphony_elixir/path_safety_test.exs
+++ b/elixir/test/symphony_elixir/path_safety_test.exs
@@ -1,0 +1,35 @@
+defmodule SymphonyElixir.PathSafetyTest do
+  use ExUnit.Case, async: false
+
+  alias SymphonyElixir.PathSafety
+
+  test "canonicalize returns expanded path when a trailing segment does not exist" do
+    root = Path.join(System.tmp_dir!(), "symphony-path-safety-missing-#{System.unique_integer([:positive])}")
+    missing = Path.join([root, "existing", "future", "workspace"])
+
+    on_exit(fn -> File.rm_rf(root) end)
+
+    File.mkdir_p!(Path.join(root, "existing"))
+
+    assert PathSafety.canonicalize(missing) == {:ok, Path.expand(missing)}
+  end
+
+  test "canonicalize resolves symlinks before appending remaining segments" do
+    root = Path.join(System.tmp_dir!(), "symphony-path-safety-link-#{System.unique_integer([:positive])}")
+    target = Path.join(root, "target")
+    link = Path.join(root, "link")
+
+    on_exit(fn -> File.rm_rf(root) end)
+
+    File.mkdir_p!(Path.join(target, "nested"))
+
+    case File.ln_s(target, link) do
+      :ok ->
+        assert PathSafety.canonicalize(Path.join([link, "nested", "file.txt"])) ==
+                 {:ok, Path.join([target, "nested", "file.txt"])}
+
+      {:error, reason} when reason in [:eperm, :eacces, :enotsup] ->
+        :ok
+    end
+  end
+end

--- a/elixir/test/symphony_elixir/path_safety_test.exs
+++ b/elixir/test/symphony_elixir/path_safety_test.exs
@@ -3,6 +3,44 @@ defmodule SymphonyElixir.PathSafetyTest do
 
   alias SymphonyElixir.PathSafety
 
+  defmodule FakeFile do
+    def lstat(path) do
+      path = normalize(path)
+      link = Process.get({__MODULE__, :link})
+      denied = Process.get({__MODULE__, :denied})
+
+      cond do
+        path == normalize(link) ->
+          {:ok, %File.Stat{type: :symlink}}
+
+        path == normalize(denied) ->
+          {:error, :eacces}
+
+        path_is_ancestor?(path, link) or path_is_ancestor?(path, denied) ->
+          {:ok, %File.Stat{type: :directory}}
+
+        true ->
+          {:error, :enoent}
+      end
+    end
+
+    defp path_is_ancestor?(_path, nil), do: false
+
+    defp path_is_ancestor?(path, descendant) do
+      descendant = normalize(descendant)
+      path != descendant and String.starts_with?(descendant, path <> "/")
+    end
+
+    defp normalize(nil), do: nil
+
+    defp normalize(path) do
+      path
+      |> to_string()
+      |> String.replace("\\", "/")
+      |> String.downcase()
+    end
+  end
+
   test "canonicalize returns expanded path when a trailing segment does not exist" do
     root = Path.join(System.tmp_dir!(), "symphony-path-safety-missing-#{System.unique_integer([:positive])}")
     missing = Path.join([root, "existing", "future", "workspace"])
@@ -12,6 +50,12 @@ defmodule SymphonyElixir.PathSafetyTest do
     File.mkdir_p!(Path.join(root, "existing"))
 
     assert PathSafety.canonicalize(missing) == {:ok, Path.expand(missing)}
+  end
+
+  test "canonicalize returns the filesystem root when there are no path segments" do
+    root = System.tmp_dir!() |> Path.expand() |> Path.split() |> hd()
+
+    assert PathSafety.canonicalize(root) == {:ok, root}
   end
 
   test "canonicalize resolves symlinks before appending remaining segments" do
@@ -33,5 +77,36 @@ defmodule SymphonyElixir.PathSafetyTest do
       {:error, reason} when reason in [:eperm, :eacces, :enotsup] ->
         :ok
     end
+  end
+
+  test "canonicalize resolves injected symlink targets portably" do
+    root = Path.join(System.tmp_dir!(), "symphony-path-safety-fake-link-#{System.unique_integer([:positive])}")
+    link = Path.join(root, "link")
+    target = Path.join(root, "target")
+
+    Process.put({FakeFile, :link}, link)
+
+    assert {:ok, canonical_path} =
+             PathSafety.canonicalize(Path.join([link, "nested", "file.txt"]),
+               file_module: FakeFile,
+               read_link_fun: fn path ->
+                 assert SymphonyElixir.TestSupport.normalize_path_for_assertion(IO.chardata_to_string(path)) ==
+                          SymphonyElixir.TestSupport.normalize_path_for_assertion(link)
+
+                 {:ok, String.to_charlist(target)}
+               end
+             )
+
+    assert canonical_path == Path.expand(Path.join([target, "nested", "file.txt"]))
+  end
+
+  test "canonicalize returns filesystem errors with the expanded path" do
+    root = Path.join(System.tmp_dir!(), "symphony-path-safety-denied-#{System.unique_integer([:positive])}")
+    denied = Path.join(root, "denied")
+
+    Process.put({FakeFile, :denied}, denied)
+
+    assert PathSafety.canonicalize(Path.join([denied, "workspace"]), file_module: FakeFile) ==
+             {:error, {:path_canonicalize_failed, Path.expand(Path.join([denied, "workspace"])), :eacces}}
   end
 end

--- a/elixir/test/symphony_elixir/path_safety_test.exs
+++ b/elixir/test/symphony_elixir/path_safety_test.exs
@@ -25,8 +25,10 @@ defmodule SymphonyElixir.PathSafetyTest do
 
     case File.ln_s(target, link) do
       :ok ->
-        assert PathSafety.canonicalize(Path.join([link, "nested", "file.txt"])) ==
-                 {:ok, Path.join([target, "nested", "file.txt"])}
+        assert {:ok, canonical_path} = PathSafety.canonicalize(Path.join([link, "nested", "file.txt"]))
+
+        assert SymphonyElixir.TestSupport.normalize_path_for_assertion(canonical_path) ==
+                 SymphonyElixir.TestSupport.normalize_path_for_assertion(Path.join([target, "nested", "file.txt"]))
 
       {:error, reason} when reason in [:eperm, :eacces, :enotsup] ->
         :ok

--- a/elixir/test/symphony_elixir/ssh_test.exs
+++ b/elixir/test/symphony_elixir/ssh_test.exs
@@ -3,13 +3,6 @@ defmodule SymphonyElixir.SSHTest do
 
   alias SymphonyElixir.SSH
 
-  @fake_ssh_skip if(SymphonyElixir.TestSupport.windows?(),
-                   do: "Fake ssh tests use a Unix executable script; Windows coverage for remote SSH uses real ssh.exe.",
-                   else: nil
-                 )
-
-  if @fake_ssh_skip, do: @tag(skip: @fake_ssh_skip)
-
   test "run/3 keeps bracketed IPv6 host:port targets intact" do
     test_root = Path.join(System.tmp_dir!(), "symphony-ssh-ipv6-test-#{System.unique_integer([:positive])}")
     trace_file = Path.join(test_root, "ssh.trace")
@@ -31,8 +24,6 @@ defmodule SymphonyElixir.SSHTest do
     assert trace =~ "printf ok"
   end
 
-  if @fake_ssh_skip, do: @tag(skip: @fake_ssh_skip)
-
   test "run/3 leaves unbracketed IPv6-style targets unchanged" do
     test_root = Path.join(System.tmp_dir!(), "symphony-ssh-ipv6-raw-test-#{System.unique_integer([:positive])}")
     trace_file = Path.join(test_root, "ssh.trace")
@@ -53,8 +44,6 @@ defmodule SymphonyElixir.SSHTest do
     assert trace =~ "bash -lc"
     refute trace =~ "-p 2200"
   end
-
-  if @fake_ssh_skip, do: @tag(skip: @fake_ssh_skip)
 
   test "run/3 passes host:port targets through ssh -p" do
     test_root = Path.join(System.tmp_dir!(), "symphony-ssh-test-#{System.unique_integer([:positive])}")
@@ -80,8 +69,6 @@ defmodule SymphonyElixir.SSHTest do
     assert trace =~ "bash -lc"
     assert trace =~ "echo ready"
   end
-
-  if @fake_ssh_skip, do: @tag(skip: @fake_ssh_skip)
 
   test "run/3 keeps the user prefix when parsing user@host:port targets" do
     test_root = Path.join(System.tmp_dir!(), "symphony-ssh-user-test-#{System.unique_integer([:positive])}")
@@ -161,8 +148,6 @@ defmodule SymphonyElixir.SSHTest do
     end
   end
 
-  if @fake_ssh_skip, do: @tag(skip: @fake_ssh_skip)
-
   test "start_port/3 supports binary output without line mode" do
     test_root = Path.join(System.tmp_dir!(), "symphony-ssh-port-test-#{System.unique_integer([:positive])}")
     trace_file = Path.join(test_root, "ssh.trace")
@@ -193,8 +178,6 @@ defmodule SymphonyElixir.SSHTest do
     assert trace =~ "bash -lc"
     refute trace =~ " -F "
   end
-
-  if @fake_ssh_skip, do: @tag(skip: @fake_ssh_skip)
 
   test "start_port/3 supports line mode" do
     test_root = Path.join(System.tmp_dir!(), "symphony-ssh-line-port-test-#{System.unique_integer([:positive])}")

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -260,6 +260,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
       File.mkdir_p!(workspace_root)
       File.mkdir_p!(outside_root)
+      File.rm_rf!(symlink_path)
       File.ln_s!(outside_root, symlink_path)
 
       write_workflow_file!(Workflow.workflow_file_path(), workspace_root: workspace_root)


### PR DESCRIPTION
#### Context

Windows `make coverage` passed tests locally but failed the aggregate threshold, and CI did not expose the Windows coverage gate.

#### TL;DR

*Run the Windows native profile and coverage gate through `make.cmd` in CI.*

#### Summary

- Remove broad Windows skips from SSH and workspace-before-remove fake CLI tests.
- Cover Linear claim signing when `LINEAR_API_KEY` is absent.
- Add direct `PathSafety` tests for portable canonicalization, symlink resolution, and filesystem-error behavior.
- Keep the coverage threshold at 100 without adding `PathSafety` to coverage ignores.
- Update Windows CI to run `make.cmd windows-native-test` and `make.cmd coverage`.
- Normalize Windows path assertions and stabilize fixture timing exposed by Windows coverage.
- Merge current `origin/main` and fix Windows CI coverage flakes exposed by the real gate.

#### Alternatives

- Keep CI on two manual test files: rejected because it missed the documented native profile.
- Skip Windows coverage in CI: rejected because GH #47 is specifically the Windows coverage gate.
- Ignore `PathSafety` coverage: rejected after SubAgent review because it weakens the coverage denominator.

#### Test Plan

- [ ] `make -C elixir all` not run locally because focused Windows coverage and native gates were required first; CI `make-all` is required before review.
- [x] `mix format --check-formatted`
- [x] `mix specs.check`
- [x] `git diff --check origin/main...HEAD`
- [x] `mix test test/symphony_elixir/ssh_test.exs test/mix/tasks/workspace_before_remove_test.exs test/symphony_elixir/path_safety_test.exs test/symphony_elixir/extensions_test.exs` (57 tests, 0 failures)
- [x] `mix test test/symphony_elixir/workspace_and_config_test.exs:249 test/symphony_elixir/app_server_test.exs:700` (2 tests, 0 failures, 1 skipped locally due symlink privileges)
- [x] `.\make.cmd windows-native-test` (113 tests, 0 failures, 2 skipped)
- [x] `.\make.cmd coverage` with `SYMPHONY_DISABLE_TERMINAL_DASHBOARD` unset to match CI (415 tests, 0 failures, 7 skipped; `SymphonyElixir.PathSafety` 100.00%; Total coverage 100.00%)
- [x] `mix pr_body.check --file ..\pr-body.tmp.md` with current `origin/main` PR body rule; temp file removed

SubAgent review: initial review found the Windows coverage CI visibility issue and was addressed by running `make.cmd windows-native-test` and `make.cmd coverage` in CI. Follow-up review found a blocking `PathSafety` coverage-ignore issue; fixed by covering `PathSafety` directly and removing the ignore. Final SubAgent re-check found no blocking findings after `mix specs.check` and the final coverage run.

Fixes #47