### PR TITLE
Make startup workspace cleanup retention-aware and non-blocking

### DIFF
--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -17,6 +17,7 @@ polling:
   interval_ms: 5000
 workspace:
   root: ~/code/symphony-workspaces
+  startup_cleanup_ttl_ms: 604800000
 hooks:
   after_create: |
     git clone --depth 1 https://github.com/openai/symphony .

--- a/elixir/docs/windows-native.md
+++ b/elixir/docs/windows-native.md
@@ -482,9 +482,21 @@ issue in `In Progress` unless a manager explicitly chooses another state.
 
 When the issue moves to a terminal state such as `Done`, Symphony stops the
 active agent and runs `hooks.before_remove` before removing the workspace.
-At startup, Symphony also queries terminal states and removes matching issue workspaces under the
-configured `workspace.root`. The cleanup script above is for manual retention cleanup, log cleanup,
-and operator-initiated workspace cleanup.
+At startup, Symphony schedules terminal workspace cleanup after the orchestrator
+returns from init, so dashboard and app readiness are not blocked by old
+workspace removal or `hooks.before_remove`.
+
+Startup cleanup is retention-aware. It queries terminal states plus configured
+active states and the protected `In Review` and `Blocked` states, preserves any
+non-terminal issue workspace, and removes only terminal issue workspaces whose
+`updated_at` timestamp is older than `workspace.startup_cleanup_ttl_ms`. The
+default TTL is seven days. Set the TTL to `0` only when an operator needs
+immediate terminal cleanup.
+
+Cleanup progress is exposed in orchestrator snapshots and the dashboard as
+`workspace_cleanup` with status, TTL, checked, cleaned, preserved, skipped, and
+error fields. The cleanup script above remains for manual retention cleanup, log
+cleanup, and operator-initiated workspace cleanup.
 
 ## Known Windows limitations
 

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -92,12 +92,14 @@ defmodule SymphonyElixir.Config.Schema do
     @primary_key false
     embedded_schema do
       field(:root, :string, default: Path.join(System.tmp_dir!(), "symphony_workspaces"))
+      field(:startup_cleanup_ttl_ms, :integer, default: 7 * 24 * 60 * 60 * 1_000)
     end
 
     @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
     def changeset(schema, attrs) do
       schema
-      |> cast(attrs, [:root], empty_values: [])
+      |> cast(attrs, [:root, :startup_cleanup_ttl_ms], empty_values: [])
+      |> validate_number(:startup_cleanup_ttl_ms, greater_than_or_equal_to: 0)
     end
   end
 

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -17,6 +17,8 @@ defmodule SymphonyElixir.Orchestrator do
   @poll_transition_render_delay_ms 20
   @max_recent_codex_events 80
   @steer_request_timeout_ms 3_000
+  @startup_cleanup_preserved_states ["In Review", "Blocked"]
+  @workspace_cleanup_progress_notify_every 10
   @empty_codex_totals %{
     input_tokens: 0,
     output_tokens: 0,
@@ -49,7 +51,9 @@ defmodule SymphonyElixir.Orchestrator do
       retry_attempts: %{},
       pending_steer_calls: %{},
       codex_totals: nil,
-      codex_rate_limits: nil
+      codex_rate_limits: nil,
+      workspace_cleanup: nil,
+      workspace_cleanup_ref: nil
     ]
   end
 
@@ -75,7 +79,7 @@ defmodule SymphonyElixir.Orchestrator do
       codex_rate_limits: nil
     }
 
-    run_terminal_workspace_cleanup()
+    send(self(), :run_terminal_workspace_cleanup)
     state = schedule_tick(state, 0)
 
     {:ok, state}
@@ -126,6 +130,28 @@ defmodule SymphonyElixir.Orchestrator do
     notify_dashboard()
     {:noreply, state}
   end
+
+  def handle_info(:run_terminal_workspace_cleanup, state) do
+    state = start_terminal_workspace_cleanup(state)
+    notify_dashboard()
+    {:noreply, state}
+  end
+
+  def handle_info({:terminal_workspace_cleanup_progress, cleanup_ref, cleanup}, %{workspace_cleanup_ref: cleanup_ref} = state)
+      when is_reference(cleanup_ref) and is_map(cleanup) do
+    notify_dashboard()
+    {:noreply, %{state | workspace_cleanup: cleanup}}
+  end
+
+  def handle_info({:terminal_workspace_cleanup_progress, _cleanup_ref, _cleanup}, state), do: {:noreply, state}
+
+  def handle_info({:terminal_workspace_cleanup_complete, cleanup_ref, cleanup}, %{workspace_cleanup_ref: cleanup_ref} = state)
+      when is_reference(cleanup_ref) and is_map(cleanup) do
+    notify_dashboard()
+    {:noreply, %{state | workspace_cleanup: cleanup, workspace_cleanup_ref: nil}}
+  end
+
+  def handle_info({:terminal_workspace_cleanup_complete, _cleanup_ref, _cleanup}, state), do: {:noreply, state}
 
   def handle_info(
         {:DOWN, ref, :process, _pid, reason},
@@ -1003,29 +1029,144 @@ defmodule SymphonyElixir.Orchestrator do
     {:noreply, release_issue_claim(state, issue_id)}
   end
 
-  defp cleanup_issue_workspace(identifier, worker_host \\ nil)
-
   defp cleanup_issue_workspace(identifier, worker_host) when is_binary(identifier) do
     Workspace.remove_issue_workspaces(identifier, worker_host)
   end
 
   defp cleanup_issue_workspace(_identifier, _worker_host), do: :ok
 
-  defp run_terminal_workspace_cleanup do
-    case Tracker.fetch_issues_by_states(Config.settings!().tracker.terminal_states) do
-      {:ok, issues} ->
-        issues
-        |> Enum.each(fn
-          %Issue{identifier: identifier} when is_binary(identifier) ->
-            cleanup_issue_workspace(identifier)
+  defp start_terminal_workspace_cleanup(%State{} = state) do
+    settings = Config.settings!()
+    ttl_ms = settings.workspace.startup_cleanup_ttl_ms
+    started_at = DateTime.utc_now()
+    cleanup = cleanup_result(started_at, ttl_ms)
+    cleanup_ref = make_ref()
+    owner = self()
 
-          _ ->
-            :ok
-        end)
+    Logger.info("Starting retention-aware terminal workspace cleanup ttl_ms=#{ttl_ms}")
+
+    start_workspace_cleanup_task(fn ->
+      run_terminal_workspace_cleanup(owner, cleanup_ref, settings, cleanup)
+    end)
+
+    %{state | workspace_cleanup: cleanup, workspace_cleanup_ref: cleanup_ref}
+  end
+
+  defp start_workspace_cleanup_task(fun) when is_function(fun, 0) do
+    if Process.whereis(SymphonyElixir.TaskSupervisor) do
+      start_agent_task(fun)
+    else
+      Task.start(fun)
+    end
+  end
+
+  defp run_terminal_workspace_cleanup(owner, cleanup_ref, settings, cleanup) do
+    case Tracker.fetch_issues_by_states(cleanup_candidate_states(settings)) do
+      {:ok, issues} ->
+        result =
+          issues
+          |> Enum.with_index(1)
+          |> Enum.reduce(cleanup, fn {issue, index}, result ->
+            result = maybe_cleanup_terminal_workspace(issue, result)
+            maybe_send_cleanup_progress(owner, cleanup_ref, result, index)
+            result
+          end)
+          |> Map.put(:status, :completed)
+          |> Map.put(:completed_at, DateTime.utc_now())
+
+        Logger.info("Completed terminal workspace cleanup checked=#{result.checked} cleaned=#{result.cleaned} preserved=#{result.preserved} skipped=#{result.skipped}")
+        send(owner, {:terminal_workspace_cleanup_complete, cleanup_ref, result})
 
       {:error, reason} ->
         Logger.warning("Skipping startup terminal workspace cleanup; failed to fetch terminal issues: #{inspect(reason)}")
+
+        result =
+          cleanup
+          |> Map.put(:status, :failed)
+          |> Map.put(:completed_at, DateTime.utc_now())
+          |> Map.put(:error, inspect(reason))
+
+        send(owner, {:terminal_workspace_cleanup_complete, cleanup_ref, result})
     end
+  end
+
+  defp maybe_send_cleanup_progress(owner, cleanup_ref, result, index) do
+    if rem(index, @workspace_cleanup_progress_notify_every) == 0 do
+      send(owner, {:terminal_workspace_cleanup_progress, cleanup_ref, result})
+    end
+  end
+
+  defp cleanup_candidate_states(settings) do
+    (settings.tracker.terminal_states ++ settings.tracker.active_states ++ @startup_cleanup_preserved_states)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+  end
+
+  defp cleanup_result(started_at, ttl_ms) do
+    %{
+      status: :running,
+      started_at: started_at,
+      completed_at: nil,
+      ttl_ms: ttl_ms,
+      checked: 0,
+      cleaned: 0,
+      preserved: 0,
+      skipped: 0,
+      error: nil
+    }
+  end
+
+  defp maybe_cleanup_terminal_workspace(%Issue{} = issue, result) do
+    result = Map.update!(result, :checked, &(&1 + 1))
+
+    cond do
+      !terminal_issue_state?(issue.state, terminal_state_set()) ->
+        Map.update!(result, :preserved, &(&1 + 1))
+
+      !cleanup_ttl_expired?(issue, result) ->
+        Map.update!(result, :preserved, &(&1 + 1))
+
+      is_binary(issue.identifier) ->
+        case cleanup_issue_workspace_with_result(issue.identifier) do
+          {:ok, removed_count} ->
+            Map.update!(result, :cleaned, &(&1 + removed_count))
+
+          {:error, reason} ->
+            result
+            |> Map.update!(:skipped, &(&1 + 1))
+            |> Map.put(:error, inspect(reason))
+        end
+
+      true ->
+        Map.update!(result, :skipped, &(&1 + 1))
+    end
+  end
+
+  defp maybe_cleanup_terminal_workspace(_issue, result) do
+    result
+    |> Map.update!(:checked, &(&1 + 1))
+    |> Map.update!(:skipped, &(&1 + 1))
+  end
+
+  defp cleanup_ttl_expired?(_issue, %{ttl_ms: 0}), do: true
+
+  defp cleanup_ttl_expired?(%Issue{updated_at: %DateTime{} = updated_at}, %{started_at: %DateTime{}, ttl_ms: ttl_ms} = result)
+       when is_integer(ttl_ms) and ttl_ms > 0 do
+    DateTime.diff(result.started_at, updated_at, :millisecond) >= ttl_ms
+  end
+
+  defp cleanup_ttl_expired?(_issue, _result), do: false
+
+  defp cleanup_issue_workspace_with_result(identifier) when is_binary(identifier) do
+    remove_fun =
+      Application.get_env(
+        :symphony_elixir,
+        :workspace_remove_issue_workspaces,
+        &Workspace.remove_issue_workspaces_with_result/1
+      )
+
+    remove_fun.(identifier)
   end
 
   defp notify_dashboard do
@@ -1322,6 +1463,17 @@ defmodule SymphonyElixir.Orchestrator do
     end
   end
 
+  defp workspace_cleanup_snapshot(nil), do: nil
+
+  defp workspace_cleanup_snapshot(%{} = cleanup) do
+    cleanup
+    |> Map.update(:started_at, nil, &iso8601/1)
+    |> Map.update(:completed_at, nil, &iso8601/1)
+  end
+
+  defp iso8601(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
+  defp iso8601(value), do: value
+
   @impl true
   def handle_call(:snapshot, _from, state) do
     state = refresh_runtime_config(state)
@@ -1392,6 +1544,7 @@ defmodule SymphonyElixir.Orchestrator do
        retrying: retrying,
        codex_totals: codex_totals,
        rate_limits: Map.get(state, :codex_rate_limits),
+       workspace_cleanup: workspace_cleanup_snapshot(state.workspace_cleanup),
        polling: %{
          checking?: state.poll_check_in_progress == true,
          next_poll_in_ms: next_poll_in_ms(state.next_poll_due_at_ms, now_ms),

--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -326,7 +326,8 @@ defmodule SymphonyElixir.StatusDashboard do
              retrying: retrying,
              codex_totals: codex_totals,
              rate_limits: Map.get(snapshot, :rate_limits),
-             polling: Map.get(snapshot, :polling)
+             polling: Map.get(snapshot, :polling),
+             workspace_cleanup: Map.get(snapshot, :workspace_cleanup)
            }},
           update_token_samples(token_samples, now_ms, total_tokens)
         }
@@ -345,6 +346,7 @@ defmodule SymphonyElixir.StatusDashboard do
         rate_limits = Map.get(snapshot, :rate_limits)
         project_link_lines = format_project_link_lines()
         project_refresh_line = format_project_refresh_line(Map.get(snapshot, :polling))
+        workspace_cleanup_line = format_workspace_cleanup_line(Map.get(snapshot, :workspace_cleanup))
         codex_input_tokens = Map.get(codex_totals, :input_tokens, 0)
         codex_output_tokens = Map.get(codex_totals, :output_tokens, 0)
         codex_total_tokens = Map.get(codex_totals, :total_tokens, 0)
@@ -372,6 +374,7 @@ defmodule SymphonyElixir.StatusDashboard do
              colorize(" | ", @ansi_gray) <>
              colorize("total #{format_count(codex_total_tokens)}", @ansi_yellow),
            colorize("│ Rate Limits: ", @ansi_bold) <> format_rate_limits(rate_limits, running),
+           workspace_cleanup_line,
            project_link_lines,
            project_refresh_line,
            colorize("├─ Running", @ansi_bold),
@@ -435,6 +438,39 @@ defmodule SymphonyElixir.StatusDashboard do
   defp format_project_refresh_line(_) do
     colorize("│ Next refresh: ", @ansi_bold) <> colorize("n/a", @ansi_gray)
   end
+
+  defp format_workspace_cleanup_line(%{} = cleanup) do
+    status = cleanup_value(cleanup, :status, "unknown")
+    cleaned = cleanup_value(cleanup, :cleaned, 0)
+    preserved = cleanup_value(cleanup, :preserved, 0)
+    skipped = cleanup_value(cleanup, :skipped, 0)
+    ttl_ms = cleanup_value(cleanup, :ttl_ms, nil)
+
+    colorize("│ Workspace cleanup: ", @ansi_bold) <>
+      colorize("#{status}", cleanup_status_color(status)) <>
+      colorize(" cleaned #{cleaned}", @ansi_green) <>
+      colorize(" preserved #{preserved}", @ansi_yellow) <>
+      colorize(" skipped #{skipped}", @ansi_gray) <>
+      colorize(" ttl #{format_duration_ms(ttl_ms)}", @ansi_gray)
+  end
+
+  defp format_workspace_cleanup_line(_) do
+    colorize("│ Workspace cleanup: ", @ansi_bold) <> colorize("pending", @ansi_gray)
+  end
+
+  defp cleanup_value(cleanup, key, default) do
+    Map.get(cleanup, key) || Map.get(cleanup, Atom.to_string(key)) || default
+  end
+
+  defp cleanup_status_color(status) when status in [:failed, "failed"], do: @ansi_red
+  defp cleanup_status_color(status) when status in [:running, "running"], do: @ansi_cyan
+  defp cleanup_status_color(_status), do: @ansi_green
+
+  defp format_duration_ms(ms) when is_integer(ms) and ms >= 86_400_000, do: "#{div(ms, 86_400_000)}d"
+  defp format_duration_ms(ms) when is_integer(ms) and ms >= 3_600_000, do: "#{div(ms, 3_600_000)}h"
+  defp format_duration_ms(ms) when is_integer(ms) and ms >= 60_000, do: "#{div(ms, 60_000)}m"
+  defp format_duration_ms(ms) when is_integer(ms), do: "#{ms}ms"
+  defp format_duration_ms(_ms), do: "n/a"
 
   defp linear_project_url(project_slug), do: "https://linear.app/project/#{project_slug}/issues"
 
@@ -571,7 +607,8 @@ defmodule SymphonyElixir.StatusDashboard do
              retrying: retrying,
              codex_totals: codex_totals,
              rate_limits: Map.get(snapshot, :rate_limits),
-             polling: Map.get(snapshot, :polling)
+             polling: Map.get(snapshot, :polling),
+             workspace_cleanup: Map.get(snapshot, :workspace_cleanup)
            }}
 
         _ ->

--- a/elixir/lib/symphony_elixir/workspace.ex
+++ b/elixir/lib/symphony_elixir/workspace.ex
@@ -163,6 +163,55 @@ defmodule SymphonyElixir.Workspace do
     :ok
   end
 
+  @spec remove_issue_workspaces_with_result(term()) :: {:ok, non_neg_integer()} | {:error, term()}
+  def remove_issue_workspaces_with_result(identifier), do: remove_issue_workspaces_with_result(identifier, nil)
+
+  @spec remove_issue_workspaces_with_result(term(), worker_host()) :: {:ok, non_neg_integer()} | {:error, term()}
+  def remove_issue_workspaces_with_result(identifier, worker_host) when is_binary(identifier) and is_binary(worker_host) do
+    safe_id = safe_identifier(identifier)
+
+    with {:ok, workspace} <- workspace_path_for_issue(safe_id, worker_host),
+         {:ok, _removed_paths} <- remove(workspace, worker_host) do
+      {:ok, 1}
+    end
+  end
+
+  def remove_issue_workspaces_with_result(identifier, nil) when is_binary(identifier) do
+    case Config.settings!().worker.ssh_hosts do
+      [] ->
+        remove_local_issue_workspace_with_result(identifier)
+
+      worker_hosts ->
+        worker_hosts
+        |> Enum.map(&remove_issue_workspaces_with_result(identifier, &1))
+        |> summarize_remove_results()
+    end
+  end
+
+  def remove_issue_workspaces_with_result(_identifier, _worker_host), do: {:ok, 0}
+
+  defp remove_local_issue_workspace_with_result(identifier) do
+    safe_id = safe_identifier(identifier)
+
+    with {:ok, workspace} <- workspace_path_for_issue(safe_id, nil),
+         existed_before? <- File.exists?(workspace),
+         {:ok, _removed_paths} <- remove(workspace, nil),
+         false <- File.exists?(workspace) do
+      {:ok, if(existed_before?, do: 1, else: 0)}
+    else
+      true -> {:error, :workspace_still_exists}
+      {:error, reason} -> {:error, reason}
+      {:error, reason, _output} -> {:error, reason}
+    end
+  end
+
+  defp summarize_remove_results(results) do
+    Enum.reduce_while(results, {:ok, 0}, fn
+      {:ok, count}, {:ok, total} -> {:cont, {:ok, total + count}}
+      {:error, reason}, _acc -> {:halt, {:error, reason}}
+    end)
+  end
+
   @spec run_before_run_hook(Path.t(), map() | String.t() | nil, worker_host()) ::
           :ok | {:error, term()}
   def run_before_run_hook(workspace, issue_or_identifier, worker_host \\ nil) when is_binary(workspace) do

--- a/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
@@ -317,6 +317,38 @@ defmodule SymphonyElixirWeb.DashboardLive do
         <section class="section-card">
           <div class="section-header">
             <div>
+              <h2 class="section-title">Workspace cleanup</h2>
+              <p class="section-copy"><%= workspace_cleanup_summary(@payload.workspace_cleanup) %></p>
+            </div>
+          </div>
+
+          <div class="metric-grid">
+            <article class="metric-card">
+              <p class="metric-label">Status</p>
+              <p class="metric-value"><%= workspace_cleanup_value(@payload.workspace_cleanup, :status) %></p>
+              <p class="metric-detail">Startup cleanup runs after the app is ready.</p>
+            </article>
+            <article class="metric-card">
+              <p class="metric-label">Cleaned</p>
+              <p class="metric-value numeric"><%= format_int(workspace_cleanup_value(@payload.workspace_cleanup, :cleaned)) %></p>
+              <p class="metric-detail">Terminal workspaces past retention.</p>
+            </article>
+            <article class="metric-card">
+              <p class="metric-label">Preserved</p>
+              <p class="metric-value numeric"><%= format_int(workspace_cleanup_value(@payload.workspace_cleanup, :preserved)) %></p>
+              <p class="metric-detail">Active, protected, or recent entries.</p>
+            </article>
+            <article class="metric-card">
+              <p class="metric-label">TTL</p>
+              <p class="metric-value numeric"><%= workspace_cleanup_ttl(@payload.workspace_cleanup) %></p>
+              <p class="metric-detail">Configured terminal workspace retention.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section-card">
+          <div class="section-header">
+            <div>
               <h2 class="section-title">Rate limits</h2>
               <p class="section-copy"><%= rate_limit_metadata(@payload.rate_limits) %></p>
             </div>
@@ -635,6 +667,35 @@ defmodule SymphonyElixirWeb.DashboardLive do
   end
 
   defp format_int(_value), do: "n/a"
+
+  defp workspace_cleanup_summary(%{} = cleanup) do
+    completed_at = field_value(cleanup, [:completed_at, "completed_at"])
+    error = field_value(cleanup, [:error, "error"])
+
+    cond do
+      is_binary(error) and error != "" -> "Last cleanup failed: #{error}"
+      is_binary(completed_at) -> "Last cleanup completed at #{completed_at}."
+      true -> "Cleanup has started and is reporting progress."
+    end
+  end
+
+  defp workspace_cleanup_summary(_cleanup), do: "Cleanup has not reported status yet."
+
+  defp workspace_cleanup_value(%{} = cleanup, key) do
+    field_value(cleanup, [key, Atom.to_string(key)])
+  end
+
+  defp workspace_cleanup_value(_cleanup, :status), do: "pending"
+  defp workspace_cleanup_value(_cleanup, _key), do: nil
+
+  defp workspace_cleanup_ttl(%{} = cleanup), do: cleanup |> workspace_cleanup_value(:ttl_ms) |> duration_label_from_ms()
+  defp workspace_cleanup_ttl(_cleanup), do: "n/a"
+
+  defp duration_label_from_ms(ms) when is_integer(ms) and ms >= 86_400_000, do: "#{div(ms, 86_400_000)}d"
+  defp duration_label_from_ms(ms) when is_integer(ms) and ms >= 3_600_000, do: "#{div(ms, 3_600_000)}h"
+  defp duration_label_from_ms(ms) when is_integer(ms) and ms >= 60_000, do: "#{div(ms, 60_000)}m"
+  defp duration_label_from_ms(ms) when is_integer(ms), do: "#{ms}ms"
+  defp duration_label_from_ms(_ms), do: "n/a"
 
   defp rate_limit_snapshot?(%{} = snapshot), do: map_size(snapshot) > 0
   defp rate_limit_snapshot?(_snapshot), do: false

--- a/elixir/lib/symphony_elixir_web/presenter.ex
+++ b/elixir/lib/symphony_elixir_web/presenter.ex
@@ -33,7 +33,8 @@ defmodule SymphonyElixirWeb.Presenter do
           running: Enum.map(snapshot.running, &running_entry_payload/1),
           retrying: Enum.map(snapshot.retrying, &retry_entry_payload/1),
           codex_totals: snapshot.codex_totals,
-          rate_limits: snapshot.rate_limits
+          rate_limits: snapshot.rate_limits,
+          workspace_cleanup: Map.get(snapshot, :workspace_cleanup)
         }
 
       :timeout ->

--- a/elixir/test/fixtures/status_dashboard_snapshots/backoff_queue.evidence.md
+++ b/elixir/test/fixtures/status_dashboard_snapshots/backoff_queue.evidence.md
@@ -5,6 +5,7 @@
 │ Runtime: 45m 0s
 │ Tokens: in 18,000 | out 2,200 | total 20,200
 │ Rate Limits: unavailable (no worker rate-limit data)
+│ Workspace cleanup: pending
 │ Project: https://linear.app/project/project/issues
 │ Next refresh: n/a
 ├─ Running

--- a/elixir/test/fixtures/status_dashboard_snapshots/backoff_queue.snapshot.txt
+++ b/elixir/test/fixtures/status_dashboard_snapshots/backoff_queue.snapshot.txt
@@ -4,6 +4,7 @@
 \e[1m│ Runtime: \e[0m\e[35m45m 0s\e[0m
 \e[1m│ Tokens: \e[0m\e[33min 18,000\e[0m\e[90m | \e[0m\e[33mout 2,200\e[0m\e[90m | \e[0m\e[33mtotal 20,200\e[0m
 \e[1m│ Rate Limits: \e[0m\e[90munavailable (no worker rate-limit data)\e[0m
+\e[1m│ Workspace cleanup: \e[0m\e[90mpending\e[0m
 \e[1m│ Project: \e[0m\e[36mhttps://linear.app/project/project/issues\e[0m
 \e[1m│ Next refresh: \e[0m\e[90mn/a\e[0m
 \e[1m├─ Running\e[0m

--- a/elixir/test/fixtures/status_dashboard_snapshots/credits_unlimited.evidence.md
+++ b/elixir/test/fixtures/status_dashboard_snapshots/credits_unlimited.evidence.md
@@ -5,6 +5,7 @@
 │ Runtime: 1m 15s
 │ Tokens: in 90 | out 12 | total 102
 │ Rate Limits: unavailable (no worker rate-limit data)
+│ Workspace cleanup: pending
 │ Project: https://linear.app/project/project/issues
 │ Next refresh: n/a
 ├─ Running

--- a/elixir/test/fixtures/status_dashboard_snapshots/credits_unlimited.snapshot.txt
+++ b/elixir/test/fixtures/status_dashboard_snapshots/credits_unlimited.snapshot.txt
@@ -4,6 +4,7 @@
 \e[1m│ Runtime: \e[0m\e[35m1m 15s\e[0m
 \e[1m│ Tokens: \e[0m\e[33min 90\e[0m\e[90m | \e[0m\e[33mout 12\e[0m\e[90m | \e[0m\e[33mtotal 102\e[0m
 \e[1m│ Rate Limits: \e[0m\e[90munavailable (no worker rate-limit data)\e[0m
+\e[1m│ Workspace cleanup: \e[0m\e[90mpending\e[0m
 \e[1m│ Project: \e[0m\e[36mhttps://linear.app/project/project/issues\e[0m
 \e[1m│ Next refresh: \e[0m\e[90mn/a\e[0m
 \e[1m├─ Running\e[0m

--- a/elixir/test/fixtures/status_dashboard_snapshots/idle.evidence.md
+++ b/elixir/test/fixtures/status_dashboard_snapshots/idle.evidence.md
@@ -5,6 +5,7 @@
 │ Runtime: 0m 0s
 │ Tokens: in 0 | out 0 | total 0
 │ Rate Limits: unavailable
+│ Workspace cleanup: pending
 │ Project: https://linear.app/project/project/issues
 │ Next refresh: n/a
 ├─ Running

--- a/elixir/test/fixtures/status_dashboard_snapshots/idle.snapshot.txt
+++ b/elixir/test/fixtures/status_dashboard_snapshots/idle.snapshot.txt
@@ -4,6 +4,7 @@
 \e[1m│ Runtime: \e[0m\e[35m0m 0s\e[0m
 \e[1m│ Tokens: \e[0m\e[33min 0\e[0m\e[90m | \e[0m\e[33mout 0\e[0m\e[90m | \e[0m\e[33mtotal 0\e[0m
 \e[1m│ Rate Limits: \e[0m\e[90munavailable\e[0m
+\e[1m│ Workspace cleanup: \e[0m\e[90mpending\e[0m
 \e[1m│ Project: \e[0m\e[36mhttps://linear.app/project/project/issues\e[0m
 \e[1m│ Next refresh: \e[0m\e[90mn/a\e[0m
 \e[1m├─ Running\e[0m

--- a/elixir/test/fixtures/status_dashboard_snapshots/idle_with_dashboard_url.evidence.md
+++ b/elixir/test/fixtures/status_dashboard_snapshots/idle_with_dashboard_url.evidence.md
@@ -5,6 +5,7 @@
 │ Runtime: 0m 0s
 │ Tokens: in 0 | out 0 | total 0
 │ Rate Limits: unavailable
+│ Workspace cleanup: pending
 │ Project: https://linear.app/project/project/issues
 │ Dashboard: http://127.0.0.1:4000/
 │ Next refresh: n/a

--- a/elixir/test/fixtures/status_dashboard_snapshots/idle_with_dashboard_url.snapshot.txt
+++ b/elixir/test/fixtures/status_dashboard_snapshots/idle_with_dashboard_url.snapshot.txt
@@ -4,6 +4,7 @@
 \e[1m│ Runtime: \e[0m\e[35m0m 0s\e[0m
 \e[1m│ Tokens: \e[0m\e[33min 0\e[0m\e[90m | \e[0m\e[33mout 0\e[0m\e[90m | \e[0m\e[33mtotal 0\e[0m
 \e[1m│ Rate Limits: \e[0m\e[90munavailable\e[0m
+\e[1m│ Workspace cleanup: \e[0m\e[90mpending\e[0m
 \e[1m│ Project: \e[0m\e[36mhttps://linear.app/project/project/issues\e[0m
 \e[1m│ Dashboard: \e[0m\e[36mhttp://127.0.0.1:4000/\e[0m
 \e[1m│ Next refresh: \e[0m\e[90mn/a\e[0m

--- a/elixir/test/fixtures/status_dashboard_snapshots/super_busy.evidence.md
+++ b/elixir/test/fixtures/status_dashboard_snapshots/super_busy.evidence.md
@@ -5,6 +5,7 @@
 │ Runtime: 72m 1s
 │ Tokens: in 250,000 | out 18,500 | total 268,500
 │ Rate Limits: unavailable (no worker rate-limit data)
+│ Workspace cleanup: pending
 │ Project: https://linear.app/project/project/issues
 │ Next refresh: n/a
 ├─ Running

--- a/elixir/test/fixtures/status_dashboard_snapshots/super_busy.snapshot.txt
+++ b/elixir/test/fixtures/status_dashboard_snapshots/super_busy.snapshot.txt
@@ -4,6 +4,7 @@
 \e[1m│ Runtime: \e[0m\e[35m72m 1s\e[0m
 \e[1m│ Tokens: \e[0m\e[33min 250,000\e[0m\e[90m | \e[0m\e[33mout 18,500\e[0m\e[90m | \e[0m\e[33mtotal 268,500\e[0m
 \e[1m│ Rate Limits: \e[0m\e[90munavailable (no worker rate-limit data)\e[0m
+\e[1m│ Workspace cleanup: \e[0m\e[90mpending\e[0m
 \e[1m│ Project: \e[0m\e[36mhttps://linear.app/project/project/issues\e[0m
 \e[1m│ Next refresh: \e[0m\e[90mn/a\e[0m
 \e[1m├─ Running\e[0m

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -335,6 +335,7 @@ defmodule SymphonyElixir.TestSupport do
           tracker_terminal_states: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"],
           poll_interval_ms: 30_000,
           workspace_root: Path.join(System.tmp_dir!(), "symphony_workspaces"),
+          workspace_startup_cleanup_ttl_ms: 7 * 24 * 60 * 60 * 1_000,
           worker_ssh_hosts: [],
           worker_max_concurrent_agents_per_host: nil,
           max_concurrent_agents: 10,
@@ -380,6 +381,7 @@ defmodule SymphonyElixir.TestSupport do
     tracker_terminal_states = Keyword.get(config, :tracker_terminal_states)
     poll_interval_ms = Keyword.get(config, :poll_interval_ms)
     workspace_root = Keyword.get(config, :workspace_root)
+    workspace_startup_cleanup_ttl_ms = Keyword.get(config, :workspace_startup_cleanup_ttl_ms)
     worker_ssh_hosts = Keyword.get(config, :worker_ssh_hosts)
     worker_max_concurrent_agents_per_host = Keyword.get(config, :worker_max_concurrent_agents_per_host)
     max_concurrent_agents = Keyword.get(config, :max_concurrent_agents)
@@ -428,6 +430,7 @@ defmodule SymphonyElixir.TestSupport do
         "  interval_ms: #{yaml_value(poll_interval_ms)}",
         "workspace:",
         "  root: #{yaml_value(workspace_root)}",
+        "  startup_cleanup_ttl_ms: #{yaml_value(workspace_startup_cleanup_ttl_ms)}",
         worker_yaml(worker_ssh_hosts, worker_max_concurrent_agents_per_host),
         "agent:",
         "  max_concurrent_agents: #{yaml_value(max_concurrent_agents)}",

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -385,6 +385,210 @@ defmodule SymphonyElixir.CoreTest do
     end
   end
 
+  test "startup terminal workspace cleanup runs after init and honors retention ttl" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-startup-cleanup-#{System.unique_integer([:positive])}"
+      )
+
+    previous_memory_issues = Application.get_env(:symphony_elixir, :memory_tracker_issues)
+
+    stale_workspace = Path.join(test_root, "MT-OLD")
+    recent_workspace = Path.join(test_root, "MT-RECENT")
+    active_workspace = Path.join(test_root, "MT-ACTIVE")
+    now = DateTime.utc_now()
+
+    try do
+      write_workflow_file!(Workflow.workflow_file_path(),
+        tracker_kind: "memory",
+        workspace_root: test_root,
+        workspace_startup_cleanup_ttl_ms: 60_000,
+        tracker_active_states: ["Todo", "In Progress", "In Review", "Blocked"],
+        tracker_terminal_states: ["Done", "Canceled"],
+        poll_interval_ms: 30_000
+      )
+
+      File.mkdir_p!(stale_workspace)
+      File.mkdir_p!(recent_workspace)
+      File.mkdir_p!(active_workspace)
+
+      Application.put_env(:symphony_elixir, :memory_tracker_issues, [
+        %Issue{
+          id: "issue-old",
+          identifier: "MT-OLD",
+          state: "Done",
+          updated_at: DateTime.add(now, -120_000, :millisecond)
+        },
+        %Issue{
+          id: "issue-recent",
+          identifier: "MT-RECENT",
+          state: "Done",
+          updated_at: DateTime.add(now, -1_000, :millisecond)
+        },
+        %Issue{
+          id: "issue-active",
+          identifier: "MT-ACTIVE",
+          state: "In Review",
+          updated_at: DateTime.add(now, -120_000, :millisecond)
+        }
+      ])
+
+      orchestrator_name = Module.concat(__MODULE__, :StartupCleanupOrchestrator)
+      assert {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+      on_exit(fn ->
+        restore_app_env(:memory_tracker_issues, previous_memory_issues)
+
+        if Process.alive?(pid) do
+          Process.exit(pid, :normal)
+        end
+      end)
+
+      assert is_pid(pid)
+      assert_receive_cleanup_snapshot(orchestrator_name)
+
+      refute File.exists?(stale_workspace)
+      assert File.exists?(recent_workspace)
+      assert File.exists?(active_workspace)
+
+      snapshot = Orchestrator.snapshot(orchestrator_name, 1_000)
+      assert snapshot.workspace_cleanup.status == :completed
+      assert snapshot.workspace_cleanup.cleaned == 1
+      assert snapshot.workspace_cleanup.preserved == 2
+      assert snapshot.workspace_cleanup.ttl_ms == 60_000
+    after
+      File.rm_rf(test_root)
+      restore_app_env(:memory_tracker_issues, previous_memory_issues)
+    end
+  end
+
+  test "startup terminal workspace cleanup exposes running status without blocking snapshots" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-startup-cleanup-running-#{System.unique_integer([:positive])}"
+      )
+
+    previous_memory_issues = Application.get_env(:symphony_elixir, :memory_tracker_issues)
+    previous_remove = Application.get_env(:symphony_elixir, :workspace_remove_issue_workspaces)
+    blocker = Path.join(test_root, "block-cleanup")
+    workspace = Path.join(test_root, "MT-SLOW")
+    now = DateTime.utc_now()
+
+    try do
+      write_workflow_file!(Workflow.workflow_file_path(),
+        tracker_kind: "memory",
+        workspace_root: test_root,
+        workspace_startup_cleanup_ttl_ms: 0,
+        tracker_terminal_states: ["Done"],
+        poll_interval_ms: 30_000
+      )
+
+      File.mkdir_p!(workspace)
+      File.write!(blocker, "block")
+
+      Application.put_env(:symphony_elixir, :workspace_remove_issue_workspaces, fn identifier ->
+        wait_until_missing(blocker)
+        Workspace.remove_issue_workspaces_with_result(identifier)
+      end)
+
+      Application.put_env(:symphony_elixir, :memory_tracker_issues, [
+        %Issue{
+          id: "issue-slow",
+          identifier: "MT-SLOW",
+          state: "Done",
+          updated_at: DateTime.add(now, -120_000, :millisecond)
+        }
+      ])
+
+      orchestrator_name = Module.concat(__MODULE__, :StartupCleanupRunningOrchestrator)
+      assert {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+      on_exit(fn ->
+        restore_app_env(:memory_tracker_issues, previous_memory_issues)
+        restore_app_env(:workspace_remove_issue_workspaces, previous_remove)
+
+        if Process.alive?(pid) do
+          Process.exit(pid, :normal)
+        end
+      end)
+
+      snapshot = assert_receive_running_cleanup_snapshot(orchestrator_name)
+      assert snapshot.workspace_cleanup.status == :running
+
+      File.rm!(blocker)
+      snapshot = assert_receive_cleanup_snapshot(orchestrator_name)
+      assert snapshot.workspace_cleanup.status == :completed
+      assert snapshot.workspace_cleanup.cleaned == 1
+      refute File.exists?(workspace)
+    after
+      File.rm_rf(test_root)
+      restore_app_env(:memory_tracker_issues, previous_memory_issues)
+      restore_app_env(:workspace_remove_issue_workspaces, previous_remove)
+    end
+  end
+
+  test "startup terminal workspace cleanup reports failed removals without counting them cleaned" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-startup-cleanup-failure-#{System.unique_integer([:positive])}"
+      )
+
+    previous_memory_issues = Application.get_env(:symphony_elixir, :memory_tracker_issues)
+    previous_remove = Application.get_env(:symphony_elixir, :workspace_remove_issue_workspaces)
+    workspace = Path.join(test_root, "MT-STUCK")
+
+    try do
+      write_workflow_file!(Workflow.workflow_file_path(),
+        tracker_kind: "memory",
+        workspace_root: test_root,
+        workspace_startup_cleanup_ttl_ms: 0,
+        tracker_terminal_states: ["Done"],
+        poll_interval_ms: 30_000
+      )
+
+      File.mkdir_p!(workspace)
+      File.write!(Path.join(workspace, "marker.txt"), "stuck")
+
+      Application.put_env(:symphony_elixir, :memory_tracker_issues, [
+        %Issue{
+          id: "issue-stuck",
+          identifier: "MT-STUCK",
+          state: "Done",
+          updated_at: DateTime.add(DateTime.utc_now(), -120_000, :millisecond)
+        }
+      ])
+
+      Application.put_env(:symphony_elixir, :workspace_remove_issue_workspaces, fn _identifier ->
+        {:error, :remove_failed}
+      end)
+
+      orchestrator_name = Module.concat(__MODULE__, :StartupCleanupFailureOrchestrator)
+      assert {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+      on_exit(fn ->
+        restore_app_env(:memory_tracker_issues, previous_memory_issues)
+        restore_app_env(:workspace_remove_issue_workspaces, previous_remove)
+
+        if Process.alive?(pid) do
+          Process.exit(pid, :normal)
+        end
+      end)
+
+      snapshot = assert_receive_cleanup_snapshot(orchestrator_name)
+      assert snapshot.workspace_cleanup.status == :completed
+      assert snapshot.workspace_cleanup.cleaned == 0
+      assert snapshot.workspace_cleanup.skipped == 1
+      assert snapshot.workspace_cleanup.error =~ "remove_failed"
+    after
+      File.rm_rf(test_root)
+      restore_app_env(:memory_tracker_issues, previous_memory_issues)
+      restore_app_env(:workspace_remove_issue_workspaces, previous_remove)
+    end
+  end
+
   test "missing running issues stop active agents without cleaning the workspace" do
     test_root =
       Path.join(
@@ -1032,6 +1236,53 @@ defmodule SymphonyElixir.CoreTest do
 
   defp restore_app_env(key, nil), do: Application.delete_env(:symphony_elixir, key)
   defp restore_app_env(key, value), do: Application.put_env(:symphony_elixir, key, value)
+
+  defp wait_until_missing(path) do
+    if File.exists?(path) do
+      Process.sleep(10)
+      wait_until_missing(path)
+    end
+  end
+
+  defp assert_receive_cleanup_snapshot(orchestrator_name) do
+    deadline = System.monotonic_time(:millisecond) + 1_000
+    assert_receive_cleanup_snapshot(orchestrator_name, deadline)
+  end
+
+  defp assert_receive_running_cleanup_snapshot(orchestrator_name) do
+    deadline = System.monotonic_time(:millisecond) + 1_000
+    assert_receive_running_cleanup_snapshot(orchestrator_name, deadline)
+  end
+
+  defp assert_receive_cleanup_snapshot(orchestrator_name, deadline_ms) do
+    case Orchestrator.snapshot(orchestrator_name, 1_000) do
+      %{workspace_cleanup: %{status: :completed}} = snapshot ->
+        snapshot
+
+      other ->
+        if System.monotonic_time(:millisecond) < deadline_ms do
+          Process.sleep(10)
+          assert_receive_cleanup_snapshot(orchestrator_name, deadline_ms)
+        else
+          flunk("expected startup workspace cleanup to complete, got: #{inspect(other)}")
+        end
+    end
+  end
+
+  defp assert_receive_running_cleanup_snapshot(orchestrator_name, deadline_ms) do
+    case Orchestrator.snapshot(orchestrator_name, 1_000) do
+      %{workspace_cleanup: %{status: :running}} = snapshot ->
+        snapshot
+
+      other ->
+        if System.monotonic_time(:millisecond) < deadline_ms do
+          Process.sleep(10)
+          assert_receive_running_cleanup_snapshot(orchestrator_name, deadline_ms)
+        else
+          flunk("expected startup workspace cleanup to be running, got: #{inspect(other)}")
+        end
+    end
+  end
 
   test "fetch issues by states with empty state set is a no-op" do
     assert {:ok, []} = Client.fetch_issues_by_states([])

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -899,7 +899,8 @@ defmodule SymphonyElixir.ExtensionsTest do
                "total_tokens" => 12,
                "seconds_running" => 42.5
              },
-             "rate_limits" => %{"primary" => %{"remaining" => 11}}
+             "rate_limits" => %{"primary" => %{"remaining" => 11}},
+             "workspace_cleanup" => nil
            }
 
     conn = get(build_conn(), "/api/v1/MT-HTTP")


### PR DESCRIPTION
#### Context

Startup cleanup blocked app readiness while deleting old terminal workspaces.

#### TL;DR

*Run startup workspace cleanup in the background with TTL retention and status.*

#### Summary

- Run terminal workspace cleanup in a supervised task after orchestrator init.
- Preserve active, In Review, Blocked, and recent terminal workspaces.
- Add `workspace.startup_cleanup_ttl_ms` with a 7 day default.
- Expose cleanup status in snapshots, API, terminal dashboard, and LiveView.
- Report removal failures as skipped/error instead of cleaned.
- Document the Windows startup cleanup policy.

#### Alternatives

- Keeping synchronous startup cleanup was rejected because it delays readiness.
- Deleting all terminal workspaces was rejected because recent failures need retention.
- Hiding cleanup status was rejected because operators need progress visibility.

#### Test Plan

- [x] `make -C elixir all` passed locally with full coverage gate green.
- [x] `make windows-native-test` passed: 113 tests, 0 failures.
- [x] `mix test test/symphony_elixir/core_test.exs` passed: 51 tests, 0 failures.
- [x] `mix test test/symphony_elixir/workspace_and_config_test.exs` passed: 45 tests, 0 failures.
- [x] `mix test test/symphony_elixir/status_dashboard_snapshot_test.exs test/symphony_elixir/orchestrator_status_test.exs` passed with terminal dashboard env unset: 60 tests, 0 failures.
- [x] `mix specs.check` passed.
- [x] `git diff --check` passed.

Fixes #59