### PR TITLE
fix(windows): preserve unicode log formatter output

### DIFF
--- a/elixir/lib/symphony_elixir/log_file.ex
+++ b/elixir/lib/symphony_elixir/log_file.ex
@@ -97,7 +97,7 @@ defmodule SymphonyElixir.LogFile.Formatter do
     log_event
     |> put_in([:meta, :event_id], Map.get_lazy(metadata, :event_id, &event_id/0))
     |> :logger_formatter.format(config)
-    |> IO.iodata_to_binary()
+    |> unicode_chardata_to_string()
     |> sanitize()
   end
 
@@ -109,6 +109,10 @@ defmodule SymphonyElixir.LogFile.Formatter do
     |> String.replace(@carriage_return_pattern, "")
     |> String.replace("\r\n", "\n")
     |> String.replace(@control_pattern, "")
+  end
+
+  defp unicode_chardata_to_string(chardata) do
+    :unicode.characters_to_binary(chardata)
   end
 
   defp event_id do

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -5,6 +5,7 @@ defmodule SymphonyElixir.ExtensionsTest do
   import Phoenix.LiveViewTest
 
   alias SymphonyElixir.Linear.Adapter
+  alias SymphonyElixir.LogFile.Formatter
   alias SymphonyElixir.Tracker.Memory
 
   @endpoint SymphonyElixirWeb.Endpoint
@@ -1154,6 +1155,38 @@ defmodule SymphonyElixir.ExtensionsTest do
     refute html =~ "4m "
   end
 
+  test "dashboard liveview requests log unicode timings through the file formatter" do
+    orchestrator_name = Module.concat(__MODULE__, :DashboardFormatterOrchestrator)
+
+    {:ok, _pid} =
+      StaticOrchestrator.start_link(
+        name: orchestrator_name,
+        snapshot: static_snapshot()
+      )
+
+    start_test_endpoint(orchestrator: orchestrator_name, snapshot_timeout_ms: 50)
+
+    log =
+      with_file_log_handler(fn ->
+        :logger.log(:debug, {"Replied in ~B~ts", [409, ~c"µs"]}, %{request_path: "/"})
+        {:ok, _index_view, index_html} = live(build_conn(), "/")
+
+        :logger.log(:debug, {"Replied in ~B~ts", [512, ~c"µs"]}, %{
+          request_path: "/workers/MT-HTTP"
+        })
+
+        {:ok, _detail_view, detail_html} = live(build_conn(), "/workers/MT-HTTP")
+
+        assert index_html =~ "Operations Dashboard"
+        assert detail_html =~ "Worker Detail"
+      end)
+
+    assert log =~ "Replied in 409µs"
+    assert log =~ "Replied in 512µs"
+    assert String.valid?(log)
+    refute log =~ "FORMATTER ERROR"
+  end
+
   test "worker detail liveview renders timeline and submits session-scoped steer messages" do
     orchestrator_name = Module.concat(__MODULE__, :WorkerDetailOrchestrator)
 
@@ -1399,6 +1432,35 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     Application.put_env(:symphony_elixir, SymphonyElixirWeb.Endpoint, endpoint_config)
     start_supervised!({SymphonyElixirWeb.Endpoint, []})
+  end
+
+  defp with_file_log_handler(fun) do
+    path = Path.join(System.tmp_dir!(), "symphony-dashboard-log-#{System.unique_integer([:positive])}.log")
+    handler_id = :"symphony_dashboard_log_test_#{System.unique_integer([:positive])}"
+    primary_level = :logger.get_primary_config() |> Map.fetch!(:level)
+
+    :ok =
+      :logger.add_handler(handler_id, :logger_std_h, %{
+        level: :debug,
+        formatter:
+          {Formatter,
+           %{
+             single_line: true,
+             template: [:time, " ", :level, " event_id=", :event_id, " ", :msg, "\n"]
+           }},
+        config: %{type: {:file, String.to_charlist(path)}}
+      })
+
+    try do
+      :ok = :logger.set_primary_config(:level, :debug)
+      fun.()
+      :ok = :logger.remove_handler(handler_id)
+      File.read!(path)
+    after
+      :logger.remove_handler(handler_id)
+      :logger.set_primary_config(:level, primary_level)
+      File.rm(path)
+    end
   end
 
   defp static_snapshot do

--- a/elixir/test/symphony_elixir/log_file_test.exs
+++ b/elixir/test/symphony_elixir/log_file_test.exs
@@ -1,5 +1,5 @@
 defmodule SymphonyElixir.LogFileTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias SymphonyElixir.LogFile
   alias SymphonyElixir.LogFile.Formatter
@@ -52,5 +52,56 @@ defmodule SymphonyElixir.LogFileTest do
     assert line =~ " info event_id=event-123 progress 10%progress 20%progress complete\n"
     refute line =~ "\r"
     assert String.ends_with?(line, "\n")
+  end
+
+  test "file logger formatter emits unicode duration units as valid UTF-8" do
+    event = %{
+      level: :debug,
+      msg: {"Replied in ~B~ts", [409, ~c"µs"]},
+      meta: %{time: 1_771_000_000_000_000, event_id: ~c"event-456"}
+    }
+
+    line =
+      Formatter.format(event, %{
+        single_line: true,
+        template: [:time, " ", :level, " event_id=", :event_id, " ", :msg, "\n"]
+      })
+
+    assert line =~ " debug event_id=event-456 Replied in 409µs\n"
+    assert String.valid?(line)
+  end
+
+  test "file logger handler writes unicode duration units without formatter errors" do
+    path = Path.join(System.tmp_dir!(), "symphony-log-file-#{System.unique_integer([:positive])}.log")
+    handler_id = :"symphony_log_file_test_#{System.unique_integer([:positive])}"
+    primary_level = :logger.get_primary_config() |> Map.fetch!(:level)
+
+    :ok =
+      :logger.add_handler(handler_id, :logger_std_h, %{
+        level: :debug,
+        formatter:
+          {Formatter,
+           %{
+             single_line: true,
+             template: [:time, " ", :level, " event_id=", :event_id, " ", :msg, "\n"]
+           }},
+        config: %{type: {:file, String.to_charlist(path)}}
+      })
+
+    try do
+      :ok = :logger.set_primary_config(:level, :debug)
+      :logger.log(:debug, {"Replied in ~B~ts", [409, ~c"µs"]}, %{})
+      :ok = :logger.remove_handler(handler_id)
+
+      log = File.read!(path)
+
+      assert log =~ "Replied in 409µs"
+      assert String.valid?(log)
+      refute log =~ "FORMATTER ERROR"
+    after
+      :logger.remove_handler(handler_id)
+      :logger.set_primary_config(:level, primary_level)
+      File.rm(path)
+    end
   end
 end


### PR DESCRIPTION
#### Context

Fixes #61 / ALB-40: Windows log file formatting crashed on LiveView Unicode timing units such as `µs`.

#### TL;DR

*Preserve Unicode logger formatter output before log-file sanitization.*

#### Summary

- Convert OTP logger formatter output as Unicode chardata before sanitizing.
- Add focused regressions for Phoenix-style `Replied in 409µs` log events.
- Exercise dashboard `/` and `/workers/MT-HTTP` requests with the file formatter.
- Merge current `origin/main` and keep the dashboard rate-limit tests from main.

#### Alternatives

- Did not silence Phoenix or LiveView logs because the issue is formatter encoding.
- Did not change redaction or sanitizer rules beyond preserving valid Unicode first.

#### Test Plan

- [x] GitHub Actions `make-all` passed for `5a8d0a7`.
- [x] GitHub Actions `validate-pr-description` passed for PR #66 after the branch update.
- [x] `cd elixir; mix test test/symphony_elixir/log_file_test.exs test/symphony_elixir/extensions_test.exs:1158`
- [x] `cd elixir; mix specs.check`
- [x] `cd elixir; make windows-native-test`
- [x] `cd elixir; make all`
- [x] `git diff --check`
- [x] Independent SubAgent review completed with no blocking findings.