### PR TITLE
ci(quality): relax mechanical coverage threshold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,8 @@ mise exec -- mix symphony.preflight.windows .\WORKFLOW.optimization.windows.md
 - Run `mix format` for touched Elixir files and `mix specs.check` when public
   `lib/` functions are added or changed.
 - Do not skip, weaken, disable, or hide failures from format, lint, coverage,
-  tests, CI, review-readiness, or PR-body checks.
+  tests, CI, review-readiness, or PR-body checks to land unrelated work. Quality
+  gate policy changes require a dedicated manager-owned issue, PR, and review.
 
 ## Branches, Commits, And PRs
 
@@ -104,6 +105,8 @@ Workpad. Blocking findings keep the issue in `In Progress` or return it to
 - `WorkflowStore` and other global/stateful runtime paths can leak state across
   tests; preserve cleanup and isolation semantics.
 - Coverage threshold or ignore-list changes are quality-gate changes and need
-  explicit review; do not add changed production modules to coverage ignores.
+  explicit manager review; do not add changed production modules to coverage
+  ignores. Coverage is a signal for meaningful tests, not a demand for filler
+  tests to reach mechanical perfection.
 - Path and environment handling must preserve Windows drive paths, forward-slash
   compatibility, `$VAR` workflow expansion rules, and secret redaction.

--- a/elixir/docs/agent-quality-flywheel.md
+++ b/elixir/docs/agent-quality-flywheel.md
@@ -27,6 +27,12 @@ Agents must not weaken, skip, disable, or relax CI, lint, formatter, or test gat
 work. If a gate is wrong or flaky, file or link a follow-up defect and keep the current issue out of
 `In Review` until the required checks pass or a manager explicitly overrides the state transition.
 
+Coverage is a quality signal, not a mechanical target. The repository keeps a high total coverage
+threshold, but it is intentionally below 100% so workers are not forced to add filler tests for
+incidental branches. Review should still demand meaningful tests for the changed behavior, failure
+modes, and public contracts. Coverage threshold changes are manager-owned policy work and must be
+made through an explicit issue and review, not as a drive-by workaround in an unrelated PR.
+
 Coverage ignore changes are gate changes. A PR must not add a production module to
 `test_coverage.ignore_modules` when that same module is changed in the PR. The review-readiness
 gate rejects that overlap before an agent can move the Linear issue to review. If a manager believes

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -10,7 +10,7 @@ defmodule SymphonyElixir.MixProject do
       start_permanent: Mix.env() == :prod,
       test_coverage: [
         summary: [
-          threshold: 100
+          threshold: 95
         ],
         ignore_modules: [
           Mix.Tasks.Symphony.Preflight.Windows,

--- a/elixir/test/symphony_elixir/mix_project_test.exs
+++ b/elixir/test/symphony_elixir/mix_project_test.exs
@@ -1,0 +1,14 @@
+defmodule SymphonyElixir.MixProjectTest do
+  use ExUnit.Case, async: true
+
+  test "coverage threshold stays high without requiring mechanical perfection" do
+    threshold =
+      SymphonyElixir.MixProject.project()
+      |> Keyword.fetch!(:test_coverage)
+      |> get_in([:summary, :threshold])
+
+    assert threshold == 95
+    assert threshold < 100
+    assert threshold >= 95
+  end
+end


### PR DESCRIPTION
#### Context

Fixes #95

The 100% coverage gate pushes workers toward filler tests for tiny uncovered branches instead of intent-based validation.

#### TL;DR

*Keep coverage high at 95%, but stop requiring mechanical perfection.*

#### Summary

- Lower total coverage threshold from 100% to 95%
- Document coverage as a quality signal rather than a mechanical target
- Keep coverage-ignore abuse guardrails explicit in worker docs
- Add a regression test for the intended coverage threshold policy

#### Alternatives

- Keeping 100% was rejected because it encourages low-value tests and slows the flywheel.
- Removing coverage was rejected because coverage remains useful as a regression signal.

#### Test Plan

- [x] `mise exec -- mix test test/symphony_elixir/mix_project_test.exs test/symphony_elixir/dynamic_tool_test.exs test/symphony_elixir/validation_evidence_test.exs` -> 101 tests, 0 failures
- [x] `mise exec -- mix test --cover` -> passed
- [x] `git diff --check` -> passed
- [ ] `make -C elixir all` not run locally because targeted coverage, review-readiness, and PR evidence checks cover this quality-gate policy change while full local make is affected by existing Windows CRLF fmt-check debt.