### PR TITLE
fix(linear): keep claim visibility test lease active

### DIFF
--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -366,7 +366,7 @@ defmodule SymphonyElixir.ExtensionsTest do
 
   test "linear adapter acquires visible claim when this worker owns the oldest active lease" do
     Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
-    now = ~U[2026-05-02 00:00:00Z]
+    now = DateTime.add(DateTime.utc_now(), -60, :second)
 
     Process.put({FakeLinearClient, :graphql_result}, fn query, variables ->
       cond do


### PR DESCRIPTION
#### Context

GH #58 reports make-all became date-dependent after the fixed synthetic Linear claim timestamp expired.

#### TL;DR

*Keep the synthetic claim comment timestamp relative to test runtime.*

#### Summary

- Use a runtime-relative fake Linear comment `createdAt` for the visible claim fixture.
- Preserve the adapter path that clamps leases to the trusted Linear comment timestamp.
- Keep the change scoped to the time-dependent test fixture for GH #58 / ALB-38.

#### Alternatives

- Injecting an adapter clock would be broader production/test infrastructure for this fixture.
- Extending the lease TTL would weaken the behavior under test.

#### Test Plan

- [ ] `make -C elixir all`
- [x] `mise exec -- mix test test/symphony_elixir/extensions_test.exs` (28 tests, 0 failures)
- [x] `mise exec -- mix format test/symphony_elixir/extensions_test.exs`
- [x] `make all` attempted from `elixir/`; failed in unrelated `OrchestratorStatusTest` offline-render assertions at `test/symphony_elixir/orchestrator_status_test.exs:1437` and `:2044`, then coverage reported 93.94% below the 100% threshold.
- [x] `mise exec -- mix test test/symphony_elixir/orchestrator_status_test.exs:1437 test/symphony_elixir/orchestrator_status_test.exs:2044` reproduced the unrelated two failures.