### PR TITLE
Require local validation evidence before handoff

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,4 +19,5 @@
 #### Test Plan
 
 - [ ] `make -C elixir all`
-- [ ] <!-- Additional targeted checks (list below) -->
+- [ ] <!-- Additional local targeted checks, with command/result evidence -->
+- <!-- If `make -C elixir all` was not run locally, explain why and name the narrower local validation above. -->

--- a/elixir/lib/mix/tasks/pr_body.check.ex
+++ b/elixir/lib/mix/tasks/pr_body.check.ex
@@ -1,6 +1,8 @@
 defmodule Mix.Tasks.PrBody.Check do
   use Mix.Task
 
+  alias SymphonyElixir.Codex.ValidationEvidence
+
   @shortdoc "Validate PR body format against the repository PR template"
 
   @moduledoc """
@@ -131,23 +133,26 @@ defmodule Mix.Tasks.PrBody.Check do
   end
 
   defp check_sections_from_template(errors, template, body, headings) do
-    Enum.reduce(headings, errors, fn heading, acc ->
-      template_section = capture_heading_section(template, heading, headings)
-      body_section = capture_heading_section(body, heading, headings)
+    section_errors =
+      Enum.reduce(headings, errors, fn heading, acc ->
+        template_section = capture_heading_section(template, heading, headings)
+        body_section = capture_heading_section(body, heading, headings)
 
-      cond do
-        is_nil(body_section) ->
-          acc
+        cond do
+          is_nil(body_section) ->
+            acc
 
-        String.trim(body_section) == "" ->
-          acc ++ ["Section cannot be empty: #{heading}"]
+          String.trim(body_section) == "" ->
+            acc ++ ["Section cannot be empty: #{heading}"]
 
-        true ->
-          acc
-          |> maybe_require_bullets(heading, template_section, body_section)
-          |> maybe_require_checkboxes(heading, template_section, body_section)
-      end
-    end)
+          true ->
+            acc
+            |> maybe_require_bullets(heading, template_section, body_section)
+            |> maybe_require_checkboxes(heading, template_section, body_section)
+        end
+      end)
+
+    section_errors ++ ValidationEvidence.lint_pr_body(body)
   end
 
   defp maybe_require_bullets(errors, heading, template_section, body_section) do

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -7,6 +7,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   @github_accept "application/vnd.github+json"
   @passing_status_states MapSet.new(["success"])
   @passing_check_conclusions MapSet.new(["success", "neutral", "skipped"])
+  alias SymphonyElixir.Codex.ValidationEvidence
   alias SymphonyElixir.Config
 
   @context_query """
@@ -381,6 +382,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   defp required_checks_passed?(issue, %{owner: owner, repo: repo, number: number}, github_client) do
     with {:ok, pr} <- github_json(github_client, "#{@github_api}/repos/#{owner}/#{repo}/pulls/#{number}"),
          :ok <- pull_request_matches_issue?(issue, owner, repo, pr),
+         :ok <- local_validation_evidence_ready?(pr),
          {:ok, head_sha} <- required_string(pr, ["head", "sha"], :review_readiness_missing_pr_head_sha),
          {:ok, base_ref} <- required_string(pr, ["base", "ref"], :review_readiness_missing_pr_base_ref),
          :ok <- pull_request_file_count_fetchable?(pr),
@@ -393,6 +395,19 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
          {:ok, statuses} <- github_json(github_client, "#{@github_api}/repos/#{owner}/#{repo}/commits/#{head_sha}/status"),
          {:ok, check_runs} <- github_json(github_client, "#{@github_api}/repos/#{owner}/#{repo}/commits/#{head_sha}/check-runs") do
       verify_contexts(required_checks, statuses, check_runs)
+    end
+  end
+
+  defp local_validation_evidence_ready?(pr) do
+    case Map.get(pr, "body") do
+      body when is_binary(body) ->
+        case ValidationEvidence.lint_pr_body(body) do
+          [] -> :ok
+          errors -> {:error, {:review_readiness_local_validation_evidence_missing, errors}}
+        end
+
+      _ ->
+        {:error, {:review_readiness_local_validation_evidence_missing, ["PR body is missing."]}}
     end
   end
 
@@ -1197,6 +1212,9 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
 
   defp rejection_message({:review_readiness_required_checks_not_passing, failures}),
     do: "required GitHub checks are not passing: #{format_failures(failures)}."
+
+  defp rejection_message({:review_readiness_local_validation_evidence_missing, errors}),
+    do: "local validation evidence is missing from the linked PR Test Plan: #{Enum.join(errors, " ")}"
 
   defp rejection_message({:review_readiness_pr_file_list_too_large, changed_files}),
     do: "the linked PR changes #{changed_files} files; review readiness only verifies the first 100 GitHub PR files. Split the PR or get manager review outside the agent session."

--- a/elixir/lib/symphony_elixir/codex/validation_evidence.ex
+++ b/elixir/lib/symphony_elixir/codex/validation_evidence.ex
@@ -6,9 +6,11 @@ defmodule SymphonyElixir.Codex.ValidationEvidence do
   @checked_checkbox_regex ~r/^\s*[-*]\s+\[[xX]\]\s+(.+)$/m
   @unchecked_checkbox_regex ~r/^\s*[-*]\s+\[ \]\s+(.+)$/m
   @heavy_check_regex ~r/(^|[^a-z0-9_-])(make\s+(-C\s+elixir\s+)?all|make-all)([^a-z0-9_-]|$)/i
+  @ci_only_regex ~r/(?:(?:^\s*(?:ci|github actions?)\b\s*(?::|-|[a-z]+\b))|\b(?:in|by|via|on)\s+(?:ci|github actions?)\b)/i
   @skip_words ~w(skip skipped not cannot can't unable unavailable pending later)
   @why_regex ~r/\b(because|due to|cannot|can't|unable|unavailable|not run|skipped|skip)\b/i
-  @command_regex ~r/(`[^`]+`|\bmix\s+\S+|\bmake(\.cmd)?\s+\S+|\bmake\s+(-C\s+\S+\s+)?\S+|\bgh\s+\S+|\bnpm\s+\S+|\bpnpm\s+\S+|\byarn\s+\S+)/i
+  @inline_code_regex ~r/`([^`]+)`/
+  @validation_command_regex ~r/^\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*(?:(?:mix\s+(?:test|format|pr_body\.check|specs\.check|symphony\.preflight\.windows)\b)|(?:make(?:\.cmd)?(?:\s+-C\s+\S+)?\s+(?:all|test|windows-native-test|diff-check|validate-pr-description|[\w.-]*test[\w.-]*|[\w.-]*check[\w.-]*))|(?:git\s+diff\s+--check\b)|(?:(?:npm|pnpm|yarn)\s+(?:test|lint|format|check|typecheck|type-check)\b)|(?:gh\s+(?:pr\s+checks|run\s+view)\b))/i
 
   @spec lint_pr_body(String.t()) :: [String.t()]
   def lint_pr_body(body) when is_binary(body) do
@@ -36,10 +38,9 @@ defmodule SymphonyElixir.Codex.ValidationEvidence do
   defp require_heavy_skip_justification(errors, section, checked_items, unchecked_items, local_evidence_items) do
     heavy_checked? = Enum.any?(checked_items, &heavy_check?/1)
     heavy_skip_items = heavy_skip_items(section, unchecked_items)
-    heavy_skipped? = heavy_skip_items != []
 
     cond do
-      heavy_checked? or not heavy_skipped? ->
+      heavy_checked? ->
         errors
 
       not Enum.any?(heavy_skip_items, &Regex.match?(@why_regex, &1)) ->
@@ -58,9 +59,25 @@ defmodule SymphonyElixir.Codex.ValidationEvidence do
   defp local_validation_evidence?(item) do
     normalized = normalize(item)
 
-    Regex.match?(@command_regex, item) and
+    has_validation_command?(item) and
       not only_delegates_to_ci?(normalized) and
+      not ci_only_evidence?(item) and
       not skip_item?(normalized)
+  end
+
+  defp has_validation_command?(item) do
+    item
+    |> validation_command_candidates()
+    |> Enum.any?(&Regex.match?(@validation_command_regex, &1))
+  end
+
+  defp validation_command_candidates(item) do
+    inline_commands =
+      @inline_code_regex
+      |> Regex.scan(item)
+      |> Enum.map(fn [_, command] -> command end)
+
+    [item | inline_commands]
   end
 
   defp heavy_skip_items(section, unchecked_items) do
@@ -74,6 +91,8 @@ defmodule SymphonyElixir.Codex.ValidationEvidence do
 
     Enum.uniq(unchecked_heavy_items ++ prose_skip_items)
   end
+
+  defp ci_only_evidence?(item), do: Regex.match?(@ci_only_regex, item)
 
   defp heavy_check?(text), do: Regex.match?(@heavy_check_regex, text)
 

--- a/elixir/lib/symphony_elixir/codex/validation_evidence.ex
+++ b/elixir/lib/symphony_elixir/codex/validation_evidence.ex
@@ -6,11 +6,11 @@ defmodule SymphonyElixir.Codex.ValidationEvidence do
   @checked_checkbox_regex ~r/^\s*[-*]\s+\[[xX]\]\s+(.+)$/m
   @unchecked_checkbox_regex ~r/^\s*[-*]\s+\[ \]\s+(.+)$/m
   @heavy_check_regex ~r/(^|[^a-z0-9_-])(make(?:\.cmd)?\s+(-C\s+elixir\s+)?all|make-all)([^a-z0-9_-]|$)/i
-  @ci_only_regex ~r/(?:(?:^\s*(?:ci|github actions?)\b\s*(?::|-|[a-z]+\b))|\b(?:in|by|via|on|from)\s+(?:ci|github actions?)\b)/i
+  @ci_only_regex ~r/(?:(?:^\s*(?:ci|github actions?)\b\s*(?::|-|[a-z]+\b))|\bci[-\s]+only\b|\b(?:in|by|via|on|from)\s+(?:ci|github actions?)\b)/i
   @skip_words ~w(skip skipped not cannot can't unable unavailable pending later)
-  @restated_skip_words ~w(all cannot can't check gate heavy local locally make not run skipped unable unavailable validation)
+  @restated_skip_words ~w(all cannot can't check gate heavy local locally make not run skipped to unable unavailable validation)
   @inline_code_regex ~r/`([^`]+)`/
-  @validation_command_regex ~r/^\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*(?:(?:mix\s+(?:test|format|pr_body\.check|specs\.check|symphony\.preflight\.windows)\b)|(?:make(?:\.cmd)?(?:\s+-C\s+\S+)?\s+(?:all|test|windows-native-test|diff-check|validate-pr-description|[\w.-]*test[\w.-]*|[\w.-]*check[\w.-]*))|(?:git\s+diff\s+--check\b)|(?:(?:npm|pnpm|yarn)\s+(?:test|lint|format|check|typecheck|type-check)\b)|(?:gh\s+(?:pr\s+checks|run\s+view)\b))/i
+  @validation_command_regex ~r/^\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*(?:(?:mix\s+(?:test|format|pr_body\.check|specs\.check|symphony\.preflight\.windows)\b)|(?:make(?:\.cmd)?(?:\s+-C\s+\S+)?\s+(?:all|test|windows-native-test|diff-check|validate-pr-description|[\w.-]*test[\w.-]*|[\w.-]*check[\w.-]*))|(?:git\s+diff\s+--check\b)|(?:(?:npm|pnpm|yarn)\s+(?:test|lint|format|check|typecheck|type-check)\b))/i
 
   @spec lint_pr_body(String.t()) :: [String.t()]
   def lint_pr_body(body) when is_binary(body) do
@@ -27,7 +27,7 @@ defmodule SymphonyElixir.Codex.ValidationEvidence do
 
     []
     |> require_local_validation_evidence(local_evidence_items)
-    |> require_heavy_skip_justification(section, checked_items, unchecked_items, local_evidence_items)
+    |> require_heavy_skip_justification(section, unchecked_items, local_evidence_items)
   end
 
   defp require_local_validation_evidence(errors, []),
@@ -35,8 +35,8 @@ defmodule SymphonyElixir.Codex.ValidationEvidence do
 
   defp require_local_validation_evidence(errors, _items), do: errors
 
-  defp require_heavy_skip_justification(errors, section, checked_items, unchecked_items, local_evidence_items) do
-    heavy_checked? = Enum.any?(checked_items, &heavy_check?/1)
+  defp require_heavy_skip_justification(errors, section, unchecked_items, local_evidence_items) do
+    heavy_checked? = Enum.any?(local_evidence_items, &heavy_check?/1)
     heavy_skip_items = heavy_skip_items(section, unchecked_items)
 
     cond do

--- a/elixir/lib/symphony_elixir/codex/validation_evidence.ex
+++ b/elixir/lib/symphony_elixir/codex/validation_evidence.ex
@@ -99,11 +99,18 @@ defmodule SymphonyElixir.Codex.ValidationEvidence do
   defp heavy_skip_justified?(item) do
     normalized = normalize(item)
 
-    concrete_due_to_reason?(normalized) or Regex.match?(~r/\b(cannot|can't|unable|unavailable)\b/, normalized)
+    concrete_due_to_reason?(normalized) or concrete_inability_reason?(normalized)
   end
 
   defp concrete_due_to_reason?(normalized) do
     case Regex.run(~r/\b(?:because|due to)\b\s+(.+)$/, normalized) do
+      [_, reason] -> concrete_reason?(reason)
+      _ -> false
+    end
+  end
+
+  defp concrete_inability_reason?(normalized) do
+    case Regex.run(~r/\b(?:cannot|can't|unable|unavailable)\b\s+(.+)$/, normalized) do
       [_, reason] -> concrete_reason?(reason)
       _ -> false
     end

--- a/elixir/lib/symphony_elixir/codex/validation_evidence.ex
+++ b/elixir/lib/symphony_elixir/codex/validation_evidence.ex
@@ -8,7 +8,7 @@ defmodule SymphonyElixir.Codex.ValidationEvidence do
   @heavy_check_regex ~r/(^|[^a-z0-9_-])(make(?:\.cmd)?\s+(-C\s+elixir\s+)?all|make-all)([^a-z0-9_-]|$)/i
   @ci_only_regex ~r/(?:(?:^\s*(?:ci|github actions?)\b\s*(?::|-|[a-z]+\b))|\b(?:in|by|via|on|from)\s+(?:ci|github actions?)\b)/i
   @skip_words ~w(skip skipped not cannot can't unable unavailable pending later)
-  @restated_skip_words ~w(all check gate heavy local locally make not run skipped validation)
+  @restated_skip_words ~w(all cannot can't check gate heavy local locally make not run skipped unable unavailable validation)
   @inline_code_regex ~r/`([^`]+)`/
   @validation_command_regex ~r/^\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*(?:(?:mix\s+(?:test|format|pr_body\.check|specs\.check|symphony\.preflight\.windows)\b)|(?:make(?:\.cmd)?(?:\s+-C\s+\S+)?\s+(?:all|test|windows-native-test|diff-check|validate-pr-description|[\w.-]*test[\w.-]*|[\w.-]*check[\w.-]*))|(?:git\s+diff\s+--check\b)|(?:(?:npm|pnpm|yarn)\s+(?:test|lint|format|check|typecheck|type-check)\b)|(?:gh\s+(?:pr\s+checks|run\s+view)\b))/i
 

--- a/elixir/lib/symphony_elixir/codex/validation_evidence.ex
+++ b/elixir/lib/symphony_elixir/codex/validation_evidence.ex
@@ -5,10 +5,10 @@ defmodule SymphonyElixir.Codex.ValidationEvidence do
   @heading_regex ~r/^\#{1,6}\s+.+$/m
   @checked_checkbox_regex ~r/^\s*[-*]\s+\[[xX]\]\s+(.+)$/m
   @unchecked_checkbox_regex ~r/^\s*[-*]\s+\[ \]\s+(.+)$/m
-  @heavy_check_regex ~r/(^|[^a-z0-9_-])(make\s+(-C\s+elixir\s+)?all|make-all)([^a-z0-9_-]|$)/i
-  @ci_only_regex ~r/(?:(?:^\s*(?:ci|github actions?)\b\s*(?::|-|[a-z]+\b))|\b(?:in|by|via|on)\s+(?:ci|github actions?)\b)/i
+  @heavy_check_regex ~r/(^|[^a-z0-9_-])(make(?:\.cmd)?\s+(-C\s+elixir\s+)?all|make-all)([^a-z0-9_-]|$)/i
+  @ci_only_regex ~r/(?:(?:^\s*(?:ci|github actions?)\b\s*(?::|-|[a-z]+\b))|\b(?:in|by|via|on|from)\s+(?:ci|github actions?)\b)/i
   @skip_words ~w(skip skipped not cannot can't unable unavailable pending later)
-  @why_regex ~r/\b(because|due to|cannot|can't|unable|unavailable|not run|skipped|skip)\b/i
+  @restated_skip_words ~w(all check gate heavy local locally make not run skipped validation)
   @inline_code_regex ~r/`([^`]+)`/
   @validation_command_regex ~r/^\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*(?:(?:mix\s+(?:test|format|pr_body\.check|specs\.check|symphony\.preflight\.windows)\b)|(?:make(?:\.cmd)?(?:\s+-C\s+\S+)?\s+(?:all|test|windows-native-test|diff-check|validate-pr-description|[\w.-]*test[\w.-]*|[\w.-]*check[\w.-]*))|(?:git\s+diff\s+--check\b)|(?:(?:npm|pnpm|yarn)\s+(?:test|lint|format|check|typecheck|type-check)\b)|(?:gh\s+(?:pr\s+checks|run\s+view)\b))/i
 
@@ -43,7 +43,7 @@ defmodule SymphonyElixir.Codex.ValidationEvidence do
       heavy_checked? ->
         errors
 
-      not Enum.any?(heavy_skip_items, &Regex.match?(@why_regex, &1)) ->
+      not Enum.any?(heavy_skip_items, &heavy_skip_justified?/1) ->
         errors ++ ["Test Plan must explain why the heavy local validation check was not run."]
 
       no_narrower_local_evidence?(local_evidence_items) ->
@@ -95,6 +95,26 @@ defmodule SymphonyElixir.Codex.ValidationEvidence do
   defp ci_only_evidence?(item), do: Regex.match?(@ci_only_regex, item)
 
   defp heavy_check?(text), do: Regex.match?(@heavy_check_regex, text)
+
+  defp heavy_skip_justified?(item) do
+    normalized = normalize(item)
+
+    concrete_due_to_reason?(normalized) or Regex.match?(~r/\b(cannot|can't|unable|unavailable)\b/, normalized)
+  end
+
+  defp concrete_due_to_reason?(normalized) do
+    case Regex.run(~r/\b(?:because|due to)\b\s+(.+)$/, normalized) do
+      [_, reason] -> concrete_reason?(reason)
+      _ -> false
+    end
+  end
+
+  defp concrete_reason?(reason) do
+    reason
+    |> String.replace(@inline_code_regex, " ")
+    |> String.split(~r/[^a-z0-9']+/, trim: true)
+    |> Enum.any?(&(&1 not in @restated_skip_words))
+  end
 
   defp checked_items(section), do: checkbox_items(section, @checked_checkbox_regex)
 

--- a/elixir/lib/symphony_elixir/codex/validation_evidence.ex
+++ b/elixir/lib/symphony_elixir/codex/validation_evidence.ex
@@ -1,0 +1,123 @@
+defmodule SymphonyElixir.Codex.ValidationEvidence do
+  @moduledoc false
+
+  @test_plan_heading_regex ~r/^\#{1,6}\s+Test Plan\s*$/m
+  @heading_regex ~r/^\#{1,6}\s+.+$/m
+  @checked_checkbox_regex ~r/^\s*[-*]\s+\[[xX]\]\s+(.+)$/m
+  @unchecked_checkbox_regex ~r/^\s*[-*]\s+\[ \]\s+(.+)$/m
+  @heavy_check_regex ~r/(^|[^a-z0-9_-])(make\s+(-C\s+elixir\s+)?all|make-all)([^a-z0-9_-]|$)/i
+  @skip_words ~w(skip skipped not cannot can't unable unavailable pending later)
+  @why_regex ~r/\b(because|due to|cannot|can't|unable|unavailable|not run|skipped|skip)\b/i
+  @command_regex ~r/(`[^`]+`|\bmix\s+\S+|\bmake(\.cmd)?\s+\S+|\bmake\s+(-C\s+\S+\s+)?\S+|\bgh\s+\S+|\bnpm\s+\S+|\bpnpm\s+\S+|\byarn\s+\S+)/i
+
+  @spec lint_pr_body(String.t()) :: [String.t()]
+  def lint_pr_body(body) when is_binary(body) do
+    case test_plan_section(body) do
+      nil -> ["PR body must include a Test Plan section with local validation evidence."]
+      section -> lint_test_plan(section)
+    end
+  end
+
+  defp lint_test_plan(section) do
+    checked_items = checked_items(section)
+    unchecked_items = unchecked_items(section)
+    local_evidence_items = Enum.filter(checked_items, &local_validation_evidence?/1)
+
+    []
+    |> require_local_validation_evidence(local_evidence_items)
+    |> require_heavy_skip_justification(section, checked_items, unchecked_items, local_evidence_items)
+  end
+
+  defp require_local_validation_evidence(errors, []),
+    do: errors ++ ["Test Plan must include at least one checked local validation command or targeted check."]
+
+  defp require_local_validation_evidence(errors, _items), do: errors
+
+  defp require_heavy_skip_justification(errors, section, checked_items, unchecked_items, local_evidence_items) do
+    heavy_checked? = Enum.any?(checked_items, &heavy_check?/1)
+    heavy_skip_items = heavy_skip_items(section, unchecked_items)
+    heavy_skipped? = heavy_skip_items != []
+
+    cond do
+      heavy_checked? or not heavy_skipped? ->
+        errors
+
+      not Enum.any?(heavy_skip_items, &Regex.match?(@why_regex, &1)) ->
+        errors ++ ["Test Plan must explain why the heavy local validation check was not run."]
+
+      no_narrower_local_evidence?(local_evidence_items) ->
+        errors ++ ["Test Plan must name narrower local validation when the heavy check is skipped."]
+
+      true ->
+        errors
+    end
+  end
+
+  defp no_narrower_local_evidence?(items), do: not Enum.any?(items, &(not heavy_check?(&1)))
+
+  defp local_validation_evidence?(item) do
+    normalized = normalize(item)
+
+    Regex.match?(@command_regex, item) and
+      not only_delegates_to_ci?(normalized) and
+      not skip_item?(normalized)
+  end
+
+  defp heavy_skip_items(section, unchecked_items) do
+    unchecked_heavy_items = Enum.filter(unchecked_items, &heavy_check?/1)
+
+    prose_skip_items =
+      section
+      |> String.split("\n")
+      |> Enum.map(&String.trim/1)
+      |> Enum.filter(fn line -> heavy_check?(line) and skip_item?(normalize(line)) end)
+
+    Enum.uniq(unchecked_heavy_items ++ prose_skip_items)
+  end
+
+  defp heavy_check?(text), do: Regex.match?(@heavy_check_regex, text)
+
+  defp checked_items(section), do: checkbox_items(section, @checked_checkbox_regex)
+
+  defp unchecked_items(section), do: checkbox_items(section, @unchecked_checkbox_regex)
+
+  defp checkbox_items(section, regex) do
+    regex
+    |> Regex.scan(section)
+    |> Enum.map(fn [_, item] -> String.trim(item) end)
+  end
+
+  defp skip_item?(normalized) do
+    Enum.any?(@skip_words, &String.contains?(normalized, &1))
+  end
+
+  defp only_delegates_to_ci?(normalized) do
+    String.contains?(normalized, "ci") and
+      not Regex.match?(~r/\b(mix|make|npm|pnpm|yarn|gh|test|format|check)\b/, normalized)
+  end
+
+  defp test_plan_section(body) do
+    with {heading_start, heading_length} <- first_match(@test_plan_heading_regex, body) do
+      content_start = heading_start + heading_length
+      content = binary_part(body, content_start, byte_size(body) - content_start)
+
+      case first_match(@heading_regex, content) do
+        nil -> content
+        {next_heading_start, _next_heading_length} -> binary_part(content, 0, next_heading_start)
+      end
+    end
+  end
+
+  defp first_match(regex, body) do
+    case Regex.run(regex, body, return: :index) do
+      [{first, length} | _] -> {first, length}
+      nil -> nil
+    end
+  end
+
+  defp normalize(text) do
+    text
+    |> String.downcase()
+    |> String.replace(~r/\s+/, " ")
+  end
+end

--- a/elixir/lib/symphony_elixir/codex/validation_evidence.ex
+++ b/elixir/lib/symphony_elixir/codex/validation_evidence.ex
@@ -7,6 +7,7 @@ defmodule SymphonyElixir.Codex.ValidationEvidence do
   @unchecked_checkbox_regex ~r/^\s*[-*]\s+\[ \]\s+(.+)$/m
   @heavy_check_regex ~r/(^|[^a-z0-9_-])(make(?:\.cmd)?\s+(-C\s+elixir\s+)?all|make-all)([^a-z0-9_-]|$)/i
   @ci_only_regex ~r/(?:(?:^\s*(?:ci|github actions?)\b\s*(?::|-|[a-z]+\b))|\bci[-\s]+only\b|\b(?:in|by|via|on|from)\s+(?:ci|github actions?)\b)/i
+  @unsuccessful_result_regex ~r/\b(?:failed|failing|errored|timed\s+out|timeout|timedout|cancelled|canceled)\b/i
   @skip_words ~w(skip skipped not cannot can't unable unavailable pending later)
   @restated_skip_words ~w(all cannot can't check gate heavy local locally make not run skipped to unable unavailable validation)
   @inline_code_regex ~r/`([^`]+)`/
@@ -62,6 +63,7 @@ defmodule SymphonyElixir.Codex.ValidationEvidence do
     has_validation_command?(item) and
       not only_delegates_to_ci?(normalized) and
       not ci_only_evidence?(item) and
+      not unsuccessful_result?(item) and
       not skip_item?(normalized)
   end
 
@@ -93,6 +95,8 @@ defmodule SymphonyElixir.Codex.ValidationEvidence do
   end
 
   defp ci_only_evidence?(item), do: Regex.match?(@ci_only_regex, item)
+
+  defp unsuccessful_result?(item), do: Regex.match?(@unsuccessful_result_regex, item)
 
   defp heavy_check?(text), do: Regex.match?(@heavy_check_regex, text)
 

--- a/elixir/test/mix/tasks/pr_body_check_test.exs
+++ b/elixir/test/mix/tasks/pr_body_check_test.exs
@@ -46,6 +46,7 @@ defmodule Mix.Tasks.PrBody.CheckTest do
 
   #### Test Plan
 
+  - [ ] `make -C elixir all` not run locally because this unit test fixture uses targeted validation only.
   - [x] `mix test test/mix/tasks/pr_body_check_test.exs` passed locally.
   """
 
@@ -159,6 +160,7 @@ defmodule Mix.Tasks.PrBody.CheckTest do
 
       #### Test Plan
 
+      - [ ] `make -C elixir all` not run locally because this fixture validates heading order only.
       - [x] Ran targeted checks.
       """
 
@@ -215,6 +217,7 @@ defmodule Mix.Tasks.PrBody.CheckTest do
 
       #### Test Plan
 
+      - [ ] `make -C elixir all` not run locally because this fixture validates section parsing only.
       - [x] Ran targeted checks.
       """
 
@@ -356,6 +359,45 @@ defmodule Mix.Tasks.PrBody.CheckTest do
     end)
   end
 
+  test "fails when checked Test Plan item only has backticked non-command prose" do
+    in_temp_repo(fn ->
+      write_template!(@template)
+
+      invalid_evidence = """
+      #### Context
+
+      Context text.
+
+      #### TL;DR
+
+      Short summary.
+
+      #### Summary
+
+      - First change.
+
+      #### Alternatives
+
+      - Alternative considered.
+
+      #### Test Plan
+
+      - [x] `README.md passed locally`
+      """
+
+      File.write!("body.md", invalid_evidence)
+
+      error_output =
+        capture_io(:stderr, fn ->
+          assert_raise Mix.Error, ~r/PR body format invalid/, fn ->
+            Check.run(["lint", "--file", "body.md"])
+          end
+        end)
+
+      assert error_output =~ "Test Plan must include at least one checked local validation command or targeted check"
+    end)
+  end
+
   test "passes with valid targeted local evidence without requiring make all" do
     in_temp_repo(fn ->
       write_template!(@template)
@@ -379,6 +421,7 @@ defmodule Mix.Tasks.PrBody.CheckTest do
 
       #### Test Plan
 
+      - [ ] `make -C elixir all` not run locally because this test exercises targeted evidence.
       - [x] `mix test test/mix/tasks/pr_body_check_test.exs` passed locally.
       """
 
@@ -390,6 +433,85 @@ defmodule Mix.Tasks.PrBody.CheckTest do
         end)
 
       assert output =~ "PR body format OK"
+    end)
+  end
+
+  test "fails when targeted evidence omits heavy validation or skip justification" do
+    in_temp_repo(fn ->
+      write_template!(@template)
+
+      missing_heavy_gate = """
+      #### Context
+
+      Context text.
+
+      #### TL;DR
+
+      Short summary.
+
+      #### Summary
+
+      - First change.
+
+      #### Alternatives
+
+      - Alternative considered.
+
+      #### Test Plan
+
+      - [x] `mix test test/mix/tasks/pr_body_check_test.exs` passed locally.
+      """
+
+      File.write!("body.md", missing_heavy_gate)
+
+      error_output =
+        capture_io(:stderr, fn ->
+          assert_raise Mix.Error, ~r/PR body format invalid/, fn ->
+            Check.run(["lint", "--file", "body.md"])
+          end
+        end)
+
+      assert error_output =~ "Test Plan must explain why the heavy local validation check was not run"
+    end)
+  end
+
+  test "fails when checked validation command only ran in CI" do
+    in_temp_repo(fn ->
+      write_template!(@template)
+
+      ci_only_evidence = """
+      #### Context
+
+      Context text.
+
+      #### TL;DR
+
+      Short summary.
+
+      #### Summary
+
+      - First change.
+
+      #### Alternatives
+
+      - Alternative considered.
+
+      #### Test Plan
+
+      - [ ] `make -C elixir all` not run locally because the full gate is unavailable.
+      - [x] `mix test test/mix/tasks/pr_body_check_test.exs` passed in CI.
+      """
+
+      File.write!("body.md", ci_only_evidence)
+
+      error_output =
+        capture_io(:stderr, fn ->
+          assert_raise Mix.Error, ~r/PR body format invalid/, fn ->
+            Check.run(["lint", "--file", "body.md"])
+          end
+        end)
+
+      assert error_output =~ "Test Plan must include at least one checked local validation command or targeted check"
     end)
   end
 

--- a/elixir/test/mix/tasks/pr_body_check_test.exs
+++ b/elixir/test/mix/tasks/pr_body_check_test.exs
@@ -515,6 +515,46 @@ defmodule Mix.Tasks.PrBody.CheckTest do
     end)
   end
 
+  test "fails when checked validation command reports a local failure" do
+    in_temp_repo(fn ->
+      write_template!(@template)
+
+      failed_evidence = """
+      #### Context
+
+      Context text.
+
+      #### TL;DR
+
+      Short summary.
+
+      #### Summary
+
+      - First change.
+
+      #### Alternatives
+
+      - Alternative considered.
+
+      #### Test Plan
+
+      - [ ] `make -C elixir all` not run locally because the focused check failed first.
+      - [x] `mix test test/mix/tasks/pr_body_check_test.exs` failed locally.
+      """
+
+      File.write!("body.md", failed_evidence)
+
+      error_output =
+        capture_io(:stderr, fn ->
+          assert_raise Mix.Error, ~r/PR body format invalid/, fn ->
+            Check.run(["lint", "--file", "body.md"])
+          end
+        end)
+
+      assert error_output =~ "Test Plan must include at least one checked local validation command or targeted check"
+    end)
+  end
+
   test "passes when skipped heavy validation is justified with narrower local evidence" do
     in_temp_repo(fn ->
       write_template!(@template)

--- a/elixir/test/mix/tasks/pr_body_check_test.exs
+++ b/elixir/test/mix/tasks/pr_body_check_test.exs
@@ -46,7 +46,7 @@ defmodule Mix.Tasks.PrBody.CheckTest do
 
   #### Test Plan
 
-  - [x] Ran targeted checks.
+  - [x] `mix test test/mix/tasks/pr_body_check_test.exs` passed locally.
   """
 
   setup do
@@ -313,6 +313,161 @@ defmodule Mix.Tasks.PrBody.CheckTest do
         end)
 
       assert output =~ "PR body format OK"
+    end)
+  end
+
+  test "fails when Test Plan has no checked local validation evidence" do
+    in_temp_repo(fn ->
+      write_template!(@template)
+
+      missing_evidence = """
+      #### Context
+
+      Context text.
+
+      #### TL;DR
+
+      Short summary.
+
+      #### Summary
+
+      - First change.
+
+      #### Alternatives
+
+      - Alternative considered.
+
+      #### Test Plan
+
+      - [ ] `make -C elixir all`
+      - CI will validate this later.
+      """
+
+      File.write!("body.md", missing_evidence)
+
+      error_output =
+        capture_io(:stderr, fn ->
+          assert_raise Mix.Error, ~r/PR body format invalid/, fn ->
+            Check.run(["lint", "--file", "body.md"])
+          end
+        end)
+
+      assert error_output =~ "Test Plan must include at least one checked local validation command or targeted check"
+    end)
+  end
+
+  test "passes with valid targeted local evidence without requiring make all" do
+    in_temp_repo(fn ->
+      write_template!(@template)
+
+      targeted_evidence = """
+      #### Context
+
+      Context text.
+
+      #### TL;DR
+
+      Short summary.
+
+      #### Summary
+
+      - First change.
+
+      #### Alternatives
+
+      - Alternative considered.
+
+      #### Test Plan
+
+      - [x] `mix test test/mix/tasks/pr_body_check_test.exs` passed locally.
+      """
+
+      File.write!("body.md", targeted_evidence)
+
+      output =
+        capture_io(fn ->
+          Check.run(["lint", "--file", "body.md"])
+        end)
+
+      assert output =~ "PR body format OK"
+    end)
+  end
+
+  test "passes when skipped heavy validation is justified with narrower local evidence" do
+    in_temp_repo(fn ->
+      write_template!(@template)
+
+      justified_skip = """
+      #### Context
+
+      Context text.
+
+      #### TL;DR
+
+      Short summary.
+
+      #### Summary
+
+      - First change.
+
+      #### Alternatives
+
+      - Alternative considered.
+
+      #### Test Plan
+
+      - [ ] `make -C elixir all` not run locally because dependency install is unavailable in this workspace.
+      - [x] `mix test test/mix/tasks/pr_body_check_test.exs` passed locally as narrower validation.
+      """
+
+      File.write!("body.md", justified_skip)
+
+      output =
+        capture_io(fn ->
+          Check.run(["lint", "--file", "body.md"])
+        end)
+
+      assert output =~ "PR body format OK"
+    end)
+  end
+
+  test "fails when skipped heavy validation reason is only attached to targeted evidence" do
+    in_temp_repo(fn ->
+      write_template!(@template)
+
+      misplaced_reason = """
+      #### Context
+
+      Context text.
+
+      #### TL;DR
+
+      Short summary.
+
+      #### Summary
+
+      - First change.
+
+      #### Alternatives
+
+      - Alternative considered.
+
+      #### Test Plan
+
+      - [ ] `make -C elixir all`
+      - [x] `mix test test/mix/tasks/pr_body_check_test.exs` passed locally because it covers the changed code.
+      """
+
+      File.write!("body.md", misplaced_reason)
+
+      error_output =
+        capture_io(:stderr, fn ->
+          assert_raise Mix.Error, ~r/PR body format invalid/, fn ->
+            Check.run(["lint", "--file", "body.md"])
+          end
+        end)
+
+      assert error_output =~ "Test Plan must explain why the heavy local validation check was not run"
     end)
   end
 

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -1130,6 +1130,107 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     assert body =~ "make-all=check:in_progress"
   end
 
+  test "linear_graphql rejects In Review transition when linked PR lacks local validation evidence" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{
+              "body" => """
+              #### Context
+
+              Context text.
+
+              #### TL;DR
+
+              Summary.
+
+              #### Summary
+
+              - Change.
+
+              #### Alternatives
+
+              - None.
+
+              #### Test Plan
+
+              - [ ] `make -C elixir all`
+              - CI will validate this later.
+              """,
+              "head" => %{"sha" => "abc123"},
+              "base" => %{"ref" => "main"}
+            },
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{"check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]}
+          })
+      )
+
+    assert response["success"] == false
+    assert Jason.decode!(response["output"])["error"]["message"] =~ "local validation evidence is missing"
+    assert_received {:workpad_recorded, body}
+    assert body =~ "local validation evidence is missing"
+    refute_received {:linear_mutation_allowed, _, _}
+  end
+
+  test "linear_graphql accepts targeted local evidence without requiring local make all" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{
+              "body" => targeted_validation_pr_body(),
+              "head" => %{"sha" => "abc123"},
+              "base" => %{"ref" => "main"}
+            },
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{"check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]}
+          })
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
+    refute_received {:workpad_recorded, _}
+  end
+
+  test "linear_graphql accepts justified skipped heavy validation with narrower local evidence" do
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue_with_pr()),
+        github_client:
+          github_client(%{
+            "pulls/42" => %{
+              "body" => justified_skip_pr_body(),
+              "head" => %{"sha" => "abc123"},
+              "base" => %{"ref" => "main"}
+            },
+            "branches/main/protection/required_status_checks" => %{"contexts" => ["make-all"]},
+            "commits/abc123/status" => %{"statuses" => []},
+            "commits/abc123/check-runs" => %{"check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]}
+          })
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
+    refute_received {:workpad_recorded, _}
+  end
+
   test "linear_graphql rejects In Review transition when required checks fail" do
     test_pid = self()
 
@@ -1559,6 +1660,7 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
         |> Map.put_new("sha", "base123")
 
       payload
+      |> Map.put_new("body", targeted_validation_pr_body())
       |> put_in(["head"], default_head)
       |> put_in(["base"], default_base)
     else
@@ -1567,6 +1669,55 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
   end
 
   defp default_pr_payload(_url, payload), do: payload
+
+  defp targeted_validation_pr_body do
+    """
+    #### Context
+
+    Context text.
+
+    #### TL;DR
+
+    Summary.
+
+    #### Summary
+
+    - Change.
+
+    #### Alternatives
+
+    - None.
+
+    #### Test Plan
+
+    - [x] `mix test test/symphony_elixir/dynamic_tool_test.exs` passed locally.
+    """
+  end
+
+  defp justified_skip_pr_body do
+    """
+    #### Context
+
+    Context text.
+
+    #### TL;DR
+
+    Summary.
+
+    #### Summary
+
+    - Change.
+
+    #### Alternatives
+
+    - None.
+
+    #### Test Plan
+
+    - [ ] `make -C elixir all` not run locally because this test simulates a narrower handoff.
+    - [x] `mix test test/symphony_elixir/dynamic_tool_test.exs` passed locally as narrower validation.
+    """
+  end
 
   defp default_github_response(url) do
     cond do

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -106,7 +106,7 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
         github_client:
           github_client(%{
             "pulls/42" => %{
-              "body" => "#### Context\n\nImplements the linked spec.\n\nFixes #46",
+              "body" => with_validation_evidence("#### Context\n\nImplements the linked spec.\n\nFixes #46"),
               "head" => %{"sha" => "abc123"},
               "base" => %{"ref" => "main"}
             },
@@ -132,7 +132,7 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
         github_client:
           github_client(%{
             "pulls/42" => %{
-              "body" => "#### Context\n\nImplements the linked spec.\n\nFixes albert-zen/symphony-windows-native#46",
+              "body" => with_validation_evidence("#### Context\n\nImplements the linked spec.\n\nFixes albert-zen/symphony-windows-native#46"),
               "head" => %{"sha" => "abc123"},
               "base" => %{"ref" => "main"}
             },
@@ -160,7 +160,7 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
         github_client:
           github_client(%{
             "pulls/42" => %{
-              "body" => "#### Context\n\nImplements the linked spec.\n\nFixes: #46",
+              "body" => with_validation_evidence("#### Context\n\nImplements the linked spec.\n\nFixes: #46"),
               "head" => %{"sha" => "abc123"},
               "base" => %{"ref" => "main"}
             },
@@ -215,7 +215,7 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
         github_client:
           github_client(%{
             "pulls/42" => %{
-              "body" => "#### Context\n\nImplements the linked spec without a closing keyword.",
+              "body" => with_validation_evidence("#### Context\n\nImplements the linked spec without a closing keyword."),
               "head" => %{"sha" => "abc123"},
               "base" => %{"ref" => "main"}
             }
@@ -240,7 +240,7 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
         github_client:
           github_client(%{
             "pulls/42" => %{
-              "body" => "#### Context\n\nImplements the linked spec without a closing keyword.",
+              "body" => with_validation_evidence("#### Context\n\nImplements the linked spec without a closing keyword."),
               "head" => %{"sha" => "abc123"},
               "base" => %{"ref" => "main"}
             }
@@ -265,7 +265,7 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
         github_client:
           github_client(%{
             "pulls/42" => %{
-              "body" => "#### Context\n\nImplements the linked spec without a closing keyword.",
+              "body" => with_validation_evidence("#### Context\n\nImplements the linked spec without a closing keyword."),
               "head" => %{"sha" => "abc123"},
               "base" => %{"ref" => "main"}
             }
@@ -2082,6 +2082,8 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
   end
 
   defp passing_review_readiness_responses(pr_payload) do
+    pr_payload = Map.update(pr_payload, "body", targeted_validation_pr_body(), &with_validation_evidence/1)
+
     %{
       "pulls/42" =>
         Map.merge(
@@ -2094,6 +2096,17 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
         "check_runs" => [%{"name" => "make-all", "status" => "completed", "conclusion" => "success"}]
       }
     }
+  end
+
+  defp with_validation_evidence(body) do
+    body <>
+      """
+
+      #### Test Plan
+
+      - [ ] `make -C elixir all` not run locally because this test simulates targeted review-readiness validation.
+      - [x] `mix test test/symphony_elixir/dynamic_tool_test.exs` passed locally.
+      """
   end
 
   defp default_pr_payload(url, %{"head" => head} = payload) when is_map(head) do

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -1690,6 +1690,7 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
 
     #### Test Plan
 
+    - [ ] `make -C elixir all` not run locally because this test simulates targeted review-readiness validation.
     - [x] `mix test test/symphony_elixir/dynamic_tool_test.exs` passed locally.
     """
   end

--- a/elixir/test/symphony_elixir/validation_evidence_test.exs
+++ b/elixir/test/symphony_elixir/validation_evidence_test.exs
@@ -200,6 +200,35 @@ defmodule SymphonyElixir.Codex.ValidationEvidenceTest do
            ]
   end
 
+  test "rejects checked validation commands reported as unsuccessful" do
+    for result <- ["failed locally", "errored locally", "timed out locally", "canceled locally", "cancelled locally"] do
+      body = """
+      #### Test Plan
+
+      - [ ] `make -C elixir all` not run locally because this test checks unsuccessful evidence rejection.
+      - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` #{result}.
+      """
+
+      assert ValidationEvidence.lint_pr_body(body) == [
+               "Test Plan must include at least one checked local validation command or targeted check.",
+               "Test Plan must name narrower local validation when the heavy check is skipped."
+             ]
+    end
+  end
+
+  test "rejects checked heavy validation reported as unsuccessful" do
+    body = """
+    #### Test Plan
+
+    - [x] `make -C elixir all` failed locally.
+    - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed locally.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must explain why the heavy local validation check was not run."
+           ]
+  end
+
   test "accepts unbackticked targeted validation commands" do
     body = """
     #### Test Plan

--- a/elixir/test/symphony_elixir/validation_evidence_test.exs
+++ b/elixir/test/symphony_elixir/validation_evidence_test.exs
@@ -82,6 +82,21 @@ defmodule SymphonyElixir.Codex.ValidationEvidenceTest do
     end
   end
 
+  test "rejects inability words as because and due to reasons" do
+    for reason <- ["because cannot", "because can't", "because unable", "because unavailable", "due to unavailable"] do
+      body = """
+      #### Test Plan
+
+      - [ ] `make -C elixir all` not run locally #{reason}.
+      - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed locally.
+      """
+
+      assert ValidationEvidence.lint_pr_body(body) == [
+               "Test Plan must explain why the heavy local validation check was not run."
+             ]
+    end
+  end
+
   test "accepts concrete inability reason for skipped heavy validation" do
     body = """
     #### Test Plan

--- a/elixir/test/symphony_elixir/validation_evidence_test.exs
+++ b/elixir/test/symphony_elixir/validation_evidence_test.exs
@@ -3,6 +3,18 @@ defmodule SymphonyElixir.Codex.ValidationEvidenceTest do
 
   alias SymphonyElixir.Codex.ValidationEvidence
 
+  test "requires a Test Plan section" do
+    body = """
+    #### Summary
+
+    - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed locally.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "PR body must include a Test Plan section with local validation evidence."
+           ]
+  end
+
   test "reports skipped heavy validation without narrower local evidence" do
     body = """
     #### Test Plan
@@ -16,15 +28,145 @@ defmodule SymphonyElixir.Codex.ValidationEvidenceTest do
            ]
   end
 
+  test "reports skipped heavy validation without a reason" do
+    body = """
+    #### Test Plan
+
+    - [ ] `make -C elixir all`
+    - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed locally.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must explain why the heavy local validation check was not run."
+           ]
+  end
+
+  test "accepts justified skipped heavy validation with narrower local evidence" do
+    body = """
+    #### Test Plan
+
+    - [ ] `make -C elixir all` not run locally because the full gate is unavailable.
+    - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed locally.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == []
+  end
+
   test "rejects checked commands that only delegate validation to CI" do
     body = """
     #### Test Plan
 
+    - [ ] `make -C elixir all` not run locally because this test checks CI-only evidence rejection.
     - [x] `ruff` in CI.
     """
 
     assert ValidationEvidence.lint_pr_body(body) == [
-             "Test Plan must include at least one checked local validation command or targeted check."
+             "Test Plan must include at least one checked local validation command or targeted check.",
+             "Test Plan must name narrower local validation when the heavy check is skipped."
+           ]
+  end
+
+  test "accepts recognized CI inspection commands when run locally" do
+    body = """
+    #### Test Plan
+
+    - [ ] `make -C elixir all` not run locally because only CI failure inspection was needed.
+    - [x] `gh run view 25243442043 --log-failed` used locally to inspect CI failure evidence.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == []
+  end
+
+  test "rejects checked backticked prose that is not a validation command" do
+    body = """
+    #### Test Plan
+
+    - [ ] `make -C elixir all` not run locally because this test checks non-command evidence rejection.
+    - [x] `README.md passed locally`
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must include at least one checked local validation command or targeted check.",
+             "Test Plan must name narrower local validation when the heavy check is skipped."
+           ]
+  end
+
+  test "accepts unbackticked targeted validation commands" do
+    body = """
+    #### Test Plan
+
+    - [ ] `make -C elixir all` not run locally because this change only touched validation evidence parsing.
+    - [x] mix test test/symphony_elixir/validation_evidence_test.exs passed locally.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == []
+  end
+
+  test "rejects targeted local evidence without heavy validation or skip justification" do
+    body = """
+    #### Test Plan
+
+    - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed locally.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must explain why the heavy local validation check was not run."
+           ]
+  end
+
+  test "rejects validation commands reported only from CI" do
+    body = """
+    #### Test Plan
+
+    - [ ] `make -C elixir all` not run locally because CI reported the broader gate.
+    - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed in CI.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must include at least one checked local validation command or targeted check.",
+             "Test Plan must name narrower local validation when the heavy check is skipped."
+           ]
+  end
+
+  test "rejects validation commands where CI is the actor" do
+    body = """
+    #### Test Plan
+
+    - [ ] `make -C elixir all` not run locally because GitHub Actions reported the broader gate.
+    - [x] CI ran `mix test test/symphony_elixir/validation_evidence_test.exs`.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must include at least one checked local validation command or targeted check.",
+             "Test Plan must name narrower local validation when the heavy check is skipped."
+           ]
+  end
+
+  test "rejects validation commands under CI status labels" do
+    body = """
+    #### Test Plan
+
+    - [ ] `make -C elixir all` not run locally because CI reported the broader gate.
+    - [x] CI: `mix test test/symphony_elixir/validation_evidence_test.exs` passed.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must include at least one checked local validation command or targeted check.",
+             "Test Plan must name narrower local validation when the heavy check is skipped."
+           ]
+  end
+
+  test "rejects validation commands where CI uses another actor verb" do
+    body = """
+    #### Test Plan
+
+    - [ ] `make -C elixir all` not run locally because CI reported the broader gate.
+    - [x] CI executed `mix test test/symphony_elixir/validation_evidence_test.exs` successfully.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must include at least one checked local validation command or targeted check.",
+             "Test Plan must name narrower local validation when the heavy check is skipped."
            ]
   end
 
@@ -32,6 +174,7 @@ defmodule SymphonyElixir.Codex.ValidationEvidenceTest do
     body = """
     #### Test Plan
 
+    - [x] `make -C elixir all` passed locally.
     - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed locally.
 
     #### Notes

--- a/elixir/test/symphony_elixir/validation_evidence_test.exs
+++ b/elixir/test/symphony_elixir/validation_evidence_test.exs
@@ -97,6 +97,21 @@ defmodule SymphonyElixir.Codex.ValidationEvidenceTest do
     end
   end
 
+  test "rejects filler-only inability phrases" do
+    for reason <- ["cannot run", "unable to run", "unavailable to run"] do
+      body = """
+      #### Test Plan
+
+      - [ ] `make -C elixir all` #{reason}.
+      - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed locally.
+      """
+
+      assert ValidationEvidence.lint_pr_body(body) == [
+               "Test Plan must explain why the heavy local validation check was not run."
+             ]
+    end
+  end
+
   test "accepts concrete inability reason for skipped heavy validation" do
     body = """
     #### Test Plan
@@ -143,7 +158,7 @@ defmodule SymphonyElixir.Codex.ValidationEvidenceTest do
            ]
   end
 
-  test "accepts recognized CI inspection commands when run locally" do
+  test "rejects CI inspection commands as local validation evidence" do
     body = """
     #### Test Plan
 
@@ -151,7 +166,24 @@ defmodule SymphonyElixir.Codex.ValidationEvidenceTest do
     - [x] `gh run view 25243442043 --log-failed` used locally to inspect CI failure evidence.
     """
 
-    assert ValidationEvidence.lint_pr_body(body) == []
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must include at least one checked local validation command or targeted check.",
+             "Test Plan must name narrower local validation when the heavy check is skipped."
+           ]
+  end
+
+  test "rejects gh pr checks as local validation evidence" do
+    body = """
+    #### Test Plan
+
+    - [ ] `make -C elixir all` not run locally because only CI failure inspection was needed.
+    - [x] `gh pr checks 57` used locally to inspect CI failure evidence.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must include at least one checked local validation command or targeted check.",
+             "Test Plan must name narrower local validation when the heavy check is skipped."
+           ]
   end
 
   test "rejects checked backticked prose that is not a validation command" do
@@ -216,6 +248,45 @@ defmodule SymphonyElixir.Codex.ValidationEvidenceTest do
     assert ValidationEvidence.lint_pr_body(body) == [
              "Test Plan must include at least one checked local validation command or targeted check.",
              "Test Plan must name narrower local validation when the heavy check is skipped."
+           ]
+  end
+
+  test "rejects checked heavy validation reported only from CI" do
+    body = """
+    #### Test Plan
+
+    - [x] `make -C elixir all` passed in CI.
+    - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed locally.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must explain why the heavy local validation check was not run."
+           ]
+  end
+
+  test "rejects checked heavy validation reported as CI-only" do
+    body = """
+    #### Test Plan
+
+    - [x] `make -C elixir all` CI-only.
+    - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed locally.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must explain why the heavy local validation check was not run."
+           ]
+  end
+
+  test "rejects checked make-all reported only from CI" do
+    body = """
+    #### Test Plan
+
+    - [x] `make-all` passed in CI.
+    - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed locally.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must explain why the heavy local validation check was not run."
            ]
   end
 

--- a/elixir/test/symphony_elixir/validation_evidence_test.exs
+++ b/elixir/test/symphony_elixir/validation_evidence_test.exs
@@ -67,6 +67,32 @@ defmodule SymphonyElixir.Codex.ValidationEvidenceTest do
            ]
   end
 
+  test "rejects bare inability words as skipped heavy validation reasons" do
+    for word <- ["cannot", "can't", "unable", "unavailable"] do
+      body = """
+      #### Test Plan
+
+      - [ ] `make -C elixir all` #{word}.
+      - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed locally.
+      """
+
+      assert ValidationEvidence.lint_pr_body(body) == [
+               "Test Plan must explain why the heavy local validation check was not run."
+             ]
+    end
+  end
+
+  test "accepts concrete inability reason for skipped heavy validation" do
+    body = """
+    #### Test Plan
+
+    - [ ] `make -C elixir all` unavailable while the Windows-only shell profile is isolated in CI.
+    - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed locally.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == []
+  end
+
   test "accepts justified skipped heavy validation with narrower local evidence" do
     body = """
     #### Test Plan

--- a/elixir/test/symphony_elixir/validation_evidence_test.exs
+++ b/elixir/test/symphony_elixir/validation_evidence_test.exs
@@ -41,12 +41,48 @@ defmodule SymphonyElixir.Codex.ValidationEvidenceTest do
            ]
   end
 
+  test "rejects skipped heavy validation that only restates it was not run" do
+    body = """
+    #### Test Plan
+
+    - [ ] `make -C elixir all` not run locally.
+    - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed locally.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must explain why the heavy local validation check was not run."
+           ]
+  end
+
+  test "rejects skipped heavy validation with because plus only skip wording" do
+    body = """
+    #### Test Plan
+
+    - [ ] `make -C elixir all` not run locally because skipped.
+    - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed locally.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must explain why the heavy local validation check was not run."
+           ]
+  end
+
   test "accepts justified skipped heavy validation with narrower local evidence" do
     body = """
     #### Test Plan
 
     - [ ] `make -C elixir all` not run locally because the full gate is unavailable.
     - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed locally.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == []
+  end
+
+  test "accepts make.cmd all as the heavy local validation gate" do
+    body = """
+    #### Test Plan
+
+    - [x] `make.cmd all` passed locally.
     """
 
     assert ValidationEvidence.lint_pr_body(body) == []
@@ -120,6 +156,34 @@ defmodule SymphonyElixir.Codex.ValidationEvidenceTest do
 
     - [ ] `make -C elixir all` not run locally because CI reported the broader gate.
     - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed in CI.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must include at least one checked local validation command or targeted check.",
+             "Test Plan must name narrower local validation when the heavy check is skipped."
+           ]
+  end
+
+  test "rejects validation commands reported as results from CI" do
+    body = """
+    #### Test Plan
+
+    - [ ] `make -C elixir all` not run locally because CI reported the broader gate.
+    - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` results from CI.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must include at least one checked local validation command or targeted check.",
+             "Test Plan must name narrower local validation when the heavy check is skipped."
+           ]
+  end
+
+  test "rejects validation commands reported as GitHub Actions results" do
+    body = """
+    #### Test Plan
+
+    - [ ] `make -C elixir all` not run locally because GitHub Actions reported the broader gate.
+    - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` results from GitHub Actions.
     """
 
     assert ValidationEvidence.lint_pr_body(body) == [

--- a/elixir/test/symphony_elixir/validation_evidence_test.exs
+++ b/elixir/test/symphony_elixir/validation_evidence_test.exs
@@ -1,0 +1,44 @@
+defmodule SymphonyElixir.Codex.ValidationEvidenceTest do
+  use ExUnit.Case, async: true
+
+  alias SymphonyElixir.Codex.ValidationEvidence
+
+  test "reports skipped heavy validation without narrower local evidence" do
+    body = """
+    #### Test Plan
+
+    - [ ] `make -C elixir all` not run locally because the full gate is unavailable.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must include at least one checked local validation command or targeted check.",
+             "Test Plan must name narrower local validation when the heavy check is skipped."
+           ]
+  end
+
+  test "rejects checked commands that only delegate validation to CI" do
+    body = """
+    #### Test Plan
+
+    - [x] `ruff` in CI.
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == [
+             "Test Plan must include at least one checked local validation command or targeted check."
+           ]
+  end
+
+  test "stops Test Plan parsing at the next markdown heading" do
+    body = """
+    #### Test Plan
+
+    - [x] `mix test test/symphony_elixir/validation_evidence_test.exs` passed locally.
+
+    #### Notes
+
+    - [ ] `make -C elixir all`
+    """
+
+    assert ValidationEvidence.lint_pr_body(body) == []
+  end
+end


### PR DESCRIPTION
#### Context

ALB-33 hardens the PR handoff gate so CI-only, non-command, or unsuccessful evidence cannot satisfy local validation requirements.

Fixes #50

#### TL;DR

*Require successful local validation evidence before review handoff.*

#### Summary

- Require checked heavy-gate evidence to be accepted successful local validation before it satisfies the heavy gate.
- Stop counting `gh pr checks` and `gh run view` as local validation evidence.
- Reject CI-only heavy-gate results, filler-only skip reasons such as `unable to run`, and checked commands reported as failed/errored/timed out/canceled.
- Add regressions for the manager/SubAgent review blockers and update merged readiness fixtures so the new gate composes with origin-issue enforcement.

#### Alternatives

- Kept targeted local checks allowed when the heavy gate has a concrete local skip reason.
- Treated GitHub CLI check inspection as supplemental CI context, not as local validation evidence.

#### Test Plan

- [x] `mix format lib/symphony_elixir/codex/review_readiness.ex lib/symphony_elixir/codex/validation_evidence.ex test/symphony_elixir/validation_evidence_test.exs test/mix/tasks/pr_body_check_test.exs test/symphony_elixir/review_readiness_test.exs test/symphony_elixir/dynamic_tool_test.exs` passed locally.
- [x] `mix test test/symphony_elixir/validation_evidence_test.exs test/mix/tasks/pr_body_check_test.exs test/symphony_elixir/review_readiness_test.exs` passed locally: 55 tests, 0 failures.
- [x] `mix test test/symphony_elixir/dynamic_tool_test.exs` passed locally: 71 tests, 0 failures.
- [x] `git diff --check` passed locally.
- [x] `make windows-native-test` passed locally after merging `origin/main`: 113 tests, 0 failures, 14 skipped.
- [x] `make all` passed locally after fixing the merged readiness fixtures.
- [x] Independent SubAgent review passed after fixing the failed-evidence blocker; final result had no blocking findings.