### PR TITLE
Recover stale same-host Linear claim leases

### DIFF
--- a/elixir/docs/windows-native.md
+++ b/elixir/docs/windows-native.md
@@ -314,6 +314,15 @@ pass `-WorkflowPath` to locate a matching launcher process:
 .\scripts\stop-windows-native.ps1 -WorkflowPath .\WORKFLOW.windows.md -Force
 ```
 
+Linear claim leases are also cleaned up as workers stop. If the host or runtime
+exits before a release comment is written, the next runtime startup checks active
+Linear claim comments before dispatch. A claim owned by the same Windows host is
+released only when its recorded OS process ID is no longer alive; claims from
+other hosts, malformed owners, or still-running local processes remain protected.
+While another active lease is preserved, the issue appears in the dashboard
+backoff queue with an `external_claim` reason instead of being shown as a local
+running worker.
+
 ## Install a Windows long-running task
 
 The recommended Windows-native long-running setup is Task Scheduler. It runs under the same

--- a/elixir/lib/symphony_elixir/linear/adapter.ex
+++ b/elixir/lib/symphony_elixir/linear/adapter.ex
@@ -117,6 +117,22 @@ defmodule SymphonyElixir.Linear.Adapter do
     end
   end
 
+  @spec recover_stale_issue_claim(term()) :: :ok | {:error, term()}
+  def recover_stale_issue_claim(%{id: issue_id}) when is_binary(issue_id) do
+    case fetch_claim_comments(issue_id) do
+      {:ok, claims} ->
+        case winning_claim(claims, DateTime.utc_now()) do
+          {:ok, claim} -> recover_claim_if_stale(issue_id, claim)
+          {:error, :claim_not_visible} -> :ok
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  def recover_stale_issue_claim(_issue), do: {:error, :invalid_issue_claim}
+
   @spec create_comment(String.t(), String.t()) :: :ok | {:error, term()}
   def create_comment(issue_id, body) when is_binary(issue_id) and is_binary(body) do
     with {:ok, response} <- client_module().graphql(@create_comment_mutation, %{issueId: issue_id, body: body}),
@@ -449,6 +465,84 @@ defmodule SymphonyElixir.Linear.Adapter do
 
   defp secure_compare(left, right) when is_binary(left) and is_binary(right) do
     byte_size(left) == byte_size(right) and :crypto.hash_equals(left, right)
+  end
+
+  defp recover_claim_if_stale(issue_id, %{owner: owner} = claim) do
+    case local_owner_process_status(owner) do
+      :dead ->
+        release_issue_claim(issue_id, claim)
+
+      :alive ->
+        :ok
+
+      :external ->
+        :ok
+    end
+  end
+
+  defp local_owner_process_status(owner) when is_binary(owner) do
+    with {:ok, owner_host, owner_pid} <- parse_claim_owner(owner),
+         true <- same_hostname?(owner_host) do
+      if local_os_pid_alive?(owner_pid), do: :alive, else: :dead
+    else
+      _ -> :external
+    end
+  end
+
+  defp parse_claim_owner(owner) when is_binary(owner) do
+    case String.split(owner, ":", parts: 3) do
+      [owner_host, pid, _rest] when owner_host != "" ->
+        case Integer.parse(pid) do
+          {parsed_pid, ""} when parsed_pid > 0 -> {:ok, owner_host, pid}
+          _ -> :error
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  defp same_hostname?(owner_host) when is_binary(owner_host) do
+    String.downcase(owner_host) == String.downcase(hostname())
+  end
+
+  defp local_os_pid_alive?(pid) when is_binary(pid) do
+    process_alive_fun = Application.get_env(:symphony_elixir, :local_os_pid_alive?, &default_local_os_pid_alive?/1)
+    process_alive_fun.(pid)
+  end
+
+  defp default_local_os_pid_alive?(pid) when is_binary(pid) do
+    pid
+    |> tasklist_output()
+    |> tasklist_pid_present?(pid)
+  end
+
+  defp tasklist_output(pid) do
+    lookup_fun = Application.get_env(:symphony_elixir, :tasklist_lookup, &System.find_executable/1)
+    cmd_fun = Application.get_env(:symphony_elixir, :tasklist_cmd, &System.cmd/3)
+
+    case lookup_fun.("tasklist") do
+      nil ->
+        ""
+
+      tasklist ->
+        case cmd_fun.(tasklist, ["/FI", "PID eq #{pid}", "/FO", "CSV", "/NH"], stderr_to_stdout: true) do
+          {output, 0} -> output
+          _ -> ""
+        end
+    end
+  end
+
+  defp tasklist_pid_present?(output, pid) when is_binary(output) do
+    output
+    |> String.split("\n")
+    |> Enum.any?(&csv_pid_row?(&1, pid))
+  end
+
+  defp csv_pid_row?(row, pid) do
+    row
+    |> String.trim()
+    |> String.contains?(~s(","#{pid}","))
   end
 
   @doc false

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -764,12 +764,23 @@ defmodule SymphonyElixir.Orchestrator do
     recipient = self()
 
     with worker_host when worker_host != :no_worker_capacity <- select_worker_host(state, preferred_worker_host),
+         :ok <- recover_stale_issue_claim(issue),
          {:ok, claim} <- acquire_issue_claim(issue) do
       spawn_issue_on_worker_host(state, issue, attempt, recipient, worker_host, claim, retry_metadata)
     else
       {:error, {:issue_claimed, claim}} ->
         Logger.info("Skipping dispatch; durable claim is held for #{issue_context(issue)} owner=#{claim.owner} expires_at=#{DateTime.to_iso8601(claim.expires_at)}")
-        state
+
+        schedule_issue_retry(state, issue.id, next_claim_retry_attempt(attempt), %{
+          identifier: issue.identifier,
+          error: "durable claim held by #{claim.owner} until #{DateTime.to_iso8601(claim.expires_at)}",
+          error_kind: "external_claim",
+          worker_host: preferred_worker_host,
+          workspace_path: Map.get(retry_metadata, :workspace_path),
+          branch_name: retry_metadata[:branch_name] || issue.branch_name,
+          prior_error: Map.get(retry_metadata, :prior_error),
+          prior_error_kind: Map.get(retry_metadata, :prior_error_kind)
+        })
 
       {:error, reason} ->
         Logger.warning("Skipping dispatch; unable to acquire durable claim for #{issue_context(issue)}: #{inspect(reason)}")
@@ -784,6 +795,13 @@ defmodule SymphonyElixir.Orchestrator do
   defp acquire_issue_claim(%Issue{} = issue) do
     Tracker.acquire_issue_claim(issue)
   end
+
+  defp recover_stale_issue_claim(%Issue{} = issue) do
+    Tracker.recover_stale_issue_claim(issue)
+  end
+
+  defp next_claim_retry_attempt(attempt) when is_integer(attempt), do: attempt + 1
+  defp next_claim_retry_attempt(_attempt), do: nil
 
   defp spawn_issue_on_worker_host(%State{} = state, issue, attempt, recipient, worker_host, claim, retry_metadata) do
     case start_agent_task(fn ->

--- a/elixir/lib/symphony_elixir/tracker.ex
+++ b/elixir/lib/symphony_elixir/tracker.ex
@@ -10,6 +10,7 @@ defmodule SymphonyElixir.Tracker do
   @callback fetch_issue_states_by_ids([String.t()]) :: {:ok, [term()]} | {:error, term()}
   @callback acquire_issue_claim(term()) :: {:ok, map()} | {:error, term()}
   @callback release_issue_claim(String.t(), map() | nil) :: :ok | {:error, term()}
+  @callback recover_stale_issue_claim(term()) :: :ok | {:error, term()}
   @callback create_comment(String.t(), String.t()) :: :ok | {:error, term()}
   @callback update_issue_state(String.t(), String.t()) :: :ok | {:error, term()}
 
@@ -39,6 +40,11 @@ defmodule SymphonyElixir.Tracker do
   @spec release_issue_claim(String.t(), map() | nil) :: :ok | {:error, term()}
   def release_issue_claim(issue_id, claim) do
     adapter().release_issue_claim(issue_id, claim)
+  end
+
+  @spec recover_stale_issue_claim(term()) :: :ok | {:error, term()}
+  def recover_stale_issue_claim(issue) do
+    adapter().recover_stale_issue_claim(issue)
   end
 
   @spec create_comment(String.t(), String.t()) :: :ok | {:error, term()}

--- a/elixir/lib/symphony_elixir/tracker/memory.ex
+++ b/elixir/lib/symphony_elixir/tracker/memory.ex
@@ -59,6 +59,14 @@ defmodule SymphonyElixir.Tracker.Memory do
     :ok
   end
 
+  @spec recover_stale_issue_claim(Issue.t()) :: :ok | {:error, term()}
+  def recover_stale_issue_claim(%Issue{id: issue_id, identifier: identifier}) when is_binary(issue_id) do
+    send_event({:memory_tracker_claim_recovery_checked, issue_id, identifier})
+    :ok
+  end
+
+  def recover_stale_issue_claim(_issue), do: {:error, :invalid_issue_claim}
+
   @spec create_comment(String.t(), String.t()) :: :ok | {:error, term()}
   def create_comment(issue_id, body) do
     send_event({:memory_tracker_comment, issue_id, body})

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -65,6 +65,12 @@ defmodule SymphonyElixir.TestSupport do
           Application.delete_env(:symphony_elixir, :server_port_override)
           Application.delete_env(:symphony_elixir, :memory_tracker_issues)
           Application.delete_env(:symphony_elixir, :memory_tracker_recipient)
+          Application.delete_env(:symphony_elixir, :local_os_pid_alive?)
+          Application.delete_env(:symphony_elixir, :linear_client_module)
+          Application.delete_env(:symphony_elixir, :task_supervisor_start_child)
+          Application.delete_env(:symphony_elixir, :orchestrator_status_fake_linear)
+          Application.delete_env(:symphony_elixir, :tasklist_lookup)
+          Application.delete_env(:symphony_elixir, :tasklist_cmd)
           File.rm_rf(workflow_root)
         end)
 

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -216,12 +216,15 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert {:ok, [^issue]} = SymphonyElixir.Tracker.fetch_issues_by_states([" in progress ", 42])
     assert {:ok, [^issue]} = SymphonyElixir.Tracker.fetch_issue_states_by_ids(["issue-1"])
     assert {:ok, %{id: "memory-issue-1", owner: "memory"}} = SymphonyElixir.Tracker.acquire_issue_claim(issue)
+    assert :ok = SymphonyElixir.Tracker.recover_stale_issue_claim(issue)
     assert :ok = SymphonyElixir.Tracker.release_issue_claim("issue-1")
     assert :ok = Memory.release_issue_claim("issue-1")
     assert {:error, :invalid_issue_claim} = Memory.acquire_issue_claim(%{})
+    assert {:error, :invalid_issue_claim} = Memory.recover_stale_issue_claim(%{})
     assert :ok = SymphonyElixir.Tracker.create_comment("issue-1", "comment")
     assert :ok = SymphonyElixir.Tracker.update_issue_state("issue-1", "Done")
     assert_receive {:memory_tracker_claim_acquired, "issue-1", "MT-1", %{owner: "memory"}}
+    assert_receive {:memory_tracker_claim_recovery_checked, "issue-1", "MT-1"}
     assert_receive {:memory_tracker_claim_released, "issue-1"}
     assert_receive {:memory_tracker_comment, "issue-1", "comment"}
     assert_receive {:memory_tracker_state_update, "issue-1", "Done"}
@@ -464,6 +467,229 @@ defmodule SymphonyElixir.ExtensionsTest do
     refute Process.get(:claim_body)
   end
 
+  test "linear adapter recovers same-host stale claim when owner pid is not alive" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+    Application.put_env(:symphony_elixir, :local_os_pid_alive?, fn "424242" -> false end)
+
+    claimed_at = DateTime.add(DateTime.utc_now(), -60, :second)
+    expires_at = DateTime.add(claimed_at, 4, :hour)
+    owner = "#{test_hostname()}:424242:#PID<0.1.0>:1"
+    claim_body = signed_claim_body("ALB-CLAIM", owner, "stale-token", claimed_at, expires_at)
+
+    Process.put({FakeLinearClient, :graphql_results}, [
+      claim_comments([%{"id" => "claim-stale", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}]),
+      fn query, variables ->
+        assert String.contains?(query, "commentCreate")
+        assert variables.issueId == "issue-claim"
+        assert variables.body =~ "## Symphony Claim Release"
+        assert variables.body =~ "claim_id: claim-stale"
+        assert variables.body =~ "owner: #{owner}"
+        assert variables.body =~ "token: stale-token"
+
+        {:ok, %{"data" => %{"commentCreate" => %{"success" => true}}}}
+      end,
+      empty_claim_comments(),
+      fn query, variables ->
+        assert String.contains?(query, "commentCreate")
+        Process.put(:claim_body, variables.body)
+
+        {:ok,
+         %{
+           "data" => %{
+             "commentCreate" => %{
+               "success" => true,
+               "comment" => %{"id" => "claim-own", "createdAt" => DateTime.to_iso8601(DateTime.utc_now())}
+             }
+           }
+         }}
+      end,
+      fn query, _variables ->
+        assert String.contains?(query, "SymphonyIssueClaimComments")
+
+        claim_body = Process.get(:claim_body)
+
+        claim_comments([
+          %{"id" => "claim-own", "body" => claim_body, "createdAt" => DateTime.to_iso8601(DateTime.utc_now())}
+        ])
+      end
+    ])
+
+    assert :ok = Adapter.recover_stale_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+    assert {:ok, %{id: "claim-own"}} = Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+  end
+
+  test "linear adapter preserves same-host claim when owner pid is still alive" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+    Application.put_env(:symphony_elixir, :local_os_pid_alive?, fn "31337" -> true end)
+
+    claimed_at = DateTime.add(DateTime.utc_now(), -60, :second)
+    expires_at = DateTime.add(claimed_at, 4, :hour)
+    owner = "#{test_hostname()}:31337:#PID<0.1.0>:1"
+    claim_body = signed_claim_body("ALB-CLAIM", owner, "live-token", claimed_at, expires_at)
+
+    Process.put(
+      {FakeLinearClient, :graphql_result},
+      claim_comments([%{"id" => "claim-live", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}])
+    )
+
+    assert :ok = Adapter.recover_stale_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+
+    assert {:error, {:issue_claimed, %{id: "claim-live", owner: ^owner}}} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+  end
+
+  test "linear adapter default pid probe releases missing same-host owner" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+    Application.delete_env(:symphony_elixir, :local_os_pid_alive?)
+
+    claimed_at = DateTime.add(DateTime.utc_now(), -60, :second)
+    expires_at = DateTime.add(claimed_at, 4, :hour)
+    owner = "#{test_hostname()}:999999:#PID<0.1.0>:1"
+    claim_body = signed_claim_body("ALB-CLAIM", owner, "missing-pid-token", claimed_at, expires_at)
+
+    Application.put_env(:symphony_elixir, :tasklist_lookup, fn "tasklist" -> nil end)
+
+    Process.put({FakeLinearClient, :graphql_results}, [
+      claim_comments([%{"id" => "claim-missing-tasklist", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}]),
+      fn query, variables ->
+        assert String.contains?(query, "commentCreate")
+        assert variables.body =~ "claim_id: claim-missing-tasklist"
+
+        {:ok, %{"data" => %{"commentCreate" => %{"success" => true}}}}
+      end
+    ])
+
+    assert :ok = Adapter.recover_stale_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+
+    Application.put_env(:symphony_elixir, :tasklist_lookup, fn "tasklist" -> "tasklist.exe" end)
+    Application.put_env(:symphony_elixir, :tasklist_cmd, fn "tasklist.exe", _args, _opts -> {"", 1} end)
+
+    Process.put({FakeLinearClient, :graphql_results}, [
+      claim_comments([%{"id" => "claim-tasklist-error", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}]),
+      fn query, variables ->
+        assert String.contains?(query, "commentCreate")
+        assert variables.body =~ "claim_id: claim-tasklist-error"
+
+        {:ok, %{"data" => %{"commentCreate" => %{"success" => true}}}}
+      end
+    ])
+
+    assert :ok = Adapter.recover_stale_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+
+    Application.put_env(:symphony_elixir, :tasklist_cmd, fn "tasklist.exe", _args, _opts ->
+      {~s("Image Name","PID","Session Name"\n"beam.smp.exe","123456","Console"), 0}
+    end)
+
+    Process.put({FakeLinearClient, :graphql_results}, [
+      claim_comments([%{"id" => "claim-missing-pid", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}]),
+      fn query, variables ->
+        assert String.contains?(query, "commentCreate")
+        assert variables.body =~ "claim_id: claim-missing-pid"
+        assert variables.body =~ "token: missing-pid-token"
+
+        {:ok, %{"data" => %{"commentCreate" => %{"success" => true}}}}
+      end
+    ])
+
+    assert :ok = Adapter.recover_stale_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+  end
+
+  test "linear adapter default pid probe preserves listed same-host owner" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+    Application.delete_env(:symphony_elixir, :local_os_pid_alive?)
+    Application.put_env(:symphony_elixir, :tasklist_lookup, fn "tasklist" -> "tasklist.exe" end)
+
+    Application.put_env(:symphony_elixir, :tasklist_cmd, fn "tasklist.exe", _args, _opts ->
+      {~s("Image Name","PID","Session Name"\n"beam.smp.exe","31337","Console"), 0}
+    end)
+
+    claimed_at = DateTime.add(DateTime.utc_now(), -60, :second)
+    expires_at = DateTime.add(claimed_at, 4, :hour)
+    owner = "#{test_hostname()}:31337:#PID<0.1.0>:1"
+    claim_body = signed_claim_body("ALB-CLAIM", owner, "listed-pid-token", claimed_at, expires_at)
+
+    Process.put(
+      {FakeLinearClient, :graphql_result},
+      claim_comments([%{"id" => "claim-listed-pid", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}])
+    )
+
+    assert :ok = Adapter.recover_stale_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+
+    assert {:error, {:issue_claimed, %{id: "claim-listed-pid", owner: ^owner}}} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+  end
+
+  test "linear adapter stops recovery when stale claim release fails" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+    Application.put_env(:symphony_elixir, :local_os_pid_alive?, fn "424242" -> false end)
+
+    claimed_at = DateTime.add(DateTime.utc_now(), -60, :second)
+    expires_at = DateTime.add(claimed_at, 4, :hour)
+    owner = "#{test_hostname()}:424242:#PID<0.1.0>:1"
+    claim_body = signed_claim_body("ALB-CLAIM", owner, "stale-token", claimed_at, expires_at)
+
+    Process.put({FakeLinearClient, :graphql_results}, [
+      claim_comments([%{"id" => "claim-stale", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}]),
+      {:ok, %{"data" => %{"commentCreate" => %{"success" => false}}}}
+    ])
+
+    assert {:error, :claim_release_failed} =
+             Adapter.recover_stale_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+  end
+
+  test "linear adapter preserves other-host active claim during recovery" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+    Application.put_env(:symphony_elixir, :local_os_pid_alive?, fn _pid -> flunk("other-host pid must not be inspected") end)
+
+    claimed_at = DateTime.add(DateTime.utc_now(), -60, :second)
+    expires_at = DateTime.add(claimed_at, 4, :hour)
+    owner = "other-host:424242:#PID<0.1.0>:1"
+    claim_body = signed_claim_body("ALB-CLAIM", owner, "other-token", claimed_at, expires_at)
+
+    Process.put(
+      {FakeLinearClient, :graphql_result},
+      claim_comments([%{"id" => "claim-other", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}])
+    )
+
+    assert :ok = Adapter.recover_stale_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+
+    assert {:error, {:issue_claimed, %{id: "claim-other", owner: ^owner}}} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+  end
+
+  test "linear adapter preserves malformed-owner active claim during recovery" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+    Application.put_env(:symphony_elixir, :local_os_pid_alive?, fn _pid -> flunk("malformed owner pid must not be inspected") end)
+
+    claimed_at = DateTime.add(DateTime.utc_now(), -60, :second)
+    expires_at = DateTime.add(claimed_at, 4, :hour)
+    owner = "#{test_hostname()}:not-a-pid:#PID<0.1.0>:1"
+    claim_body = signed_claim_body("ALB-CLAIM", owner, "malformed-token", claimed_at, expires_at)
+
+    Process.put(
+      {FakeLinearClient, :graphql_result},
+      claim_comments([%{"id" => "claim-malformed", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}])
+    )
+
+    assert :ok = Adapter.recover_stale_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+
+    assert {:error, {:issue_claimed, %{id: "claim-malformed", owner: ^owner}}} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+
+    owner = "malformed-owner"
+    claim_body = signed_claim_body("ALB-CLAIM", owner, "malformed-token-2", claimed_at, expires_at)
+
+    Process.put(
+      {FakeLinearClient, :graphql_result},
+      claim_comments([%{"id" => "claim-malformed-2", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}])
+    )
+
+    assert :ok = Adapter.recover_stale_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+
+    assert {:error, {:issue_claimed, %{id: "claim-malformed-2", owner: ^owner}}} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+  end
+
   test "linear adapter ignores unsigned spoofed claims before dispatch" do
     Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
     older = DateTime.add(DateTime.utc_now(), -60, :second)
@@ -598,9 +824,18 @@ defmodule SymphonyElixir.ExtensionsTest do
     Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
 
     assert {:error, :invalid_issue_claim} = Adapter.acquire_issue_claim(%{})
+    assert {:error, :invalid_issue_claim} = Adapter.recover_stale_issue_claim(%{})
     assert :ok = Adapter.release_issue_claim("issue-claim")
     assert :ok = Adapter.release_issue_claim("issue-claim", %{})
     assert :ok = Adapter.release_issue_claim("issue-claim", :invalid_claim)
+
+    Process.put({FakeLinearClient, :graphql_result}, empty_claim_comments())
+    assert :ok = Adapter.recover_stale_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+
+    Process.put({FakeLinearClient, :graphql_result}, {:error, :recovery_timeout})
+
+    assert {:error, :recovery_timeout} =
+             Adapter.recover_stale_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
 
     Process.put(
       {FakeLinearClient, :graphql_result},
@@ -2790,12 +3025,16 @@ defmodule SymphonyElixir.ExtensionsTest do
   defp assert_eventually(_fun, 0), do: flunk("condition not met in time")
 
   defp empty_claim_comments do
+    claim_comments([])
+  end
+
+  defp claim_comments(nodes) do
     {:ok,
      %{
        "data" => %{
          "issue" => %{
            "comments" => %{
-             "nodes" => [],
+             "nodes" => nodes,
              "pageInfo" => %{"hasNextPage" => false}
            }
          }
@@ -2828,6 +3067,11 @@ defmodule SymphonyElixir.ExtensionsTest do
 
   defp signed_release_body(claim_id, owner, token, released_at) do
     Adapter.release_body_for_test(claim_id, owner, token, released_at)
+  end
+
+  defp test_hostname do
+    {:ok, hostname} = :inet.gethostname()
+    List.to_string(hostname)
   end
 
   defp ensure_workflow_store_running do

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -1,6 +1,35 @@
 defmodule SymphonyElixir.OrchestratorStatusTest do
   use SymphonyElixir.TestSupport
 
+  alias SymphonyElixir.Linear.Adapter
+
+  defmodule FakeLinearClient do
+    def fetch_candidate_issues do
+      {:ok, Keyword.get(config(), :candidate_issues, [])}
+    end
+
+    def fetch_issues_by_states(_states), do: {:ok, []}
+
+    def fetch_issue_states_by_ids(issue_ids) do
+      issues =
+        config()
+        |> Keyword.get(:candidate_issues, [])
+        |> Enum.filter(&(&1.id in issue_ids))
+
+      {:ok, issues}
+    end
+
+    def graphql(query, variables) do
+      config()
+      |> Keyword.fetch!(:graphql)
+      |> then(& &1.(query, variables))
+    end
+
+    defp config do
+      Application.fetch_env!(:symphony_elixir, :orchestrator_status_fake_linear)
+    end
+  end
+
   test "snapshot returns :timeout when snapshot server is unresponsive" do
     server_name = Module.concat(__MODULE__, :UnresponsiveSnapshotServer)
     parent = self()
@@ -99,6 +128,125 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
              message: %{method: "some-event"},
              timestamp: now
            }
+  end
+
+  test "orchestrator releases durable claim when a controlled worker exits" do
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "memory")
+    Application.put_env(:symphony_elixir, :memory_tracker_recipient, self())
+
+    issue_id = "issue-shutdown-release"
+
+    issue = %Issue{
+      id: issue_id,
+      identifier: "MT-189",
+      title: "Shutdown release",
+      description: "Release claim on controlled exit",
+      state: "In Progress",
+      url: "https://example.org/issues/MT-189"
+    }
+
+    orchestrator_name = Module.concat(__MODULE__, :ShutdownReleaseOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    ref = make_ref()
+    initial_state = :sys.get_state(pid)
+
+    running_entry = %{
+      pid: self(),
+      ref: ref,
+      identifier: issue.identifier,
+      issue: issue,
+      claim: %{id: "claim-shutdown", owner: "memory", token: "token"},
+      session_id: "thread-shutdown",
+      turn_count: 0,
+      last_codex_message: nil,
+      last_codex_timestamp: nil,
+      last_codex_event: nil,
+      started_at: DateTime.utc_now()
+    }
+
+    :sys.replace_state(pid, fn _ ->
+      initial_state
+      |> Map.put(:running, %{issue_id => running_entry})
+      |> Map.put(:claimed, MapSet.put(initial_state.claimed, issue_id))
+    end)
+
+    send(pid, {:DOWN, ref, :process, self(), :normal})
+
+    assert_receive {:memory_tracker_claim_released, ^issue_id}, 1_000
+    assert %{running: [], retrying: retrying} = wait_for_snapshot(pid, &match?(%{running: []}, &1))
+    assert Enum.any?(retrying, &(&1.issue_id == issue_id and &1.error_kind == "continuation"))
+  end
+
+  test "orchestrator exposes external claim in retry state without spawning duplicate worker" do
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "linear", polling_interval_ms: 50)
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+    Application.put_env(:symphony_elixir, :task_supervisor_start_child, fn _fun -> flunk("external claim must not spawn") end)
+
+    issue_id = "issue-external-claim"
+
+    issue = %Issue{
+      id: issue_id,
+      identifier: "MT-190",
+      title: "External claim",
+      description: "Do not duplicate externally claimed workers",
+      state: "In Progress",
+      url: "https://example.org/issues/MT-190"
+    }
+
+    claimed_at = DateTime.add(DateTime.utc_now(), -60, :second)
+    expires_at = DateTime.add(claimed_at, 4, :hour)
+    owner = "other-host:424242:#PID<0.1.0>:1"
+    claim_body = Adapter.claim_body_for_test(issue.identifier, owner, "external-token", claimed_at, expires_at)
+
+    Application.put_env(:symphony_elixir, :orchestrator_status_fake_linear,
+      candidate_issues: [issue],
+      graphql: fn query, _variables ->
+        assert String.contains?(query, "SymphonyIssueClaimComments")
+
+        {:ok,
+         %{
+           "data" => %{
+             "issue" => %{
+               "comments" => %{
+                 "nodes" => [
+                   %{"id" => "claim-external", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}
+                 ],
+                 "pageInfo" => %{"hasNextPage" => false}
+               }
+             }
+           }
+         }}
+      end
+    )
+
+    orchestrator_name = Module.concat(__MODULE__, :ExternalClaimOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    snapshot =
+      wait_for_snapshot(pid, fn
+        %{running: [], retrying: retrying} ->
+          Enum.any?(retrying, &(&1.issue_id == issue_id and &1.error_kind == "external_claim"))
+
+        _ ->
+          false
+      end)
+
+    assert snapshot.running == []
+    assert [%{error: error, error_kind: "external_claim"}] = snapshot.retrying
+    assert error =~ "durable claim held by #{owner}"
   end
 
   test "orchestrator snapshot includes command watchdog metadata and stalled policy comments" do


### PR DESCRIPTION
#### Context

Recover stale Linear claim leases left by stopped local workers after runtime restarts.

#### TL;DR

*Recover dead same-host Linear leases and show external claims in retry state.*

#### Summary

- Add tracker recovery before dispatch for stale same-host Linear claim leases.
- Preserve other-host, malformed-owner, and live local-owner claim comments.
- Show active external claims as `external_claim` retry entries instead of local workers.
- Document Windows restart recovery and dashboard behavior.

#### Alternatives

- Shortening lease TTL was rejected because it does not fix restart stalls promptly.
- Reclaiming all same-host leases was rejected because live local workers must stay protected.
- Removing signatures was rejected; recovery still uses signed claim and release comments.

#### Test Plan

- [x] `make.cmd all` - passed on Windows with `SYMPHONY_DISABLE_TERMINAL_DASHBOARD=0`; 464 tests and 100% coverage.
- [x] `make.cmd windows-native-test` - passed on Windows with `SYMPHONY_DISABLE_TERMINAL_DASHBOARD=0`; 113 tests.
- [x] `mix test test/symphony_elixir/extensions_test.exs test/symphony_elixir/orchestrator_status_test.exs --trace` - passed with 113 tests.
- [x] `mix test test/symphony_elixir/app_server_test.exs:696 --trace` - passed when rerun after one transient broad-gate timing issue.

SubAgent review: requested independent review for lease safety and duplicate dispatch risk. Result: no blocking findings. Follow-up coverage added for external-claim retry/no-spawn, release failure, malformed-owner preservation, and non-Windows tasklist absence.