### PR TITLE
fix(readiness): use authenticated gh token fallback

### DIFF
--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -1222,10 +1222,52 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
   defp summarize_body(body), do: body |> inspect(limit: 20, printable_limit: 200)
 
   defp maybe_add_github_token(headers) do
-    case System.get_env("GITHUB_TOKEN") || System.get_env("GH_TOKEN") do
+    case github_token() do
       token when is_binary(token) and token != "" -> [{"Authorization", "Bearer #{token}"} | headers]
       _ -> headers
     end
+  end
+
+  defp github_token do
+    env_github_token() || gh_auth_token()
+  end
+
+  defp env_github_token do
+    ["GITHUB_TOKEN", "GH_TOKEN"]
+    |> Enum.map(&System.get_env/1)
+    |> Enum.find_value(&normalize_github_token/1)
+  end
+
+  defp normalize_github_token(token) when is_binary(token) do
+    case String.trim(token) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp normalize_github_token(_token), do: nil
+
+  defp gh_auth_token do
+    with gh when is_binary(gh) <- System.find_executable("gh"),
+         {token, 0} <- run_gh_auth_token(gh),
+         token <- String.trim(token),
+         false <- token == "" do
+      token
+    else
+      _ -> nil
+    end
+  end
+
+  defp run_gh_auth_token(gh) do
+    if windows_batch?(gh) do
+      System.cmd("cmd", ["/c", gh, "auth", "token"], stderr_to_stdout: true)
+    else
+      System.cmd(gh, ["auth", "token"], stderr_to_stdout: true)
+    end
+  end
+
+  defp windows_batch?(path) do
+    match?({:win32, _}, :os.type()) and String.downcase(Path.extname(path)) in [".bat", ".cmd"]
   end
 
   defp normalize(value) do

--- a/elixir/test/symphony_elixir/review_readiness_test.exs
+++ b/elixir/test/symphony_elixir/review_readiness_test.exs
@@ -1,0 +1,163 @@
+defmodule SymphonyElixir.Codex.ReviewReadinessTest do
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.Codex.ReviewReadiness
+
+  test "github_get uses GitHub CLI auth token when env tokens are absent" do
+    previous_github_token = System.get_env("GITHUB_TOKEN")
+    previous_gh_token = System.get_env("GH_TOKEN")
+    previous_path = System.get_env("PATH")
+    test_root = Path.join(System.tmp_dir!(), "symphony-gh-token-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(test_root)
+    write_fake_gh!(test_root, "cli-token")
+
+    System.delete_env("GITHUB_TOKEN")
+    System.delete_env("GH_TOKEN")
+    System.put_env("PATH", test_root <> SymphonyElixir.TestSupport.path_separator() <> (previous_path || ""))
+
+    on_exit(fn ->
+      restore_env("GITHUB_TOKEN", previous_github_token)
+      restore_env("GH_TOKEN", previous_gh_token)
+      restore_env("PATH", previous_path)
+      File.rm_rf(test_root)
+    end)
+
+    {:ok, url, request_task} = capture_http_request!()
+
+    assert {:ok, %{status: 200, body: %{"ok" => true}}} = ReviewReadiness.github_get(url)
+    assert {:ok, request} = Task.await(request_task)
+    assert request =~ "authorization: bearer cli-token"
+  end
+
+  test "github_get prefers env token over GitHub CLI auth token" do
+    previous_github_token = System.get_env("GITHUB_TOKEN")
+    previous_gh_token = System.get_env("GH_TOKEN")
+    previous_path = System.get_env("PATH")
+    test_root = Path.join(System.tmp_dir!(), "symphony-gh-env-token-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(test_root)
+    write_failing_gh!(test_root)
+
+    System.put_env("GITHUB_TOKEN", "env-token")
+    System.delete_env("GH_TOKEN")
+    System.put_env("PATH", test_root <> SymphonyElixir.TestSupport.path_separator() <> (previous_path || ""))
+
+    on_exit(fn ->
+      restore_env("GITHUB_TOKEN", previous_github_token)
+      restore_env("GH_TOKEN", previous_gh_token)
+      restore_env("PATH", previous_path)
+      File.rm_rf(test_root)
+    end)
+
+    {:ok, url, request_task} = capture_http_request!()
+
+    assert {:ok, %{status: 200, body: %{"ok" => true}}} = ReviewReadiness.github_get(url)
+    assert {:ok, request} = Task.await(request_task)
+    assert request =~ "authorization: bearer env-token"
+  end
+
+  test "github_get uses GH_TOKEN before GitHub CLI auth token" do
+    previous_github_token = System.get_env("GITHUB_TOKEN")
+    previous_gh_token = System.get_env("GH_TOKEN")
+    previous_path = System.get_env("PATH")
+    test_root = Path.join(System.tmp_dir!(), "symphony-gh-env-token-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(test_root)
+    write_failing_gh!(test_root)
+
+    System.delete_env("GITHUB_TOKEN")
+    System.put_env("GH_TOKEN", "gh-env-token")
+    System.put_env("PATH", test_root <> SymphonyElixir.TestSupport.path_separator() <> (previous_path || ""))
+
+    on_exit(fn ->
+      restore_env("GITHUB_TOKEN", previous_github_token)
+      restore_env("GH_TOKEN", previous_gh_token)
+      restore_env("PATH", previous_path)
+      File.rm_rf(test_root)
+    end)
+
+    {:ok, url, request_task} = capture_http_request!()
+
+    assert {:ok, %{status: 200, body: %{"ok" => true}}} = ReviewReadiness.github_get(url)
+    assert {:ok, request} = Task.await(request_task)
+    assert request =~ "authorization: bearer gh-env-token"
+  end
+
+  defp write_fake_gh!(dir, token) do
+    if SymphonyElixir.TestSupport.windows?() do
+      path = Path.join(dir, "gh.cmd")
+
+      File.write!(path, """
+      @echo off
+      if "%1"=="auth" if "%2"=="token" (
+        echo #{token}
+        exit /b 0
+      )
+      exit /b 1
+      """)
+    else
+      path = Path.join(dir, "gh")
+
+      File.write!(path, """
+      #!/bin/sh
+      if [ "$1" = "auth" ] && [ "$2" = "token" ]; then
+        echo #{token}
+        exit 0
+      fi
+      exit 1
+      """)
+
+      File.chmod!(path, 0o755)
+    end
+  end
+
+  defp write_failing_gh!(dir) do
+    if SymphonyElixir.TestSupport.windows?() do
+      path = Path.join(dir, "gh.cmd")
+
+      File.write!(path, """
+      @echo off
+      exit /b 1
+      """)
+    else
+      path = Path.join(dir, "gh")
+
+      File.write!(path, """
+      #!/bin/sh
+      exit 1
+      """)
+
+      File.chmod!(path, 0o755)
+    end
+  end
+
+  defp capture_http_request! do
+    {:ok, listen_socket} =
+      :gen_tcp.listen(0, [:binary, active: false, packet: :raw, ip: {127, 0, 0, 1}, reuseaddr: true])
+
+    {:ok, {_address, port}} = :inet.sockname(listen_socket)
+
+    task =
+      Task.async(fn ->
+        with {:ok, socket} <- :gen_tcp.accept(listen_socket, 5_000),
+             {:ok, request} <- :gen_tcp.recv(socket, 0, 5_000) do
+          :ok =
+            :gen_tcp.send(socket, [
+              "HTTP/1.1 200 OK\r\n",
+              "content-type: application/json\r\n",
+              "content-length: 11\r\n",
+              "connection: close\r\n",
+              "\r\n",
+              ~s({"ok":true})
+            ])
+
+          :gen_tcp.close(socket)
+          :gen_tcp.close(listen_socket)
+          {:ok, String.downcase(request)}
+        end
+      end)
+
+    {:ok, "http://127.0.0.1:#{port}/github", task}
+  end
+end


### PR DESCRIPTION
#### Context

GH #77 reports readiness blocking on unauthenticated GitHub REST rate limits after checks pass.

Fixes #77

#### TL;DR

*Use the local GitHub CLI token before making unauthenticated readiness requests.*

#### Summary

- Keep `GITHUB_TOKEN` and `GH_TOKEN` as the first GitHub auth sources.
- Fall back to `gh auth token` for authenticated readiness REST calls.
- Route Windows `.cmd` GitHub CLI shims through `cmd /c`.
- Add socket-level tests for auth header precedence and CLI fallback.

#### Alternatives

- Use only env tokens: rejected because GH #77 occurred when env tokens were absent.
- Trust manual CI evidence: rejected because the guard should verify readiness itself.

#### Test Plan

- [ ] `make -C elixir all`
- [x] `mix test test/symphony_elixir/review_readiness_test.exs`
- [x] `mix test test/symphony_elixir/dynamic_tool_test.exs`
- [x] `mix specs.check`
- [x] `mix format --check-formatted`
- [x] `git diff --check`
- [x] `make windows-native-test`

Notes:
- `make all` failed at `mix test --cover`: tests passed, then coverage reported 93.94% below the configured 100.00% threshold.
- An earlier `make all` attempt also failed two existing status-dashboard output assertions because the shell had `SYMPHONY_DISABLE_TERMINAL_DASHBOARD=1`; rerunning with that variable removed those failures.

SubAgent review:
- Requested independent review for runtime guard changes.
- Blocking findings: none.
- Non-blocking concerns: env-token precedence tests use a failing fake `gh`, and no-token/no-`gh` fallback lacks direct coverage; code path remains straightforward and no readiness gate weakening was found.