### PR TITLE
docs(flywheel): clarify manager-owned work policy

### DIFF
--- a/elixir/docs/manager-agent-runbook.md
+++ b/elixir/docs/manager-agent-runbook.md
@@ -28,6 +28,30 @@ system defects into durable issues.
 - Keep the system saturated, not chaotic. Raise concurrency only after claim
   behavior, review readiness, and CI signal are trustworthy.
 
+## Manager-owned work
+
+Some issues should stay with the manager instead of being released to an
+ordinary worker. Keep work manager-owned when success depends on global context
+across the live dashboard, GitHub, Linear, previous operator intent, or recent
+flywheel incidents.
+
+Examples:
+
+- Choosing the canonical issue for a repeated system defect, marking duplicates,
+  or defining defect intake policy.
+- Deciding whether a dependency chain is resolved enough to release downstream
+  work to `Todo`.
+- Applying privacy-sensitive history cleanup or deployment/restart changes.
+- Root-causing why active work is `Blocked`, stale, duplicated, or running on
+  old code.
+- Changing manager automation, concurrency policy, release criteria, or review
+  policy.
+
+Workers are a good fit for bounded implementation tasks with a complete public
+spec, test intent, acceptance criteria, and no need to decide cross-system
+policy. If a manager-owned issue can be decomposed, create narrower worker-safe
+subtasks and keep the policy decision in the manager Workpad.
+
 ## Main loop
 
 Run this loop until the operator deliberately pauses the flywheel.
@@ -57,6 +81,8 @@ Run this loop until the operator deliberately pauses the flywheel.
 4. Feed the next work.
    - Choose the next Backlog issue after completed work is reviewed and blockers
      are root-caused, owned, or confirmed not to affect available capacity.
+   - Classify whether the issue is worker-safe or manager-owned before moving
+     it. Do not release manager-owned work merely to fill a concurrency slot.
    - Complete the GitHub issue spec, testing intent, and acceptance criteria.
    - Add links between GitHub and Linear.
    - Move it to `Todo` only when there is available capacity and the task is


### PR DESCRIPTION
#### Context

Manager feedback during the May 2 flywheel run: issues that require global manager context across Dashboard, GitHub, Linear, recent operator intent, and flywheel history should not be released to ordinary worker agents just to keep concurrency full.

#### TL;DR

*Document when work is manager-owned and must not be handed to limited-context workers.*

#### Summary

- Add a manager-owned work section to the manager agent runbook.
- Name examples such as canonical defect policy, dependency release decisions, privacy/history cleanup, blocker root cause, deployment, concurrency, and review policy.
- Add an explicit release-loop check to classify work as worker-safe or manager-owned before moving Backlog to Todo.

#### Alternatives

- Only updated the heartbeat automation, but portable deployments need the rule in repo docs too.
- Could create a worker issue, but this policy decision itself requires manager context.

#### Test Plan

- [ ] `make -C elixir all` not run locally because this is a docs-only manager runbook update.
- [x] `git diff --check` passed locally.