### PR TITLE
fix(dashboard): render worker detail as agent messages

### DIFF
--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -16,6 +16,7 @@ defmodule SymphonyElixir.Orchestrator do
   # Slightly above the dashboard render interval so "checking now…" can render.
   @poll_transition_render_delay_ms 20
   @max_recent_codex_events 80
+  @max_completed_agent_messages 120
   @steer_request_timeout_ms 3_000
   @empty_codex_totals %{
     input_tokens: 0,
@@ -1354,6 +1355,7 @@ defmodule SymphonyElixir.Orchestrator do
           last_codex_message: metadata.last_codex_message,
           last_codex_event: metadata.last_codex_event,
           recent_codex_events: Map.get(metadata, :recent_codex_events, []),
+          completed_agent_messages: Map.get(metadata, :completed_agent_messages, []),
           command_watchdog:
             CommandWatchdog.snapshot(
               Map.get(metadata, :command_watchdog),
@@ -1486,6 +1488,7 @@ defmodule SymphonyElixir.Orchestrator do
         turn_id: id_for_update(Map.get(running_entry, :turn_id), update, :turn_id),
         last_codex_event: event,
         recent_codex_events: recent_codex_events_for_update(running_entry, update),
+        completed_agent_messages: completed_agent_messages_for_update(running_entry, update),
         codex_app_server_pid: codex_app_server_pid_for_update(codex_app_server_pid, update),
         codex_input_tokens: codex_input_tokens + token_delta.input_tokens,
         codex_output_tokens: codex_output_tokens + token_delta.output_tokens,
@@ -1650,18 +1653,76 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp recent_codex_events_for_update(running_entry, update) do
-    next_event =
-      summarize_codex_update(update)
-      |> Map.put(:raw, update[:raw])
-      |> Map.put(:session_id, update[:session_id] || Map.get(running_entry, :session_id))
-      |> Map.put(:thread_id, update[:thread_id] || Map.get(running_entry, :thread_id))
-      |> Map.put(:turn_id, update[:turn_id] || Map.get(running_entry, :turn_id))
-
     running_entry
     |> Map.get(:recent_codex_events, [])
-    |> Kernel.++([next_event])
+    |> Kernel.++([codex_event_for_update(running_entry, update)])
     |> Enum.take(-@max_recent_codex_events)
   end
+
+  defp completed_agent_messages_for_update(running_entry, update) do
+    existing = Map.get(running_entry, :completed_agent_messages, [])
+
+    if completed_agent_message_update?(update) do
+      existing
+      |> Kernel.++([codex_event_for_update(running_entry, update)])
+      |> Enum.take(-@max_completed_agent_messages)
+    else
+      existing
+    end
+  end
+
+  defp codex_event_for_update(running_entry, update) do
+    summarize_codex_update(update)
+    |> Map.put(:raw, update[:raw])
+    |> Map.put(:session_id, update[:session_id] || Map.get(running_entry, :session_id))
+    |> Map.put(:thread_id, update[:thread_id] || Map.get(running_entry, :thread_id))
+    |> Map.put(:turn_id, update[:turn_id] || Map.get(running_entry, :turn_id))
+  end
+
+  defp completed_agent_message_update?(update) do
+    payload = codex_update_payload(update)
+
+    event_method(payload) == "item/completed" and
+      (map_path(payload, ["params", "item", "type"]) ||
+         map_path(payload, [:params, :item, :type])) == "agentMessage"
+  end
+
+  defp codex_update_payload(update) do
+    cond do
+      is_map(update[:message]) -> update[:message]
+      is_map(update[:payload]) -> update[:payload]
+      is_map(update[:raw]) -> update[:raw]
+      is_binary(update[:raw]) -> decode_json_payload(update[:raw])
+      true -> nil
+    end
+  end
+
+  defp decode_json_payload(raw) do
+    case Jason.decode(raw) do
+      {:ok, %{} = payload} -> payload
+      _ -> nil
+    end
+  end
+
+  defp event_method(payload) do
+    map_path(payload, ["method"]) ||
+      map_path(payload, [:method]) ||
+      map_path(payload, ["payload", "method"]) ||
+      map_path(payload, [:payload, :method]) ||
+      map_path(payload, ["params", "msg", "method"]) ||
+      map_path(payload, [:params, :msg, :method])
+  end
+
+  defp map_path(value, path), do: Enum.reduce_while(path, value, &map_path_step/2)
+
+  defp map_path_step(key, %{} = value) do
+    case Map.fetch(value, key) do
+      {:ok, next} -> {:cont, next}
+      :error -> {:halt, nil}
+    end
+  end
+
+  defp map_path_step(_key, _value), do: {:halt, nil}
 
   defp validate_steer_message(message) when is_binary(message) do
     case String.trim(message) do

--- a/elixir/lib/symphony_elixir_web/components/layouts.ex
+++ b/elixir/lib/symphony_elixir_web/components/layouts.ex
@@ -52,6 +52,17 @@ defmodule SymphonyElixirWeb.Layouts do
                     second: "2-digit"
                   });
                 }
+              },
+              AutoScroll: {
+                mounted: function () {
+                  this.scrollToBottom();
+                },
+                updated: function () {
+                  this.scrollToBottom();
+                },
+                scrollToBottom: function () {
+                  this.el.scrollTop = this.el.scrollHeight;
+                }
               }
             };
 

--- a/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
@@ -130,121 +130,97 @@ defmodule SymphonyElixirWeb.DashboardLive do
                 tokens: %{input_tokens: nil, output_tokens: nil, total_tokens: nil}
               } %>
 
-          <section class="metric-grid">
-            <article class="metric-card">
-              <p class="metric-label">State</p>
-              <p class="metric-value"><%= running.state %></p>
-              <p class="metric-detail"><%= detail.title || detail.issue_identifier %></p>
-            </article>
-            <article class="metric-card">
-              <p class="metric-label">Session</p>
-              <p class="metric-value mono detail-session"><%= running.session_id || "n/a" %></p>
-              <p class="metric-detail">Turn <%= running.turn_count %></p>
-            </article>
-            <article class="metric-card">
-              <p class="metric-label">Workspace</p>
-              <p class="metric-value detail-path"><%= detail.workspace.path %></p>
-              <p class="metric-detail"><%= detail.workspace.host || "local" %></p>
-            </article>
-            <article class="metric-card">
-              <p class="metric-label">Branch / Checks</p>
-              <p class="metric-value detail-path"><%= detail.retry && detail.retry.branch_name || "n/a" %></p>
-              <p class="metric-detail"><%= if detail.url, do: detail.url, else: "PR and checks unavailable" %></p>
-            </article>
-          </section>
+          <section class="worker-detail-workspace">
+            <aside class="worker-status-sidebar">
+              <div class="sidebar-section">
+                <p class="metric-label">State</p>
+                <p class="metric-value"><%= running.state %></p>
+                <p class="metric-detail"><%= detail.title || detail.issue_identifier %></p>
+              </div>
+              <div class="sidebar-section">
+                <p class="metric-label">Session</p>
+                <p class="metric-value mono detail-session"><%= running.session_id || "n/a" %></p>
+                <p class="metric-detail">Turn <%= running.turn_count %></p>
+              </div>
+              <div class="sidebar-section">
+                <p class="metric-label">Workspace</p>
+                <p class="metric-value detail-path"><%= detail.workspace.path %></p>
+                <p class="metric-detail"><%= detail.workspace.host || "local" %></p>
+              </div>
+              <div class="sidebar-section">
+                <p class="metric-label">Branch / Checks</p>
+                <p class="metric-value detail-path"><%= detail.retry && detail.retry.branch_name || "n/a" %></p>
+                <p class="metric-detail"><%= if detail.url, do: detail.url, else: "PR and checks unavailable" %></p>
+              </div>
+              <details class="debug-drawer">
+                <summary>Worker debug payload</summary>
+                <pre class="code-panel"><%= detail.debug.payload_excerpt %><%= if detail.debug.payload_truncated?, do: "\n[truncated]" %></pre>
+              </details>
+            </aside>
 
-          <section class="agent-panel">
-            <div class="agent-panel-header">
-              <div>
-                <h2 class="section-title">Conversation</h2>
-                <p class="section-copy">
-                  <%= if detail.running do %>
-                    <%= if @steer_auth_required and not @steer_token_configured do %>
-                      Steering is locked because this dashboard is exposed without an operator token.
+            <section class="agent-panel">
+              <div class="agent-panel-header">
+                <div>
+                  <h2 class="section-title">Agent Messages</h2>
+                  <p class="section-copy">
+                    <%= if detail.running do %>
+                      <%= if @steer_auth_required and not @steer_token_configured do %>
+                        Steering is locked because this dashboard is exposed without an operator token.
+                      <% else %>
+                        Completed agent messages for this worker session.
+                      <% end %>
                     <% else %>
-                      Messages and tool activity for this exact worker session.
+                      This worker is not running, so steering is disabled.
                     <% end %>
-                  <% else %>
-                    This worker is not running, so steering is disabled.
-                  <% end %>
-                </p>
+                  </p>
+                </div>
+                <span class="state-badge"><%= length(detail.conversation) %> messages</span>
               </div>
-              <span class="state-badge"><%= length(detail.conversation) %> items</span>
-            </div>
 
-            <div class="conversation-scroll">
-              <%= if detail.conversation == [] do %>
-                <p class="empty-state">No Codex conversation events recorded yet.</p>
-              <% else %>
-                <ol class="conversation-list">
-                  <li :for={item <- detail.conversation} class={conversation_item_class(item)}>
-                    <div class="conversation-meta">
-                      <span><%= item.title %></span>
-                      <span class="mono"><%= item.at || "pending" %></span>
-                    </div>
-
-                    <%= case item.type do %>
-                      <% "tool" -> %>
-                        <div class="tool-card">
-                          <div class="tool-card-main">
-                            <span class={tool_status_class(item.status)}><%= item.status %></span>
-                            <code><%= item.command %></code>
-                            <%= if item.elapsed_ms do %>
-                              <span class="muted mono"><%= format_elapsed_ms(item.elapsed_ms) %></span>
-                            <% end %>
-                          </div>
-                          <%= if item.output_excerpt != "" do %>
-                            <pre class="tool-output"><%= item.output_excerpt %><%= if item.output_truncated?, do: "\n[truncated]" %></pre>
-                          <% end %>
-                        </div>
-                      <% _ -> %>
-                        <p class="message-bubble-text"><%= item.excerpt || "Worker update" %></p>
-                    <% end %>
-
-                    <details class="raw-details">
-                      <summary>Debug JSON</summary>
-                      <div :for={raw <- item.raw || []} class="debug-block">
-                        <p class="debug-label"><%= raw.label %><%= if raw.truncated?, do: " (truncated)" %></p>
-                        <pre class="code-panel"><%= raw.excerpt %></pre>
+              <div id="worker-conversation-scroll" class="conversation-scroll" phx-hook="AutoScroll">
+                <%= if detail.conversation == [] do %>
+                  <p class="empty-state">No completed agent messages yet.</p>
+                <% else %>
+                  <ol class="conversation-list">
+                    <li :for={item <- detail.conversation} class={conversation_item_class(item)}>
+                      <div class="conversation-meta">
+                        <span><%= item.title %></span>
+                        <span class="mono"><%= item.at || "pending" %></span>
                       </div>
-                    </details>
-                  </li>
-                </ol>
-              <% end %>
-            </div>
-
-            <.form for={%{}} as={:steer} phx-submit="steer" class="composer-form">
-              <input type="hidden" name="steer[session_id]" value={running.session_id || ""} />
-              <%= if @steer_auth_required and @steer_token_configured do %>
-                <input
-                  type="password"
-                  name="steer[operator_token]"
-                  class="steer-token"
-                  placeholder="Operator token"
-                  autocomplete="off"
-                  disabled={is_nil(running.session_id)}
-                />
-              <% end %>
-              <div class="composer-row">
-                <textarea
-                  name="steer[message]"
-                  class="composer-input"
-                  rows="2"
-                  placeholder="Send a targeted instruction to this running worker"
-                  disabled={is_nil(running.session_id) or steer_locked?(@steer_auth_required, @steer_token_configured)}
-                ></textarea>
-                <button
-                  type="submit"
-                  disabled={is_nil(running.session_id) or steer_locked?(@steer_auth_required, @steer_token_configured)}
-                >Send</button>
+                      <p class="message-bubble-text"><%= item.excerpt || "Worker update" %></p>
+                    </li>
+                  </ol>
+                <% end %>
               </div>
-            </.form>
-          </section>
 
-          <details class="debug-drawer">
-            <summary>Worker debug payload</summary>
-            <pre class="code-panel"><%= detail.debug.payload_excerpt %><%= if detail.debug.payload_truncated?, do: "\n[truncated]" %></pre>
-          </details>
+              <.form for={%{}} as={:steer} phx-submit="steer" class="composer-form">
+                <input type="hidden" name="steer[session_id]" value={running.session_id || ""} />
+                <%= if @steer_auth_required and @steer_token_configured do %>
+                  <input
+                    type="password"
+                    name="steer[operator_token]"
+                    class="steer-token"
+                    placeholder="Operator token"
+                    autocomplete="off"
+                    disabled={is_nil(running.session_id)}
+                  />
+                <% end %>
+                <div class="composer-row">
+                  <textarea
+                    name="steer[message]"
+                    class="composer-input"
+                    rows="2"
+                    placeholder="Send a targeted instruction to this running worker"
+                    disabled={is_nil(running.session_id) or steer_locked?(@steer_auth_required, @steer_token_configured)}
+                  ></textarea>
+                  <button
+                    type="submit"
+                    disabled={is_nil(running.session_id) or steer_locked?(@steer_auth_required, @steer_token_configured)}
+                  >Send</button>
+                </div>
+              </.form>
+            </section>
+          </section>
         <% end %>
       </section>
     <% else %>
@@ -324,7 +300,7 @@ defmodule SymphonyElixirWeb.DashboardLive do
 
           <%= if rate_limit_snapshot?(@payload.rate_limits) do %>
             <div class="rate-limit-list">
-              <article :for={limit <- rate_limit_rows(@payload.rate_limits, @now)} class="rate-limit-row">
+              <article :for={limit <- rate_limit_rows(@payload.rate_limits, @now)} class={"rate-limit-row #{limit.tone_class}"}>
                 <div class="rate-limit-main">
                   <div>
                     <p class="rate-limit-name"><%= limit.label %></p>
@@ -682,6 +658,7 @@ defmodule SymphonyElixirWeb.DashboardLive do
       progress_width: used_percent || 0,
       badge_class: rate_limit_badge_class(used_percent),
       bar_class: rate_limit_bar_class(used_percent),
+      tone_class: rate_limit_tone_class(label),
       window: window_label(field_value(bucket, [:window_duration_mins, :windowDurationMins, "window_duration_mins", "windowDurationMins"])),
       reset: reset_relative(reset_at, now),
       reset_absolute: reset_absolute(reset_at)
@@ -697,6 +674,7 @@ defmodule SymphonyElixirWeb.DashboardLive do
       progress_width: 0,
       badge_class: "rate-limit-badge",
       bar_class: "rate-limit-bar-fill",
+      tone_class: rate_limit_tone_class(label),
       window: "window n/a",
       reset: nil,
       reset_absolute: nil
@@ -752,6 +730,8 @@ defmodule SymphonyElixirWeb.DashboardLive do
     do: "rate-limit-bar-fill rate-limit-bar-fill-warning"
 
   defp rate_limit_bar_class(_value), do: "rate-limit-bar-fill"
+
+  defp rate_limit_tone_class(label), do: "rate-limit-row-#{String.downcase(label)}"
 
   defp window_label(minutes) when is_integer(minutes), do: "#{duration_label(minutes)} window"
   defp window_label(minutes) when is_float(minutes), do: "#{duration_label(round(minutes))} window"
@@ -872,27 +852,8 @@ defmodule SymphonyElixirWeb.DashboardLive do
 
   defp format_watchdog_age(_age_ms), do: "n/a"
 
-  defp format_elapsed_ms(elapsed_ms) when is_integer(elapsed_ms) do
-    "#{Float.round(elapsed_ms / 1_000, 1)}s"
-  end
-
-  defp format_elapsed_ms(_elapsed_ms), do: "n/a"
-
   defp conversation_item_class(%{type: "assistant"}), do: "conversation-item conversation-item-assistant"
-  defp conversation_item_class(%{type: "user"}), do: "conversation-item conversation-item-user"
-  defp conversation_item_class(%{type: "tool"}), do: "conversation-item conversation-item-tool"
-  defp conversation_item_class(%{type: "warning"}), do: "conversation-item conversation-item-warning"
   defp conversation_item_class(_item), do: "conversation-item conversation-item-system"
-
-  defp tool_status_class(status) do
-    base = "tool-status"
-
-    cond do
-      status == "running" -> "#{base} tool-status-running"
-      String.starts_with?(to_string(status), "failed") -> "#{base} tool-status-failed"
-      true -> "#{base} tool-status-completed"
-    end
-  end
 
   defp schedule_runtime_tick do
     Process.send_after(self(), :runtime_tick, @runtime_tick_ms)

--- a/elixir/lib/symphony_elixir_web/presenter.ex
+++ b/elixir/lib/symphony_elixir_web/presenter.ex
@@ -329,7 +329,8 @@ defmodule SymphonyElixirWeb.Presenter do
 
   defp conversation_event_kind(event, method, payload, message) do
     cond do
-      agent_message_delta?(method) -> :assistant_delta
+      agent_message_completed?(method, payload) -> :assistant_completed
+      agent_message_delta?(method) -> :ignore
       command_begin?(method, payload) -> :command_begin
       command_output?(method) -> :command_output
       command_end?(method, payload) -> :command_end
@@ -339,175 +340,57 @@ defmodule SymphonyElixirWeb.Presenter do
     end
   end
 
-  defp append_classified_conversation_event(:assistant_delta, event, method, payload, _raw, _message, items) do
-    append_assistant_delta(event, method, payload, items)
+  defp append_classified_conversation_event(:assistant_completed, event, method, payload, _raw, _message, items) do
+    append_completed_assistant_message(event, method, payload, items)
   end
 
-  defp append_classified_conversation_event(:command_begin, event, method, payload, _raw, _message, items) do
-    append_command_begin(event, method, payload, items)
+  defp append_classified_conversation_event(:ignore, _event, _method, _payload, _raw, _message, items) do
+    items
   end
 
-  defp append_classified_conversation_event(:command_output, event, _method, payload, _raw, _message, items) do
-    append_command_output(event, payload, items)
+  defp append_classified_conversation_event(:command_begin, _event, _method, _payload, _raw, _message, items) do
+    items
   end
 
-  defp append_classified_conversation_event(:command_end, event, _method, payload, _raw, _message, items) do
-    append_command_end(event, payload, items)
+  defp append_classified_conversation_event(:command_output, _event, _method, _payload, _raw, _message, items) do
+    items
   end
 
-  defp append_classified_conversation_event(:manager_steer, event, _method, _payload, raw, message, items) do
-    append_new_item(manager_message_item(event, message, raw), items)
+  defp append_classified_conversation_event(:command_end, _event, _method, _payload, _raw, _message, items) do
+    items
   end
 
-  defp append_classified_conversation_event(:warning, event, _method, _payload, raw, message, items) do
-    append_system_item(event, "warning", summarized_event_message(event, message), raw, items)
+  defp append_classified_conversation_event(:manager_steer, _event, _method, _payload, _raw, _message, items) do
+    items
   end
 
-  defp append_classified_conversation_event(:system, event, _method, _payload, raw, message, items) do
-    append_system_item(event, "system", summarized_event_message(event, message), raw, items)
+  defp append_classified_conversation_event(:warning, _event, _method, _payload, _raw, _message, items) do
+    items
   end
 
-  defp append_assistant_delta(event, method, payload, []) do
-    delta = extract_text_delta(payload)
-    {excerpt, truncated?} = truncate_text(delta, @text_excerpt_chars)
-
-    append_new_item(
-      %{
-        type: "assistant",
-        key: item_key(event, payload),
-        at: iso8601(event[:timestamp]),
-        title: "Assistant",
-        excerpt: excerpt <> if(truncated?, do: "\n[truncated]", else: ""),
-        truncated?: truncated?,
-        raw: [raw_item(method, event, payload)]
-      },
-      []
-    )
+  defp append_classified_conversation_event(:system, _event, _method, _payload, _raw, _message, items) do
+    items
   end
 
-  defp append_assistant_delta(event, method, payload, [last | rest] = items) do
-    key = item_key(event, payload)
-    delta = extract_text_delta(payload)
+  defp append_completed_assistant_message(event, _method, payload, items) do
+    text = payload |> extract_completed_agent_text() |> Redactor.redact() |> absorb_redacted_suffix()
+    {excerpt, truncated?} = truncate_text(text, @text_excerpt_chars)
 
-    if last[:type] == "assistant" and last[:key] == key do
-      updated =
-        last
-        |> append_excerpt_delta(delta)
-        |> prepend_raw(raw_item(method, event, payload))
-
-      [updated | rest]
+    if String.trim(excerpt) == "" do
+      items
     else
-      {excerpt, truncated?} = truncate_text(delta, @text_excerpt_chars)
-
       append_new_item(
         %{
           type: "assistant",
-          key: key,
+          key: item_key(event, payload),
           at: iso8601(event[:timestamp]),
-          title: "Assistant",
+          title: "Agent",
           excerpt: excerpt <> if(truncated?, do: "\n[truncated]", else: ""),
-          truncated?: truncated?,
-          raw: [raw_item(method, event, payload)]
+          truncated?: truncated?
         },
         items
       )
     end
-  end
-
-  defp append_assistant_delta(event, method, payload, items) do
-    append_assistant_delta(event, method, payload, List.wrap(items))
-  end
-
-  defp append_command_begin(event, method, payload, items) do
-    command = extract_command(payload) || summarize_message(payload) || "command"
-    key = item_key(event, payload)
-
-    append_new_item(
-      %{
-        type: "tool",
-        key: key,
-        at: iso8601(event[:timestamp]),
-        title: "Command",
-        command: command,
-        status: "running",
-        elapsed_ms: nil,
-        output_excerpt: "",
-        output_truncated?: false,
-        raw: [raw_item(method, event, payload)]
-      },
-      items
-    )
-  end
-
-  defp append_command_output(event, payload, items) do
-    output = extract_command_output(payload)
-    key = item_key(event, payload)
-
-    update_matching_or_append_tool(items, key, fn item ->
-      output_text =
-        item
-        |> Map.get(:output_excerpt, "")
-        |> String.replace_suffix("\n[truncated]", "")
-        |> Kernel.<>(output)
-        |> Redactor.redact()
-        |> absorb_redacted_suffix()
-
-      {excerpt, truncated?} = truncate_text(output_text, @text_excerpt_chars)
-
-      item
-      |> Map.put(:output_excerpt, excerpt)
-      |> Map.put(:output_truncated?, Map.get(item, :output_truncated?, false) or truncated?)
-      |> prepend_raw(raw_item("command output", event, payload))
-    end)
-  end
-
-  defp append_command_end(event, payload, items) do
-    key = item_key(event, payload)
-    status = command_status(payload)
-
-    update_matching_or_append_tool(items, key, fn item ->
-      item
-      |> Map.put(:status, status)
-      |> Map.put(:elapsed_ms, elapsed_ms(item.at, event[:timestamp]))
-      |> prepend_raw(raw_item("command end", event, payload))
-    end)
-  end
-
-  defp update_matching_or_append_tool(items, key, fun) do
-    case Enum.split_while(items, fn item -> !(item[:type] == "tool" and item[:key] == key) end) do
-      {before, [item | after_items]} ->
-        before ++ [fun.(item) | after_items]
-
-      _ ->
-        placeholder = %{
-          type: "tool",
-          key: key,
-          at: nil,
-          title: "Command",
-          command: "command",
-          status: "running",
-          elapsed_ms: nil,
-          output_excerpt: "",
-          output_truncated?: false,
-          raw: []
-        }
-
-        append_new_item(fun.(placeholder), items)
-    end
-  end
-
-  defp append_system_item(event, kind, message, raw, items) do
-    append_new_item(
-      %{
-        type: kind,
-        key: "#{kind}:#{iso8601(event[:timestamp])}:#{event[:event]}:#{length(items)}",
-        at: iso8601(event[:timestamp]),
-        title: if(kind == "warning", do: "Warning", else: event_label(event[:event])),
-        excerpt: message || "Worker update",
-        raw: [raw_item(event[:event], event, raw)]
-      },
-      items
-    )
   end
 
   defp append_new_item(item, items), do: [item | items]
@@ -520,59 +403,8 @@ defmodule SymphonyElixirWeb.Presenter do
     end
   end
 
-  defp prepend_raw(item, raw) do
-    Map.update(item, :raw, [raw], fn entries ->
-      [raw | entries] |> Enum.take(@raw_items_per_display_item)
-    end)
-  end
-
-  defp append_excerpt_delta(item, delta) do
-    current_excerpt =
-      item
-      |> Map.get(:excerpt, "")
-      |> String.replace_suffix("\n[truncated]", "")
-
-    {excerpt, truncated?} =
-      current_excerpt
-      |> Kernel.<>(delta)
-      |> Redactor.redact()
-      |> absorb_redacted_suffix()
-      |> truncate_text(@text_excerpt_chars)
-
-    item
-    |> Map.put(:excerpt, excerpt <> if(truncated?, do: "\n[truncated]", else: ""))
-    |> Map.put(:truncated?, Map.get(item, :truncated?, false) or truncated?)
-  end
-
   defp absorb_redacted_suffix(text) when is_binary(text) do
     Regex.replace(~r/\[REDACTED\][A-Za-z0-9_=\-]+/, text, "[REDACTED]")
-  end
-
-  defp manager_message_item(event, message, raw) do
-    text =
-      message
-      |> summarize_message()
-      |> strip_manager_prefix()
-
-    %{
-      type: "user",
-      key: "manager:#{iso8601(event[:timestamp])}:#{event[:turn_id]}",
-      at: iso8601(event[:timestamp]),
-      title: "Manager",
-      excerpt: text,
-      raw: [raw_item(event[:event], event, raw)]
-    }
-  end
-
-  defp raw_item(label, event, payload) do
-    {excerpt, truncated?} = inspect_bounded(payload, @raw_excerpt_chars)
-
-    %{
-      label: to_string(label || event[:event] || "event"),
-      at: iso8601(event[:timestamp]),
-      excerpt: excerpt,
-      truncated?: truncated?
-    }
   end
 
   defp event_method(%{} = payload) do
@@ -587,6 +419,10 @@ defmodule SymphonyElixirWeb.Presenter do
   defp event_method(_payload), do: nil
 
   defp agent_message_delta?(method), do: method in ["item/agentMessage/delta", "codex/event/agent_message_delta", "codex/event/agent_message_content_delta"]
+
+  defp agent_message_completed?(method, payload) do
+    item_lifecycle_type?(method, payload, "item/completed", "agentMessage")
+  end
 
   defp command_begin?(method, payload) do
     method in ["codex/event/exec_command_begin", "item/commandExecution/begin"] ||
@@ -617,10 +453,6 @@ defmodule SymphonyElixirWeb.Presenter do
     String.contains?(event_name, ["error", "warning", "failed"]) or String.contains?(text, ["error", "warning", "failed"])
   end
 
-  defp summarized_event_message(event, message) do
-    summarize_message(event[:message] || message || event[:raw])
-  end
-
   defp item_key(event, payload) do
     map_path(payload, ["params", "itemId"]) ||
       map_path(payload, [:params, :itemId]) ||
@@ -632,116 +464,38 @@ defmodule SymphonyElixirWeb.Presenter do
       "event"
   end
 
-  defp extract_text_delta(payload) do
+  defp extract_completed_agent_text(payload) do
     first_map_path(payload, [
-      ["params", "delta"],
-      [:params, :delta],
-      ["params", "textDelta"],
-      [:params, :textDelta],
-      ["params", "msg", "delta"],
-      [:params, :msg, :delta],
-      ["params", "msg", "textDelta"],
-      [:params, :msg, :textDelta],
-      ["params", "msg", "payload", "delta"],
-      [:params, :msg, :payload, :delta],
-      ["params", "msg", "payload", "textDelta"],
-      [:params, :msg, :payload, :textDelta],
+      ["params", "item", "text"],
+      [:params, :item, :text],
+      ["params", "item", "content"],
+      [:params, :item, :content],
+      ["params", "msg", "text"],
+      [:params, :msg, :text],
       ["params", "msg", "content"],
-      [:params, :msg, :content],
-      ["params", "msg", "payload", "content"],
-      [:params, :msg, :payload, :content]
-    ]) ||
-      ""
+      [:params, :msg, :content]
+    ])
+    |> normalize_agent_text()
   end
 
-  defp extract_command_output(payload) do
-    map_path(payload, ["params", "outputDelta"]) ||
-      map_path(payload, [:params, :outputDelta]) ||
-      map_path(payload, ["params", "msg", "delta"]) ||
-      map_path(payload, [:params, :msg, :delta]) ||
-      map_path(payload, ["params", "delta"]) ||
-      map_path(payload, [:params, :delta]) ||
-      ""
+  defp normalize_agent_text(text) when is_binary(text), do: text
+
+  defp normalize_agent_text(parts) when is_list(parts) do
+    parts
+    |> Enum.map(&normalize_agent_text_part/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n")
   end
 
-  defp extract_command(payload) do
-    command =
-      first_map_path(payload, [
-        ["params", "msg", "command"],
-        [:params, :msg, :command],
-        ["params", "item", "command"],
-        [:params, :item, :command],
-        ["params", "item", "parsedCmd"],
-        [:params, :item, :parsedCmd],
-        ["params", "item", "parsed_cmd"],
-        [:params, :item, :parsed_cmd],
-        ["params", "command"],
-        [:params, :command],
-        ["params", "parsedCmd"],
-        [:params, :parsedCmd],
-        ["params", "parsed_cmd"],
-        [:params, :parsed_cmd]
-      ])
+  defp normalize_agent_text(_text), do: ""
 
-    normalize_command(command)
+  defp normalize_agent_text_part(part) when is_binary(part), do: part
+
+  defp normalize_agent_text_part(%{} = part) do
+    map_value(part, ["text", :text, "content", :content]) |> normalize_agent_text()
   end
 
-  defp command_status(payload) do
-    exit_code =
-      map_path(payload, ["params", "msg", "exit_code"]) ||
-        map_path(payload, [:params, :msg, :exit_code]) ||
-        map_path(payload, ["params", "exitCode"]) ||
-        map_path(payload, [:params, :exitCode]) ||
-        map_path(payload, ["params", "item", "exitCode"]) ||
-        map_path(payload, [:params, :item, :exitCode])
-
-    case exit_code do
-      0 -> "completed"
-      code when is_integer(code) -> "failed (exit #{code})"
-      _ -> "completed"
-    end
-  end
-
-  defp elapsed_ms(nil, _ended_at), do: nil
-  defp elapsed_ms(_started_at, nil), do: nil
-
-  defp elapsed_ms(started_at, %DateTime{} = ended_at) when is_binary(started_at) do
-    case DateTime.from_iso8601(started_at) do
-      {:ok, parsed, _offset} -> max(DateTime.diff(ended_at, parsed, :millisecond), 0)
-      _ -> nil
-    end
-  end
-
-  defp elapsed_ms(_started_at, _ended_at), do: nil
-
-  defp strip_manager_prefix(nil), do: nil
-
-  defp strip_manager_prefix(text) when is_binary(text) do
-    text
-    |> String.replace_prefix("manager steer queued: ", "")
-    |> String.replace_prefix("manager steer delivered: ", "")
-  end
-
-  defp normalize_command(%{} = command) do
-    binary_command = map_value(command, ["parsedCmd", :parsedCmd, "command", :command, "cmd", :cmd])
-    args = map_value(command, ["args", :args, "argv", :argv])
-
-    if is_binary(binary_command) and is_list(args) do
-      normalize_command([binary_command | args])
-    else
-      normalize_command(binary_command || args)
-    end
-  end
-
-  defp normalize_command(command) when is_binary(command), do: String.trim(command)
-
-  defp normalize_command(command) when is_list(command) do
-    if Enum.all?(command, &is_binary/1) do
-      command |> Enum.join(" ") |> normalize_command()
-    end
-  end
-
-  defp normalize_command(_command), do: nil
+  defp normalize_agent_text_part(_part), do: ""
 
   defp truncate_text(text, limit) when is_binary(text) do
     if String.length(text) > limit do
@@ -750,8 +504,6 @@ defmodule SymphonyElixirWeb.Presenter do
       {text, false}
     end
   end
-
-  defp truncate_text(value, limit), do: value |> to_string() |> truncate_text(limit)
 
   defp inspect_bounded(value, limit) do
     {bounded, structurally_truncated?} = bound_debug_value(value, limit)
@@ -835,9 +587,6 @@ defmodule SymphonyElixirWeb.Presenter do
       Enum.any?(values, fn {_value, truncated?} -> truncated? end)
     }
   end
-
-  defp event_label(event) when is_atom(event), do: event |> Atom.to_string() |> String.replace("_", " ")
-  defp event_label(event), do: event |> to_string() |> String.replace("_", " ")
 
   defp first_map_path(value, paths) do
     Enum.find_value(paths, &map_path(value, &1))

--- a/elixir/lib/symphony_elixir_web/presenter.ex
+++ b/elixir/lib/symphony_elixir_web/presenter.ex
@@ -143,7 +143,19 @@ defmodule SymphonyElixirWeb.Presenter do
   defp optional_timeline(running), do: timeline_payload(running)
 
   defp optional_conversation(nil), do: []
-  defp optional_conversation(running), do: running |> Map.get(:recent_codex_events, []) |> worker_conversation()
+
+  defp optional_conversation(running) do
+    running
+    |> conversation_events()
+    |> worker_conversation()
+  end
+
+  defp conversation_events(running) do
+    case Map.get(running, :completed_agent_messages, []) do
+      [_ | _] = messages -> messages
+      _ -> Map.get(running, :recent_codex_events, [])
+    end
+  end
 
   defp retry_error(nil), do: nil
   defp retry_error(retry), do: retry.error

--- a/elixir/priv/static/dashboard.css
+++ b/elixir/priv/static/dashboard.css
@@ -432,17 +432,30 @@ pre,
 
 .rate-limit-list {
   display: grid;
-  gap: 0.8rem;
-  margin-top: 1rem;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-top: 1.05rem;
 }
 
 .rate-limit-row {
   display: grid;
-  gap: 0.65rem;
-  padding: 0.95rem;
+  gap: 0.8rem;
+  min-height: 11rem;
+  padding: 1rem;
   border: 1px solid var(--line);
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.62);
+  border-radius: 18px;
+  background: white;
+  box-shadow: var(--shadow-sm);
+}
+
+.rate-limit-row-primary {
+  background: linear-gradient(180deg, #eff8ff 0%, #ffffff 72%);
+  border-color: #bfdbfe;
+}
+
+.rate-limit-row-secondary {
+  background: linear-gradient(180deg, #f5f3ff 0%, #ffffff 72%);
+  border-color: #ddd6fe;
 }
 
 .rate-limit-main {
@@ -454,6 +467,8 @@ pre,
 
 .rate-limit-name {
   margin: 0;
+  color: var(--ink);
+  font-size: 1rem;
   font-weight: 700;
 }
 
@@ -491,10 +506,10 @@ pre,
 
 .rate-limit-bar {
   overflow: hidden;
-  height: 0.58rem;
+  height: 0.72rem;
   border-radius: 999px;
-  background: var(--card-muted);
-  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(217, 217, 227, 0.95);
 }
 
 .rate-limit-bar-fill {
@@ -515,6 +530,37 @@ pre,
 
 .rate-limit-debug {
   margin-top: 0.85rem;
+}
+
+.worker-detail-workspace {
+  display: grid;
+  grid-template-columns: minmax(16rem, 20rem) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: stretch;
+}
+
+.worker-status-sidebar {
+  display: grid;
+  align-content: start;
+  gap: 0.85rem;
+  max-height: min(74vh, 54rem);
+  overflow: auto;
+  padding: 1rem;
+  background: var(--card);
+  border: 1px solid rgba(217, 217, 227, 0.82);
+  border-radius: 22px;
+  box-shadow: var(--shadow-sm);
+}
+
+.sidebar-section {
+  display: grid;
+  gap: 0.35rem;
+  padding-bottom: 0.85rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.sidebar-section:last-of-type {
+  border-bottom: 0;
 }
 
 .steer-form {
@@ -552,12 +598,13 @@ pre,
 
 .agent-panel {
   display: grid;
-  min-height: 38rem;
-  grid-template-rows: auto minmax(18rem, 1fr) auto;
+  height: min(74vh, 54rem);
+  min-height: 34rem;
+  grid-template-rows: auto minmax(0, 1fr) auto;
   overflow: hidden;
   background: var(--card);
   border: 1px solid rgba(217, 217, 227, 0.82);
-  border-radius: 24px;
+  border-radius: 22px;
   box-shadow: var(--shadow-sm);
 }
 
@@ -571,10 +618,10 @@ pre,
 }
 
 .conversation-scroll {
-  max-height: min(68vh, 46rem);
   overflow-y: auto;
   padding: 1rem 1.15rem;
   background: #fbfbfc;
+  scroll-behavior: smooth;
 }
 
 .conversation-list {
@@ -588,12 +635,17 @@ pre,
 .conversation-item {
   display: grid;
   gap: 0.42rem;
-  max-width: min(48rem, 92%);
+  max-width: min(54rem, 96%);
   padding: 0.85rem 0.95rem;
   border: 1px solid var(--line);
   border-radius: 16px;
   background: white;
   box-shadow: var(--shadow-sm);
+}
+
+.conversation-item-assistant {
+  justify-self: stretch;
+  border-color: rgba(16, 163, 127, 0.18);
 }
 
 .conversation-item-user {
@@ -719,10 +771,11 @@ pre,
 }
 
 .debug-drawer {
-  padding: 0.95rem 1.15rem;
+  padding: 0.8rem 0 0;
   border: 1px solid var(--line);
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.72);
+  border-width: 1px 0 0;
+  border-radius: 0;
+  background: transparent;
 }
 
 .debug-drawer summary,
@@ -823,6 +876,19 @@ pre,
   .metric-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .worker-detail-workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .worker-status-sidebar,
+  .agent-panel {
+    max-height: none;
+  }
+
+  .agent-panel {
+    height: min(76vh, 44rem);
+  }
 }
 
 @media (max-width: 560px) {
@@ -832,6 +898,7 @@ pre,
 
   .section-card,
   .agent-panel,
+  .worker-status-sidebar,
   .hero-card,
   .error-card {
     border-radius: 20px;

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -1795,6 +1795,38 @@ defmodule SymphonyElixir.ExtensionsTest do
     refute html =~ hidden_marker
   end
 
+  test "worker detail projection uses durable completed messages when raw events roll over" do
+    noisy_recent_events =
+      1..80
+      |> Enum.map(fn index ->
+        command_event("item/commandExecution/outputDelta", %{"itemId" => "cmd-#{index}", "outputDelta" => "noise #{index}"}, DateTime.add(~U[2026-01-01 00:00:00Z], index, :second))
+      end)
+
+    snapshot =
+      static_snapshot()
+      |> put_in([:running, Access.at(0), :recent_codex_events], noisy_recent_events)
+      |> put_in([:running, Access.at(0), :completed_agent_messages], [
+        agent_completed_event("msg-durable", "Durable message survives noise.", ~U[2026-01-01 00:00:00Z])
+      ])
+
+    orchestrator_name = Module.concat(__MODULE__, :WorkerDetailDurableMessagesOrchestrator)
+
+    {:ok, _pid} =
+      StaticOrchestrator.start_link(
+        name: orchestrator_name,
+        snapshot: snapshot
+      )
+
+    start_test_endpoint(orchestrator: orchestrator_name, snapshot_timeout_ms: 50)
+
+    issue_payload = json_response(get(build_conn(), "/api/v1/MT-HTTP"), 200)
+    assert [%{"type" => "assistant", "excerpt" => "Durable message survives noise."}] = issue_payload["conversation"]
+
+    {:ok, _view, html} = live(build_conn(), "/workers/MT-HTTP")
+    assert html =~ "Durable message survives noise."
+    refute html =~ "noise 80"
+  end
+
   test "worker detail projection redacts secrets from completed agent messages" do
     snapshot =
       static_snapshot()

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -946,23 +946,29 @@ defmodule SymphonyElixir.ExtensionsTest do
                  "session_id" => "thread-http",
                  "thread_id" => "thread-http",
                  "turn_id" => "turn-http"
+               },
+               %{
+                 "at" => "2026-01-01T00:00:01Z",
+                 "event" => "notification",
+                 "message" => "item completed: agent message (msg-static)",
+                 "raw" => %{
+                   "excerpt" =>
+                     "%{\n  \"method\" => \"item/completed\",\n  \"params\" => %{\n    \"item\" => %{\n      \"id\" => \"msg-static\",\n      \"text\" => \"Agent update complete.\",\n      \"type\" => \"agentMessage\"\n    }\n  }\n}",
+                   "truncated?" => false
+                 },
+                 "session_id" => "thread-http",
+                 "thread_id" => "thread-http",
+                 "turn_id" => "turn-http"
                }
              ],
              "conversation" => [
                %{
-                 "type" => "user",
-                 "key" => "manager:2026-01-01T00:00:00Z:turn-http",
-                 "at" => "2026-01-01T00:00:00Z",
-                 "title" => "Manager",
-                 "excerpt" => "Keep the PR focused.",
-                 "raw" => [
-                   %{
-                     "label" => "manager_steer_delivered",
-                     "at" => "2026-01-01T00:00:00Z",
-                     "excerpt" => "%{\"id\" => 10123, \"result\" => %{\"turnId\" => \"turn-http\"}}",
-                     "truncated?" => false
-                   }
-                 ]
+                 "type" => "assistant",
+                 "key" => "msg-static",
+                 "at" => "2026-01-01T00:00:01Z",
+                 "title" => "Agent",
+                 "excerpt" => "Agent update complete.",
+                 "truncated?" => false
                }
              ],
              "debug" => %{
@@ -1732,11 +1738,12 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     {:ok, view, html} = live(build_conn(), "/workers/MT-HTTP")
     assert html =~ "Worker Detail"
-    assert html =~ "Conversation"
+    assert html =~ "Agent Messages"
     assert html =~ "thread-http"
-    assert html =~ "Keep the PR focused."
-    assert html =~ "Debug JSON"
+    assert html =~ "Agent update complete."
     assert html =~ "Worker debug payload"
+    refute html =~ "Keep the PR focused."
+    refute html =~ "Debug JSON"
     refute html =~ "Steer worker"
     refute html =~ "Timeline"
     refute html =~ "Raw worker payload"
@@ -1751,7 +1758,7 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert_received {:steer_worker_called, "MT-HTTP", "Use the narrower UI fix.", "thread-http"}
   end
 
-  test "worker detail projection coalesces streaming deltas and truncates command output" do
+  test "worker detail projection renders completed agent messages and hides command output" do
     hidden_marker = "TAIL_SHOULD_NOT_RENDER"
     long_output = String.duplicate("a", 2_050) <> hidden_marker <> String.duplicate("b", 600)
 
@@ -1759,7 +1766,7 @@ defmodule SymphonyElixir.ExtensionsTest do
       static_snapshot()
       |> put_in([:running, Access.at(0), :recent_codex_events], [
         agent_delta_event("msg-1", "Hello ", ~U[2026-01-01 00:00:00Z]),
-        agent_delta_event("msg-1", "manager.", ~U[2026-01-01 00:00:01Z]),
+        agent_completed_event("msg-1", "Hello manager.", ~U[2026-01-01 00:00:01Z]),
         command_event("item/started", %{"item" => %{"id" => "cmd-1", "type" => "commandExecution", "command" => "mix test"}}, ~U[2026-01-01 00:00:02Z]),
         command_event("item/commandExecution/outputDelta", %{"itemId" => "cmd-1", "outputDelta" => long_output}, ~U[2026-01-01 00:00:03Z]),
         command_event("item/completed", %{"item" => %{"id" => "cmd-1", "type" => "commandExecution", "exitCode" => 0}}, ~U[2026-01-01 00:00:04Z])
@@ -1776,30 +1783,24 @@ defmodule SymphonyElixir.ExtensionsTest do
     start_test_endpoint(orchestrator: orchestrator_name, snapshot_timeout_ms: 50)
 
     issue_payload = json_response(get(build_conn(), "/api/v1/MT-HTTP"), 200)
-    assert [%{"type" => "assistant", "excerpt" => "Hello manager."}, %{"type" => "tool"} = tool] = issue_payload["conversation"]
-    assert tool["command"] == "mix test"
-    assert tool["status"] == "completed"
-    assert tool["output_truncated?"] == true
-    assert String.length(tool["output_excerpt"]) == 2_000
+    assert [%{"type" => "assistant", "excerpt" => "Hello manager."}] = issue_payload["conversation"]
     refute Map.has_key?(List.first(issue_payload["conversation"]), "content")
-    refute Map.has_key?(tool, "output")
 
     rendered_payload = inspect(issue_payload, limit: :infinity)
     refute rendered_payload =~ hidden_marker
 
     {:ok, _view, html} = live(build_conn(), "/workers/MT-HTTP")
     assert html =~ "Hello manager."
-    assert html =~ "mix test"
-    assert html =~ "[truncated]"
+    refute html =~ "mix test"
     refute html =~ hidden_marker
   end
 
-  test "worker detail projection redacts secrets after coalescing streamed chunks" do
+  test "worker detail projection redacts secrets from completed agent messages" do
     snapshot =
       static_snapshot()
       |> put_in([:running, Access.at(0), :recent_codex_events], [
         agent_delta_event("msg-secret", "token sk-", ~U[2026-01-01 00:00:00Z]),
-        agent_delta_event("msg-secret", "liveSecret123", ~U[2026-01-01 00:00:01Z]),
+        agent_completed_event("msg-secret", "token sk-liveSecret123", ~U[2026-01-01 00:00:01Z]),
         command_event(
           "item/started",
           %{"item" => %{"id" => "cmd-secret", "type" => "commandExecution", "command" => "mix test"}},
@@ -1822,14 +1823,13 @@ defmodule SymphonyElixir.ExtensionsTest do
     issue_payload = json_response(get(build_conn(), "/api/v1/MT-HTTP"), 200)
     rendered_payload = inspect(issue_payload, limit: :infinity)
 
-    assert [%{"type" => "assistant", "excerpt" => "token [REDACTED]"}, %{"type" => "tool"} = tool] =
+    assert [%{"type" => "assistant", "excerpt" => "token [REDACTED]"}] =
              issue_payload["conversation"]
 
-    assert tool["output_excerpt"] == "Authorization: Bearer [REDACTED]"
     refute rendered_payload =~ "sk-liveSecret123"
   end
 
-  test "worker detail projection renders textDelta assistant chunks" do
+  test "worker detail projection ignores streaming textDelta assistant chunks" do
     snapshot =
       static_snapshot()
       |> put_in([:running, Access.at(0), :recent_codex_events], [
@@ -1849,16 +1849,15 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     issue_payload = json_response(get(build_conn(), "/api/v1/MT-HTTP"), 200)
 
-    assert [%{"type" => "assistant", "excerpt" => "Hello from textDelta"}] =
-             issue_payload["conversation"]
+    assert issue_payload["conversation"] == []
   end
 
-  test "worker detail projection reads parsed messages when raw app-server JSON is a string" do
+  test "worker detail projection reads completed messages when raw app-server JSON is a string" do
     snapshot =
       static_snapshot()
       |> put_in([:running, Access.at(0), :recent_codex_events], [
         raw_json_event("item/agentMessage/delta", %{"itemId" => "msg-json", "delta" => "Production "}, ~U[2026-01-01 00:00:00Z]),
-        raw_json_event("item/agentMessage/delta", %{"itemId" => "msg-json", "delta" => "delta"}, ~U[2026-01-01 00:00:01Z]),
+        raw_json_event("item/completed", %{"item" => %{"id" => "msg-json", "type" => "agentMessage", "text" => "Production delta"}}, ~U[2026-01-01 00:00:01Z]),
         raw_json_event(
           "item/started",
           %{"item" => %{"id" => "cmd-json", "type" => "commandExecution", "command" => ["mix", "test"]}},
@@ -1883,18 +1882,16 @@ defmodule SymphonyElixir.ExtensionsTest do
     start_test_endpoint(orchestrator: orchestrator_name, snapshot_timeout_ms: 50)
 
     issue_payload = json_response(get(build_conn(), "/api/v1/MT-HTTP"), 200)
-    assert [%{"type" => "assistant", "excerpt" => "Production delta"}, %{"type" => "tool"} = tool] = issue_payload["conversation"]
-    assert tool["command"] == "mix test"
-    assert tool["output_excerpt"] == "ok\n"
+    assert [%{"type" => "assistant", "excerpt" => "Production delta"}] = issue_payload["conversation"]
   end
 
-  test "worker detail projection handles content deltas and parsed command fields" do
+  test "worker detail projection handles completed content lists and hides parsed command fields" do
     snapshot =
       static_snapshot()
       |> put_in([:running, Access.at(0), :recent_codex_events], [
         raw_json_event(
-          "codex/event/agent_message_content_delta",
-          %{"itemId" => "msg-content", "msg" => %{"content" => "Content delta"}},
+          "item/completed",
+          %{"item" => %{"id" => "msg-content", "type" => "agentMessage", "content" => [%{"text" => "Content delta"}]}},
           ~U[2026-01-01 00:00:00Z]
         ),
         raw_json_event(
@@ -1916,7 +1913,7 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     issue_payload = json_response(get(build_conn(), "/api/v1/MT-HTTP"), 200)
 
-    assert [%{"type" => "assistant", "excerpt" => "Content delta"}, %{"type" => "tool", "command" => "mix specs.check"}] =
+    assert [%{"type" => "assistant", "excerpt" => "Content delta"}] =
              issue_payload["conversation"]
   end
 
@@ -1924,15 +1921,7 @@ defmodule SymphonyElixir.ExtensionsTest do
     many_events =
       1..160
       |> Enum.map(fn index ->
-        %{
-          event: :notification,
-          message: "system event #{index}",
-          raw: %{"index" => index},
-          session_id: "thread-http",
-          thread_id: "thread-http",
-          turn_id: "turn-http",
-          timestamp: DateTime.add(~U[2026-01-01 00:00:00Z], index, :second)
-        }
+        agent_completed_event("msg-#{index}", "agent event #{index}", DateTime.add(~U[2026-01-01 00:00:00Z], index, :second))
       end)
 
     snapshot = put_in(static_snapshot(), [:running, Access.at(0), :recent_codex_events], many_events)
@@ -1949,9 +1938,8 @@ defmodule SymphonyElixir.ExtensionsTest do
     issue_payload = json_response(get(build_conn(), "/api/v1/MT-HTTP"), 200)
     assert length(issue_payload["conversation"]) == 120
     assert length(issue_payload["timeline"]) == 120
-    refute Enum.any?(issue_payload["conversation"], &(&1["excerpt"] == "system event 1"))
-    refute Enum.any?(issue_payload["timeline"], &(&1["message"] == "system event 1"))
-    assert List.last(issue_payload["conversation"])["excerpt"] == "system event 160"
+    refute Enum.any?(issue_payload["conversation"], &(&1["excerpt"] == "agent event 1"))
+    assert List.last(issue_payload["conversation"])["excerpt"] == "agent event 160"
   end
 
   test "worker detail projection does not process oversized raw payloads outside the display window" do
@@ -1973,15 +1961,7 @@ defmodule SymphonyElixir.ExtensionsTest do
     recent_events =
       1..420
       |> Enum.map(fn index ->
-        %{
-          event: :notification,
-          message: "recent system event #{index}",
-          raw: %{"index" => index},
-          session_id: "thread-http",
-          thread_id: "thread-http",
-          turn_id: "turn-http",
-          timestamp: DateTime.add(~U[2026-01-01 00:00:00Z], index, :second)
-        }
+        agent_completed_event("msg-recent-#{index}", "recent agent event #{index}", DateTime.add(~U[2026-01-01 00:00:00Z], index, :second))
       end)
 
     snapshot = put_in(static_snapshot(), [:running, Access.at(0), :recent_codex_events], [old_oversized_event | recent_events])
@@ -2014,7 +1994,7 @@ defmodule SymphonyElixir.ExtensionsTest do
       static_snapshot()
       |> put_in([:running, Access.at(0), :giant_debug_blob], long_debug_value)
       |> put_in([:running, Access.at(0), :recent_codex_events], [
-        agent_delta_event("msg-long", long_delta, ~U[2026-01-01 00:00:00Z])
+        agent_completed_event("msg-long", long_delta, ~U[2026-01-01 00:00:00Z])
       ])
 
     orchestrator_name = Module.concat(__MODULE__, :WorkerDetailBoundedPayloadOrchestrator)
@@ -2043,7 +2023,7 @@ defmodule SymphonyElixir.ExtensionsTest do
     refute html =~ hidden_debug_marker
   end
 
-  test "worker detail debug excerpts preserve redaction and structural truncation flags" do
+  test "worker detail completed messages preserve redaction and hide raw debug fields" do
     secret = "OPENAI_API_KEY=sk-live-secret"
 
     many_small_fields =
@@ -2054,11 +2034,8 @@ defmodule SymphonyElixir.ExtensionsTest do
     snapshot =
       static_snapshot()
       |> put_in([:running, Access.at(0), :recent_codex_events], [
-        command_event(
-          "item/started",
-          %{"item" => Map.merge(many_small_fields, %{"id" => "cmd-many", "type" => "commandExecution", "command" => "mix test"})},
-          ~U[2026-01-01 00:00:00Z]
-        )
+        agent_completed_event("msg-many", "Done with #{secret}", ~U[2026-01-01 00:00:00Z]),
+        command_event("item/started", %{"item" => Map.merge(many_small_fields, %{"id" => "cmd-many", "type" => "commandExecution", "command" => "mix test"})}, ~U[2026-01-01 00:00:01Z])
       ])
 
     orchestrator_name = Module.concat(__MODULE__, :WorkerDetailDebugTruncationOrchestrator)
@@ -2073,9 +2050,8 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     issue_payload = json_response(get(build_conn(), "/api/v1/MT-HTTP"), 200)
     rendered_payload = inspect(issue_payload, limit: :infinity)
-    [%{"raw" => [raw | _]}] = issue_payload["conversation"]
 
-    assert raw["truncated?"] == true
+    assert [%{"type" => "assistant", "excerpt" => "Done with OPENAI_API_KEY=[REDACTED]"}] = issue_payload["conversation"]
     refute rendered_payload =~ "sk-live-secret"
     assert rendered_payload =~ "[REDACTED]"
   end
@@ -2131,9 +2107,7 @@ defmodule SymphonyElixir.ExtensionsTest do
     issue_payload = json_response(get(build_conn(), "/api/v1/MT-HTTP"), 200)
     rendered_payload = inspect(issue_payload, limit: :infinity)
 
-    assert [%{"raw" => [list_raw | _]}, %{"raw" => [json_raw | _]}] = issue_payload["conversation"]
-    assert list_raw["truncated?"] == true
-    assert json_raw["truncated?"] == true
+    assert issue_payload["conversation"] == []
     refute rendered_payload =~ hidden_list_marker
     refute rendered_payload =~ hidden_json_marker
     refute rendered_payload =~ "sk-large-json-secret"
@@ -2517,6 +2491,21 @@ defmodule SymphonyElixir.ExtensionsTest do
               thread_id: "thread-http",
               turn_id: "turn-http",
               timestamp: ~U[2026-01-01 00:00:00Z]
+            },
+            %{
+              event: :notification,
+              message: %{
+                "method" => "item/completed",
+                "params" => %{"item" => %{"id" => "msg-static", "type" => "agentMessage", "text" => "Agent update complete."}}
+              },
+              raw: %{
+                "method" => "item/completed",
+                "params" => %{"item" => %{"id" => "msg-static", "type" => "agentMessage", "text" => "Agent update complete."}}
+              },
+              session_id: "thread-http",
+              thread_id: "thread-http",
+              turn_id: "turn-http",
+              timestamp: ~U[2026-01-01 00:00:01Z]
             }
           ],
           started_at: DateTime.utc_now()
@@ -2542,6 +2531,18 @@ defmodule SymphonyElixir.ExtensionsTest do
       event: :notification,
       message: %{"method" => "item/agentMessage/delta", "params" => %{"itemId" => item_id, "delta" => delta}},
       raw: %{"method" => "item/agentMessage/delta", "params" => %{"itemId" => item_id, "delta" => delta}},
+      session_id: "thread-http",
+      thread_id: "thread-http",
+      turn_id: "turn-http",
+      timestamp: timestamp
+    }
+  end
+
+  defp agent_completed_event(item_id, text, timestamp) do
+    %{
+      event: :notification,
+      message: %{"method" => "item/completed", "params" => %{"item" => %{"id" => item_id, "type" => "agentMessage", "text" => text}}},
+      raw: %{"method" => "item/completed", "params" => %{"item" => %{"id" => item_id, "type" => "agentMessage", "text" => text}}},
       session_id: "thread-http",
       thread_id: "thread-http",
       turn_id: "turn-http",

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -101,6 +101,108 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
            }
   end
 
+  test "orchestrator keeps completed agent messages outside the raw event ring" do
+    issue_id = "issue-completed-agent-messages"
+
+    issue = %Issue{
+      id: issue_id,
+      identifier: "MT-189",
+      title: "Completed agent messages",
+      description: "Keep completed messages visible",
+      state: "In Progress",
+      url: "https://example.org/issues/MT-189"
+    }
+
+    orchestrator_name = Module.concat(__MODULE__, :CompletedAgentMessagesOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    initial_state = :sys.get_state(pid)
+    started_at = DateTime.utc_now()
+
+    running_entry = %{
+      pid: self(),
+      ref: make_ref(),
+      identifier: issue.identifier,
+      issue: issue,
+      session_id: "thread-message-turn-message",
+      thread_id: "thread-message",
+      turn_id: "turn-message",
+      turn_count: 1,
+      last_codex_message: nil,
+      last_codex_timestamp: nil,
+      last_codex_event: nil,
+      recent_codex_events: [],
+      completed_agent_messages: [],
+      started_at: started_at
+    }
+
+    :sys.replace_state(pid, fn _ ->
+      initial_state
+      |> Map.put(:running, %{issue_id => running_entry})
+      |> Map.put(:claimed, MapSet.put(initial_state.claimed, issue_id))
+    end)
+
+    send(
+      pid,
+      {:codex_worker_update, issue_id,
+       %{
+         event: :notification,
+         message: %{
+           "method" => "item/completed",
+           "params" => %{
+             "item" => %{
+               "id" => "msg-189",
+               "type" => "agentMessage",
+               "text" => "Durable completed message"
+             }
+           }
+         },
+         timestamp: started_at
+       }}
+    )
+
+    for index <- 1..90 do
+      send(
+        pid,
+        {:codex_worker_update, issue_id,
+         %{
+           event: :notification,
+           message: %{"method" => "item/commandExecution/outputDelta", "params" => %{"outputDelta" => "noise #{index}"}},
+           timestamp: DateTime.add(started_at, index, :second)
+         }}
+      )
+    end
+
+    snapshot = GenServer.call(pid, :snapshot)
+    assert %{running: [snapshot_entry]} = snapshot
+
+    refute Enum.any?(snapshot_entry.recent_codex_events, fn event ->
+             inspect(event, limit: :infinity) =~ "Durable completed message"
+           end)
+
+    assert [
+             %{
+               event: :notification,
+               message: %{
+                 "method" => "item/completed",
+                 "params" => %{
+                   "item" => %{
+                     "id" => "msg-189",
+                     "type" => "agentMessage",
+                     "text" => "Durable completed message"
+                   }
+                 }
+               }
+             }
+           ] = snapshot_entry.completed_agent_messages
+  end
+
   test "orchestrator snapshot includes command watchdog metadata and stalled policy comments" do
     write_workflow_file!(
       Workflow.workflow_file_path(),


### PR DESCRIPTION
#### Context

Worker detail should read like an agent chat, not raw event text; continues #13 from operator feedback.

#### TL;DR

*Show only completed agent messages and give rate limits clearer visual sections.*

#### Summary

- Render worker conversations from completed `agentMessage` items only
- Move worker status/debug into a sidebar and make messages an auto-scrolling pane
- Split primary/secondary rate-limit rows with distinct color treatment
- Update tests for completed-message projection and hidden command/system noise

#### Alternatives

- Streaming deltas stayed out because partial tokens were noisy and not needed here.
- Command/system events remain available through timeline/debug surfaces instead of chat.

#### Test Plan

- [x] `mise exec -- mix test test/symphony_elixir/extensions_test.exs` -> 57 tests, 0 failures
- [x] `mise exec -- mix test` -> passed
- [x] `mise exec -- mix dialyzer --format short` -> passed
- [x] `git diff --check` -> passed
- [ ] `make -C elixir all` not run locally because Windows `make.cmd all` stopped at existing CRLF fmt-check debt outside this PR before the full gate could complete.