### PR TITLE
docs(windows): make optimization workflow pluggable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,10 @@ policy or recurring pitfalls change.
 ## Windows Paths And Commands
 
 - Work from the generated issue workspace, not a normal source checkout.
-- Treat `albert-zen/symphony-windows-native` and `origin/main` as the canonical
-  repo/base unless the workflow explicitly says otherwise.
+- Treat the configured Windows-native GitHub repository and `origin/main` as
+  the canonical repo/base unless the workflow explicitly says otherwise.
+- Keep OpenAI's original Symphony repository as `upstream`, not `origin`, when
+  you need to compare against the prototype.
 - Run repo commands from `elixir/` unless the command says otherwise.
 - Prefer PowerShell syntax on Windows. If GNU Make is unavailable, use `make.cmd`.
 
@@ -94,8 +96,9 @@ Workpad. Blocking findings keep the issue in `In Progress` or return it to
   directly unless the wrapper is proven quiet.
 - Windows CRLF and snapshot rendering can differ from Unix expectations.
 - Fake `ssh`, `gh`, and Codex fixtures may assume Unix shebang/chmod behavior.
-- Stale `main` or noncanonical upstreams can hide newer `origin/main`; fetch and
-  compare against the canonical base before review handoff.
+- Stale `main` or a checkout where `origin` still points at the upstream
+  prototype can hide the intended Windows-native base; fetch and compare
+  against the configured canonical base before review handoff.
 - `WorkflowStore` and other global/stateful runtime paths can leak state across
   tests; preserve cleanup and isolation semantics.
 - Coverage threshold or ignore-list changes are quality-gate changes and need

--- a/elixir/.gitignore
+++ b/elixir/.gitignore
@@ -46,6 +46,8 @@ erl_crash.dump
 status.txt
 .codex/original-user-prompt.txt
 WORKFLOW.windows.md
+WORKFLOW.optimization.windows*.md
+!WORKFLOW.optimization.windows.example.md
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez

--- a/elixir/WORKFLOW.optimization.windows.example.md
+++ b/elixir/WORKFLOW.optimization.windows.example.md
@@ -2,6 +2,9 @@
 tracker:
   kind: linear
   api_key: $LINEAR_API_KEY
+  # Replace with your Linear project slug. The Windows preflight can verify
+  # Linear connectivity, and the dashboard/logs will show which project is
+  # being polled.
   project_slug: "YOUR_LINEAR_PROJECT_SLUG"
   # Optional: uncomment only if this project is shared with unrelated work.
   # labels:
@@ -17,13 +20,15 @@ tracker:
 polling:
   interval_ms: 5000
 workspace:
-  root: "D:/code/symphony-optimization-workspaces"
+  # Use a dedicated disposable automation root. Do not point this at your
+  # everyday source checkout or a broad personal directory.
+  root: "D:/code/symphony-workspaces"
 hooks:
   timeout_ms: 300000
   after_create: |
     $ErrorActionPreference = "Stop"
-    git clone --depth 1 https://github.com/albert-zen/symphony-windows-native.git .
-    git remote set-url origin https://github.com/albert-zen/symphony-windows-native.git
+    git clone --depth 1 https://github.com/YOUR_GITHUB_OWNER/YOUR_REPO.git .
+    git remote set-url origin https://github.com/YOUR_GITHUB_OWNER/YOUR_REPO.git
     git fetch origin main
     git config user.email "codex-symphony@example.invalid"
     git config user.name "Codex Symphony"
@@ -42,7 +47,7 @@ codex:
   approval_policy: never
   thread_sandbox: danger-full-access
   # Used when GitHub branch protection required-check metadata is private or unavailable.
-  review_readiness_repository: albert-zen/symphony-windows-native
+  review_readiness_repository: YOUR_GITHUB_OWNER/YOUR_REPO
   command_watchdog_long_running_ms: 300000
   command_watchdog_idle_ms: 120000
   command_watchdog_stalled_ms: 300000
@@ -83,13 +88,13 @@ Operating model:
 7. Run focused validation before committing.
 8. Commit with lightweight Conventional Commits, for example
    `docs(quality): add agent PR quality policy`, and push the branch to
-   `albert-zen/symphony-windows-native`.
+   the configured GitHub repository.
 9. Open a GitHub pull request against `main` and link it in the Linear workpad.
 10. Wait for required GitHub checks to complete before moving the Linear issue to `In Review`.
     If checks cannot be verified, record the exact reason in the workpad and PR, then keep the
     issue in `In Progress` or return it to `Todo`; only a manager may explicitly override this.
 11. Do not move unrelated Backlog issues to Todo.
-12. If you discover an automation/system defect, create a GitHub issue with label `symphony-optimization` and add a Linear mirror in project `YOUR_LINEAR_PROJECT_NAME` if the Linear tool is available.
+12. If you discover an automation/system defect, create a GitHub issue with the configured optimization label and add a Linear mirror in the configured Linear project if the Linear tool is available.
 13. Leave problem breadcrumbs without spamming:
     - Update the `## Codex Workpad` for recovered transient noise, retries, or routine validation fixes.
     - Add a separate concise Linear problem comment only for notable environment, validation, auth,
@@ -105,7 +110,7 @@ Operating model:
 Quality bar:
 
 - Prefer small, reviewable changes.
-- Treat `origin/main` in `albert-zen/symphony-windows-native` as the canonical
+- Treat `origin/main` in the configured GitHub repository as the canonical
   GitHub base ref for manager-side stale-base checks unless the workflow
   explicitly configures another trusted remote.
 - Run `mix format` for touched Elixir files.

--- a/elixir/docs/windows-native.md
+++ b/elixir/docs/windows-native.md
@@ -76,12 +76,30 @@ Symphony:
 gh auth login
 ```
 
-For the open-source Windows-native distribution, treat
-`https://github.com/albert-zen/symphony-windows-native.git` as the canonical
-repository and `origin/main` as the canonical base ref unless your workflow
-explicitly configures another trusted remote. Manager-side stale-base checks
-should compare PR branches to `origin/main` directly instead of assuming the
-local `main` branch tracks the canonical remote.
+For day-to-day Windows-native work, `origin` should point at the repository you
+intend agents to push branches and PRs to. If you also want to compare against
+OpenAI's original prototype, keep that remote as `upstream`, not `origin`:
+
+```powershell
+git remote -v
+git remote add upstream https://github.com/openai/symphony.git
+git remote set-url --push upstream DISABLED
+```
+
+If you started from an OpenAI upstream clone and later moved to a Windows-native
+fork, rename the remotes instead of leaving `origin` pointed at the upstream
+prototype:
+
+```powershell
+git remote rename origin upstream
+git remote add origin https://github.com/YOUR_GITHUB_OWNER/YOUR_REPO.git
+git remote set-url --push upstream DISABLED
+git fetch origin main
+```
+
+Manager-side stale-base checks should compare PR branches to `origin/main`
+directly instead of assuming the local `main` branch tracks the canonical
+remote.
 
 ## Configure a workflow
 
@@ -186,8 +204,7 @@ not fail preflight. It verifies:
 - `git`, `gh`, `node`, and the configured Codex app-server command resolve on `PATH`.
 - `gh auth status` succeeds for GitHub operations.
 - After refreshing `origin/main`, the local checkout's `main` branch does not
-  hide a newer canonical base behind a stale noncanonical upstream such as
-  `windows/main`.
+  hide a newer canonical base behind a stale noncanonical remote.
 - `codex app-server` can start without non-JSON startup output on stdio.
 - The repository URL in `hooks.after_create` can be cloned by Git.
 - `workspace.root` is writable.
@@ -208,14 +225,21 @@ git branch --set-upstream-to=origin/main main
 git status --short --branch
 ```
 
-When intentionally using a fork or mirror, keep the workflow and manager runbook
-explicit about that remote and compare against its fully qualified remote ref.
+When intentionally using a fork or mirror, make that repository `origin` for the
+automation checkout. Keep other comparison sources as named remotes such as
+`upstream`, and compare against their fully qualified refs only when that is the
+explicit review target.
 
 ### Optimization flywheel routing
 
-The optimization example targets the `YOUR_LINEAR_PROJECT_NAME` Linear project by slug
-`YOUR_LINEAR_PROJECT_SLUG`. Keep `Backlog` out of `tracker.active_states`; parked issues
+The optimization example is a fixed-project routing template. Replace
+`YOUR_LINEAR_PROJECT_SLUG` with the slug for the Linear project you want
+Symphony to poll. Keep `Backlog` out of `tracker.active_states`; parked issues
 remain invisible to Symphony until a human moves one issue at a time to `Todo`.
+
+Keep the public example generic. Operator-specific project names, workspace
+paths, and repository owners should live in a local workflow file such as
+`WORKFLOW.optimization.windows.md`, which is ignored by git.
 
 Use this fixed-project route as the default boundary. If the same Linear project
 must later hold unrelated work, add `tracker.labels` to route only issues with
@@ -234,6 +258,17 @@ tracker:
 The label match is case-insensitive and applies only to candidate dispatch.
 Already-running issues are still reconciled by their tracker state so Symphony
 can stop them cleanly when they move to a terminal state.
+
+To find the right Linear values, use the Linear UI for the project slug when
+possible, or query Linear GraphQL with your own API key. Do not commit API keys,
+project-specific workflow files, or local runtime logs. When preparing a public
+release, scan tracked files for obvious secrets and local markers before
+pushing:
+
+```powershell
+$patterns = @('lin' + '_api_', 'github' + '_pat_', 'ghp_', 'YOUR_PRIVATE_WORKSPACE_MARKER')
+git ls-files | ForEach-Object { Select-String -Path $_ -Pattern $patterns }
+```
 
 ## Start Symphony
 


### PR DESCRIPTION
#### Context

Make the public Windows-native optimization example reusable without private Linear project defaults, and ensure local optimization workflow files are ignored so private project/runtime settings are not accidentally committed.

Important privacy scope: this PR prevents future tracking and removes current-tree local defaults. After the operator-directed history rewrite, current origin branch refs also scan clean for the known local project markers; external forks, clones, caches, and any value with access capability still require separate rotation decisions.

#### TL;DR

*Genericize the optimization workflow example, add release hygiene scan guidance, and ignore local optimization workflow files.*

#### Summary

- Replace private Linear project slug/name with documented placeholders.
- Replace hardcoded optimization repo values in the reusable workflow example.
- Document local-only workflow files and tracked-file hygiene scans.
- Ignore local `WORKFLOW.optimization.windows*.md` files while keeping the public example tracked.

#### Alternatives

- Keep the local defaults in the public example, but that makes the open-source setup less reusable.
- Route through a flywheel issue for the privacy fix, but this specific gap could leak local workflow settings and was fixed directly by the manager.
- Leave already-published Git history untouched, but the operator explicitly requested a history rewrite for the known local markers before this PR was finalized.

#### Test Plan

- [x] `git check-ignore -v elixir/WORKFLOW.optimization.windows.md` matches `elixir/.gitignore`.
- [x] `git check-ignore -v elixir/WORKFLOW.optimization.windows.no-startup-cleanup.md` matches `elixir/.gitignore`.
- [x] `git check-ignore -v elixir/WORKFLOW.optimization.windows.example.md` returns not ignored.
- [x] `git grep -n <known local project/runtime markers> HEAD -- .` returns no current-tree matches.
- [x] Operator-directed history rewrite completed; current origin branch refs and blob scans no longer contain the known local project markers.
- [x] `git diff --check`
- [x] `mise exec -- .\make.cmd windows-native-test` (105 tests, 0 failures, 14 skipped; LiveView symlink permission warning only).
- [x] Tracked-file scan for private markers: no matches for local/user/project markers in the current tree.
- [x] Reviewed secret scan output; remaining hits are env-var references or fake redaction fixtures.
- [x] GitHub Actions `make-all` on commit `1debc83`.
- [x] GitHub Actions `validate-pr-description` on commit `1debc83`.
- [x] GitHub Actions `windows-native-test` on commit `1debc83`.