### PR TITLE
feat(flywheel): add manager dependency release guard

### DIFF
--- a/elixir/docs/manager-agent-runbook.md
+++ b/elixir/docs/manager-agent-runbook.md
@@ -138,12 +138,34 @@ manager should ensure the public GitHub issue includes:
 
 - Problem statement and user-facing intent.
 - Scope boundaries and explicit non-goals.
+- Dependencies, unresolved blockers, and the exact unblock condition.
 - Implementation hints only when they reduce ambiguity without over-prescribing
   the solution.
 - Testing intent: focused local checks, broad gates, and Windows-specific checks
   when relevant.
 - Acceptance criteria that a reviewer can verify from the final behavior.
 - Links to related issues, PRs, prior failures, and Linear mirror.
+
+Use a `## Dependencies` section or an explicit `Depends on:` line in the GitHub
+issue when the work must wait for another issue, PR, deployment, credential, or
+system capability. Do not move that issue to `Todo` while the dependency is
+active, unmerged, blocked, or merged-but-not-deployed when deployment matters.
+After the dependency is resolved, mark it with `[x]`, `resolved by`, `merged in`,
+or `deployed in`, then record the dependency resolution in the Workpad when
+releasing the issue.
+
+Before release, run the local dry-run guard against the shaped GitHub issue text
+or an exported copy of it:
+
+```powershell
+cd elixir
+mise exec -- mix symphony.manager.release_check --file ..\issue-body.md
+```
+
+The guard intentionally fails on unresolved dependency declarations. It is not a
+substitute for manager judgment across Dashboard, GitHub, and Linear; it is a
+tripwire that prevents known dependency chains from being released as if they
+were independent work.
 
 After the worker claims the issue, avoid changing the task underneath it. If the
 intent changes, update the GitHub issue and Workpad, then decide whether to let

--- a/elixir/docs/small-team-agentic-flywheel.md
+++ b/elixir/docs/small-team-agentic-flywheel.md
@@ -95,12 +95,20 @@ Good saturation looks like:
 - A small number of active issues, each scoped to one PR.
 - A ready queue of `Backlog` issues that can be promoted one at a time.
 - Clear GitHub acceptance criteria before an issue reaches `Todo`.
+- Explicit dependency notes so prerequisite work lands or deploys before
+  dependent issues are released to `Todo`.
 - Fast human responses to true blockers.
 - Follow-up issues for discovered defects instead of broadening the active PR.
 
 Avoid moving many speculative issues to `Todo` before the claim, lease, and
 quality gates are proven. A small team gets better throughput from predictable
 handoffs than from maximum parallelism.
+
+Dependent work is not independent capacity. If issue B depends on issue A,
+keep B parked in `Backlog` until A is merged and deployed when deployment is
+part of the unblock condition. Releasing both into `Todo` at the same time
+usually creates stale branches, repeated validation, and misleading `Blocked`
+states.
 
 ## Guardrails that stop quality debt from compounding
 

--- a/elixir/lib/mix/tasks/symphony.manager.release_check.ex
+++ b/elixir/lib/mix/tasks/symphony.manager.release_check.ex
@@ -1,0 +1,55 @@
+defmodule Mix.Tasks.Symphony.Manager.ReleaseCheck do
+  @moduledoc """
+  Checks whether a manager-shaped issue can be released into `Todo`.
+
+      mix symphony.manager.release_check --file issue.md
+  """
+
+  use Mix.Task
+
+  alias SymphonyElixir.ManagerReleaseGuard
+
+  @shortdoc "Checks dependency declarations before manager Todo release"
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _argv, invalid} = OptionParser.parse(args, strict: [file: :string, help: :boolean])
+
+    cond do
+      opts[:help] ->
+        Mix.shell().info("mix symphony.manager.release_check --file /path/to/issue.md")
+
+      invalid != [] ->
+        Mix.raise("Invalid option: #{inspect(invalid)}")
+
+      is_nil(opts[:file]) ->
+        Mix.raise("Missing required option --file")
+
+      true ->
+        opts[:file]
+        |> read_file!()
+        |> report()
+    end
+  end
+
+  defp read_file!(path) do
+    case File.read(path) do
+      {:ok, body} -> body
+      {:error, reason} -> Mix.raise("Unable to read #{path}: #{:file.format_error(reason)}")
+    end
+  end
+
+  defp report(body) do
+    case ManagerReleaseGuard.check(body) do
+      {:ok, _dependencies} ->
+        Mix.shell().info("Manager release check OK: no unresolved dependencies found.")
+
+      {:error, dependencies} ->
+        Enum.each(dependencies, fn dependency ->
+          Mix.shell().error("Unresolved dependency on line #{dependency.line}: #{dependency.text}")
+        end)
+
+        Mix.raise("Manager release check failed: unresolved dependencies must be resolved before Todo release")
+    end
+  end
+end

--- a/elixir/lib/symphony_elixir/manager_release_guard.ex
+++ b/elixir/lib/symphony_elixir/manager_release_guard.ex
@@ -1,0 +1,78 @@
+defmodule SymphonyElixir.ManagerReleaseGuard do
+  @moduledoc """
+  Checks whether a shaped issue is safe for manager release into `Todo`.
+
+  This is intentionally a small text guard. It gives manager agents a local
+  dry-run check for dependency declarations before they move a parked Backlog
+  issue into a Symphony-polled state.
+  """
+
+  @type dependency :: %{line: pos_integer(), text: String.t()}
+
+  @dependency_heading ~r/^\#{2,6}\s+Dependencies\b/i
+  @heading ~r/^\#{1,6}\s+/
+  @explicit_dependency ~r/\bdepends\s+on\s*:?/i
+  @none ~r/^\s*[-*]?\s*(none|n\/a|not applicable)\.?\s*$/i
+  @checked ~r/^\s*[-*]\s*\[x\]/i
+  @resolved ~r/\b(resolved by|status:\s*(resolved|done)|unblocked by)\b/i
+  @completed_reference ~r/\b(landed|merged|deployed)\s+in\s+(`?[a-f0-9]{7,40}`?|PR\s*#\d+|#\d+)\b/i
+
+  @spec check(String.t()) :: {:ok, [dependency()]} | {:error, [dependency()]}
+  def check(text) when is_binary(text) do
+    unresolved = unresolved_dependencies(text)
+
+    if unresolved == [] do
+      {:ok, []}
+    else
+      {:error, unresolved}
+    end
+  end
+
+  @spec unresolved_dependencies(String.t()) :: [dependency()]
+  def unresolved_dependencies(text) when is_binary(text) do
+    text
+    |> String.split(["\r\n", "\n"])
+    |> Enum.with_index(1)
+    |> Enum.reduce({false, []}, fn {line, line_number}, {in_dependencies?, unresolved} ->
+      next_in_dependencies? = dependencies_section?(line, in_dependencies?)
+
+      unresolved =
+        if dependency_declaration?(line, next_in_dependencies?) and not resolved_dependency?(line) do
+          [%{line: line_number, text: String.trim(line)} | unresolved]
+        else
+          unresolved
+        end
+
+      {next_in_dependencies?, unresolved}
+    end)
+    |> elem(1)
+    |> Enum.reverse()
+  end
+
+  defp dependencies_section?(line, in_dependencies?) when is_binary(line) do
+    cond do
+      Regex.match?(@dependency_heading, line) -> true
+      Regex.match?(@heading, line) -> false
+      true -> in_dependencies?
+    end
+  end
+
+  defp dependency_declaration?(line, in_dependencies?) do
+    trimmed = String.trim(line)
+
+    cond do
+      trimmed == "" -> false
+      Regex.match?(@none, trimmed) -> false
+      Regex.match?(@explicit_dependency, trimmed) -> true
+      in_dependencies? and bullet_or_checkbox?(trimmed) -> true
+      true -> false
+    end
+  end
+
+  defp bullet_or_checkbox?(line), do: String.starts_with?(line, ["-", "*"])
+
+  defp resolved_dependency?(line) do
+    Regex.match?(@checked, line) or Regex.match?(@resolved, line) or
+      Regex.match?(@completed_reference, line)
+  end
+end

--- a/elixir/test/mix/tasks/manager_release_check_test.exs
+++ b/elixir/test/mix/tasks/manager_release_check_test.exs
@@ -1,0 +1,84 @@
+defmodule Mix.Tasks.Symphony.Manager.ReleaseCheckTest do
+  use ExUnit.Case, async: false
+
+  alias Mix.Tasks.Symphony.Manager.ReleaseCheck
+
+  import ExUnit.CaptureIO
+
+  setup do
+    Mix.Task.reenable("symphony.manager.release_check")
+    :ok
+  end
+
+  test "prints help" do
+    output = capture_io(fn -> ReleaseCheck.run(["--help"]) end)
+
+    assert output =~ "mix symphony.manager.release_check --file /path/to/issue.md"
+  end
+
+  test "fails when file option is missing" do
+    assert_raise Mix.Error, ~r/Missing required option --file/, fn ->
+      ReleaseCheck.run([])
+    end
+  end
+
+  test "fails on invalid options" do
+    assert_raise Mix.Error, ~r/Invalid option/, fn ->
+      ReleaseCheck.run(["--wat"])
+    end
+  end
+
+  test "fails when file is missing" do
+    assert_raise Mix.Error, ~r/Unable to read missing.md/, fn ->
+      ReleaseCheck.run(["--file", "missing.md"])
+    end
+  end
+
+  test "passes resolved issue body" do
+    in_temp_dir(fn ->
+      File.write!("issue.md", """
+      ## Dependencies
+
+      - [x] PR #53 merged in `345d606`.
+      """)
+
+      output = capture_io(fn -> ReleaseCheck.run(["--file", "issue.md"]) end)
+
+      assert output =~ "Manager release check OK"
+    end)
+  end
+
+  test "fails unresolved issue body" do
+    in_temp_dir(fn ->
+      File.write!("issue.md", """
+      ## Dependencies
+
+      - Depends on PR #53.
+      """)
+
+      error =
+        capture_io(:stderr, fn ->
+          assert_raise Mix.Error, ~r/unresolved dependencies/, fn ->
+            ReleaseCheck.run(["--file", "issue.md"])
+          end
+        end)
+
+      assert error =~ "Unresolved dependency on line 3"
+    end)
+  end
+
+  defp in_temp_dir(fun) do
+    root = Path.join(System.tmp_dir!(), "manager-release-check-test-#{System.unique_integer([:positive])}")
+    File.rm_rf!(root)
+    File.mkdir_p!(root)
+    original_cwd = File.cwd!()
+
+    try do
+      File.cd!(root)
+      fun.()
+    after
+      File.cd!(original_cwd)
+      File.rm_rf!(root)
+    end
+  end
+end

--- a/elixir/test/symphony_elixir/manager_release_guard_test.exs
+++ b/elixir/test/symphony_elixir/manager_release_guard_test.exs
@@ -1,0 +1,81 @@
+defmodule SymphonyElixir.ManagerReleaseGuardTest do
+  use ExUnit.Case, async: true
+
+  alias SymphonyElixir.ManagerReleaseGuard
+
+  test "passes when no dependencies are declared" do
+    body = """
+    ## Summary
+
+    Ready independent work.
+    """
+
+    assert {:ok, []} = ManagerReleaseGuard.check(body)
+  end
+
+  test "blocks unresolved dependencies in dependency section" do
+    body = """
+    ## Dependencies
+
+    - GH #47 / ALB-32 must merge first.
+    - [x] GH #81 landed in main.
+
+    ## Acceptance criteria
+
+    Ready after dependency resolution.
+    """
+
+    assert {:error, [%{line: 3, text: "- GH #47 / ALB-32 must merge first."}]} =
+             ManagerReleaseGuard.check(body)
+  end
+
+  test "blocks explicit depends on declarations outside dependency section" do
+    body = """
+    ## Context
+
+    Depends on: PR #53 merged and runtime redeployed.
+    """
+
+    assert {:error, [%{line: 3, text: "Depends on: PR #53 merged and runtime redeployed."}]} =
+             ManagerReleaseGuard.check(body)
+  end
+
+  test "passes resolved dependency declarations" do
+    body = """
+    ## Dependencies
+
+    - [x] PR #53 merged in `345d606`.
+    - Status: resolved by runtime restart on 2026-05-02.
+    - Deployed in PR #81.
+    - None.
+    """
+
+    assert {:ok, []} = ManagerReleaseGuard.check(body)
+  end
+
+  test "blocks future-tense dependency conditions" do
+    body = """
+    ## Dependencies
+
+    - GH #47 must be merged in main before release.
+    - Runtime fix must be deployed in production before release.
+    """
+
+    assert {:error, dependencies} = ManagerReleaseGuard.check(body)
+    assert Enum.map(dependencies, & &1.line) == [3, 4]
+  end
+
+  test "stops dependency section at next heading" do
+    body = """
+    ## Dependencies
+
+    - [x] PR #53 merged in `345d606`.
+
+    ## Notes
+
+    - This normal bullet is not a dependency.
+    """
+
+    assert {:ok, []} = ManagerReleaseGuard.check(body)
+  end
+end


### PR DESCRIPTION
#### Context

Fixes #87 / ALB-56: dependent issues should not be released to Todo while prerequisites are unresolved.

#### TL;DR

*Add a manager release guard for dependency-aware Backlog to Todo handoff.*

#### Summary

- Add `mix symphony.manager.release_check --file` for unresolved dependency declarations.
- Block unresolved `## Dependencies` and `Depends on:` text before Todo release.
- Allow explicit resolved markers such as checked items, `resolved by`, and merged/deployed references.
- Document that dependent work is not independent capacity for the flywheel.

#### Alternatives

- Only document the policy, but this would not provide a dry-run guard before Todo release.
- Let worker agents infer dependencies, but manager-level GitHub/Linear/Dashboard context is required.

#### Test Plan

- [ ] `make -C elixir all` not run locally because the full coverage gate was run directly for this manager-owned guard change.
- [x] `mise exec -- mix test test/symphony_elixir/manager_release_guard_test.exs test/mix/tasks/manager_release_check_test.exs` - 12 tests, 0 failures.
- [x] `mise exec -- mix specs.check` - passed.
- [x] `git diff --check` - passed.
- [x] `mise exec -- mix test --cover` - 443 tests, 0 failures, 7 skipped; Total coverage 100.00%.

SubAgent review: found that future-tense `must be merged in` text could pass as resolved; fixed by requiring explicit resolved markers or completed references, with regression coverage.