### PR TITLE
Split dispatch polling from active worker states

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,10 @@ Workpad. Blocking findings keep the issue in `In Progress` or return it to
 - For a true blocker, state what failed, the command/subsystem, recovery status,
   and the next operator action in the Workpad and, when useful for public review,
   the linked GitHub issue or PR.
+- If the blocker is shared pipeline friction, such as CI OS mismatch, GitHub
+  auth/rate-limit verification, stale runtime deployment, durable-claim
+  confusion, or manager-owned policy scope, do not keep retrying blindly. Record
+  the evidence and hand it to the manager as a system defect.
 - Move the issue to `Blocked` when that state exists. If it does not, record
   `Blocked state missing` and keep the issue active for manager triage.
 - If you discover a Symphony automation/system defect, create a GitHub issue

--- a/SPEC.md
+++ b/SPEC.md
@@ -363,8 +363,14 @@ Fields:
   - Default: empty list, which means no label filter.
   - When set, a candidate issue MUST have at least one matching label after case-insensitive
     normalization.
+- `dispatch_states` (list of strings)
+  - Default: `Todo`
+  - States Symphony polls for new work.
+  - SHOULD usually exclude long-running states such as `In Progress` so a released or blocked issue
+    is not immediately reclaimed.
 - `active_states` (list of strings)
   - Default: `Todo`, `In Progress`
+  - States where an already-running worker remains valid during reconciliation.
 - `terminal_states` (list of strings)
   - Default: `Closed`, `Cancelled`, `Canceled`, `Duplicate`, `Done`
 
@@ -580,6 +586,7 @@ not require recognizing or validating extension fields unless that extension is 
 - `tracker.api_key`: string or `$VAR`, canonical env `LINEAR_API_KEY` when `tracker.kind=linear`
 - `tracker.project_slug`: string, REQUIRED when `tracker.kind=linear`
 - `tracker.labels`: list of strings, default `[]`
+- `tracker.dispatch_states`: list of strings, default `["Todo"]`
 - `tracker.active_states`: list of strings, default `["Todo", "In Progress"]`
 - `tracker.terminal_states`: list of strings, default `["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]`
 - `polling.interval_ms`: integer, default `30000`
@@ -725,7 +732,7 @@ first.
 An issue is dispatch-eligible only if all are true:
 
 - It has `id`, `identifier`, `title`, and `state`.
-- Its state is in `active_states` and not in `terminal_states`.
+- Its state is in `dispatch_states` and not in `terminal_states`.
 - It is not already in `running`.
 - It is not already in `claimed`.
 - Global concurrency slots are available.

--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -2,6 +2,8 @@
 tracker:
   kind: linear
   project_slug: "symphony-0c79b11b75ea"
+  dispatch_states:
+    - Todo
   active_states:
     - Todo
     - In Progress

--- a/elixir/WORKFLOW.optimization.windows.example.md
+++ b/elixir/WORKFLOW.optimization.windows.example.md
@@ -9,6 +9,10 @@ tracker:
   # Optional: uncomment only if this project is shared with unrelated work.
   # labels:
   #   - symphony-optimization
+  # Poll only release-ready work. Keep Backlog and In Progress out of dispatch_states.
+  dispatch_states:
+    - Todo
+  # Keep In Progress active so workers are not stopped after they claim a Todo issue.
   active_states:
     - Todo
     - In Progress
@@ -95,6 +99,13 @@ Operating model:
 10. Wait for required GitHub checks to complete before moving the Linear issue to `In Review`.
     If checks cannot be verified, record the exact reason in the workpad and PR, then keep the
     issue in `In Progress` or return it to `Todo`; only a manager may explicitly override this.
+    When checks are verified through GitHub CLI, connector, or another non-REST path, record this
+    exact machine-readable evidence in the `## Codex Workpad`:
+    `PR: https://github.com/albert-zen/symphony-windows-native/pull/<number>`
+    `Head \`<full-head-sha>\``
+    `- make-all run <run-id>: success.`
+    `- validate-pr-description run <run-id>: success.`
+    `- windows-native-test run <run-id>: success.`
 11. Do not move unrelated Backlog issues to Todo.
 12. If you discover an automation/system defect, create a GitHub issue with the configured optimization label and add a Linear mirror in the configured Linear project if the Linear tool is available.
 13. Leave problem breadcrumbs without spamming:

--- a/elixir/WORKFLOW.windows.example.md
+++ b/elixir/WORKFLOW.windows.example.md
@@ -6,6 +6,8 @@ tracker:
   # Optional: restrict candidate dispatch to issues with any of these labels.
   # labels:
   #   - symphony-optimization
+  dispatch_states:
+    - Todo
   active_states:
     - Todo
     - In Progress

--- a/elixir/WORKFLOW.windows.safe.example.md
+++ b/elixir/WORKFLOW.windows.safe.example.md
@@ -6,6 +6,8 @@ tracker:
   # Optional: restrict candidate dispatch to issues with any of these labels.
   # labels:
   #   - symphony-optimization
+  dispatch_states:
+    - Todo
   active_states:
     - Todo
     - In Progress

--- a/elixir/WORKFLOW.windows.trusted.example.md
+++ b/elixir/WORKFLOW.windows.trusted.example.md
@@ -6,6 +6,8 @@ tracker:
   # Optional: restrict candidate dispatch to issues with any of these labels.
   # labels:
   #   - symphony-optimization
+  dispatch_states:
+    - Todo
   active_states:
     - Todo
     - In Progress

--- a/elixir/docs/manager-agent-runbook.md
+++ b/elixir/docs/manager-agent-runbook.md
@@ -27,6 +27,10 @@ system defects into durable issues.
   review still needs manager review, state cleanup, and sometimes deployment.
 - Keep the system saturated, not chaotic. Raise concurrency only after claim
   behavior, review readiness, and CI signal are trustworthy.
+- Treat repeated pipeline friction as a product defect in the flywheel, not as a
+  worker performance problem. If multiple workers are debugging the same CI,
+  auth, rate-limit, deployment, or queue-control failure, stop feeding that wall
+  and fix the shared path.
 
 ## Manager-owned work
 
@@ -52,6 +56,32 @@ spec, test intent, acceptance criteria, and no need to decide cross-system
 policy. If a manager-owned issue can be decomposed, create narrower worker-safe
 subtasks and keep the policy decision in the manager Workpad.
 
+## Worker blocker handoff
+
+Workers should not burn long sessions rediscovering orchestration failures. When
+a worker hits a blocker it cannot resolve within its issue scope, the desired
+handoff is:
+
+1. Update the single `## Codex Workpad` with the exact failure, command or
+   subsystem, affected PR/check/log, local recovery attempted, and the next
+   operator action needed.
+2. Add a short Linear comment only when the Workpad is not enough to make the
+   blocker visible to a manager scanning the board.
+3. Move the issue to `Blocked` when that state exists, then release any durable
+   claim so another worker does not immediately reclaim it.
+4. Do not repeatedly retry a failing shared gate unless the Workpad records new
+   evidence that the root cause changed.
+
+The manager owns the next step after this handoff. The manager should classify
+the blocker, find or create the canonical system issue, and decide whether to
+deploy a fix, add a narrow worker-safe follow-up, or return the original issue
+to `Backlog` until the road is clear.
+
+Good blocker reports are small and concrete. They name the failed command or
+API, include the PR/check URL when available, distinguish local pass from CI
+failure, and say whether the current worker can continue after an operator
+action. Vague reports such as "GitHub failed" or "CI flaky" are not enough.
+
 ## Main loop
 
 Run this loop until the operator deliberately pauses the flywheel.
@@ -75,6 +105,8 @@ Run this loop until the operator deliberately pauses the flywheel.
    - Classify the blocker as worker implementation, stale base, failing CI,
      missing config, connector/API failure, credentials, runtime deployment, or
      duplicate/canonical issue confusion.
+   - If several workers hit the same class of blocker, pause release of related
+     work and solve the shared system defect before increasing concurrency.
    - Record the exact failure and next operator action in the Workpad.
    - Create or update one canonical GitHub issue labeled
      `symphony-optimization`, plus a Linear mirror, for system defects.
@@ -131,6 +163,9 @@ logs, dashboard state, and runtime logs. Ask these questions:
 - Did review readiness fail because the runtime is missing repository, token, or
   state configuration?
 - Did Linear/GitHub connector lookup fail while direct API access would work?
+- Is the failure caused by CI running on a different OS than the local worker,
+  such as Windows-only commands executed on Ubuntu?
+- Is a merged system fix still absent from the running runtime?
 - Did the issue duplicate a known canonical defect?
 - Did the runtime run old code after a system fix was merged?
 

--- a/elixir/docs/small-team-agentic-flywheel.md
+++ b/elixir/docs/small-team-agentic-flywheel.md
@@ -178,7 +178,7 @@ Pause the flywheel by stopping new dispatch first, then letting active work land
 or park cleanly:
 
 1. Stop moving new issues from `Backlog` to `Todo`.
-2. If immediate pause is needed, remove `Todo` from `tracker.active_states` or
+2. If immediate pause is needed, remove `Todo` from `tracker.dispatch_states` or
    stop the Symphony process.
 3. Let active agents finish their current turn when possible.
 4. For unfinished active issues, update the Workpad with the current branch,

--- a/elixir/docs/windows-native.md
+++ b/elixir/docs/windows-native.md
@@ -234,7 +234,7 @@ explicit review target.
 
 The optimization example is a fixed-project routing template. Replace
 `YOUR_LINEAR_PROJECT_SLUG` with the slug for the Linear project you want
-Symphony to poll. Keep `Backlog` out of `tracker.active_states`; parked issues
+Symphony to poll. Keep `Backlog` out of `tracker.dispatch_states`; parked issues
 remain invisible to Symphony until a human moves one issue at a time to `Todo`.
 
 Keep the public example generic. Operator-specific project names, workspace
@@ -250,14 +250,17 @@ tracker:
   project_slug: "YOUR_LINEAR_PROJECT_SLUG"
   labels:
     - symphony-optimization
+  dispatch_states:
+    - Todo
   active_states:
     - Todo
     - In Progress
 ```
 
-The label match is case-insensitive and applies only to candidate dispatch.
-Already-running issues are still reconciled by their tracker state so Symphony
-can stop them cleanly when they move to a terminal state.
+The label match and `dispatch_states` apply only to candidate dispatch.
+Already-running issues are still reconciled by `active_states` so Symphony keeps
+valid workers alive after they move from `Todo` to `In Progress`, and stops them
+cleanly when they move to a terminal state.
 
 To find the right Linear values, use the Linear UI for the project slug when
 possible, or query Linear GraphQL with your own API key. Do not commit API keys,
@@ -370,15 +373,16 @@ A practical flow is:
 - `Done`: terminal. Symphony stops the active agent.
 - `Canceled`, `Cancelled`, `Duplicate`: terminal.
 
-Set `tracker.active_states` to the states where agents should work, and
-`tracker.terminal_states` to states where Symphony should stop.
+Set `tracker.dispatch_states` to the states Symphony should poll for new work,
+`tracker.active_states` to the states where already-running agents remain valid,
+and `tracker.terminal_states` to states where Symphony should stop.
 
 ## What each phase does
 
 ### Poll
 
 Symphony queries Linear for issues in the configured project whose state is in
-`active_states`. If `tracker.labels` is configured, candidates must also have
+`dispatch_states`. If `tracker.labels` is configured, candidates must also have
 at least one matching label.
 
 ### Claim and workspace

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -488,7 +488,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     with [_ | _] <- required_contexts,
          {:ok, workpad} <- workpad_body(issue),
          true <- workpad_references_pr?(workpad, owner, repo, number),
-         {:ok, ^head_sha} <- workpad_head_sha(workpad) do
+         true <- workpad_references_head_sha?(workpad, head_sha) do
       successful_checks = MapSet.new(workpad_successful_checks(workpad))
 
       required_contexts
@@ -503,7 +503,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     with true <- github_auth_unavailable?(reason),
          {:ok, workpad} <- workpad_body(issue),
          true <- workpad_references_pr?(workpad, owner, repo, number),
-         {:ok, ^head_sha} <- workpad_head_sha(workpad),
+         true <- workpad_references_head_sha?(workpad, head_sha),
          [_ | _] = checks <- workpad_successful_checks(workpad) do
       {:ok, Enum.map(checks, &%{context: &1, app_id: nil})}
     else
@@ -532,15 +532,29 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     String.contains?(workpad, "https://github.com/#{owner}/#{repo}/pull/#{number}")
   end
 
-  defp workpad_head_sha(workpad) do
-    case Regex.run(~r/head\s+`?([a-f0-9]{6,40})`?/i, workpad) do
-      [_, sha] -> {:ok, sha}
-      _ -> :error
-    end
+  defp workpad_references_head_sha?(workpad, head_sha) do
+    normalized_head_sha = String.downcase(head_sha)
+
+    workpad
+    |> workpad_head_sha_candidates()
+    |> Enum.any?(fn candidate ->
+      String.starts_with?(normalized_head_sha, candidate)
+    end)
+  end
+
+  defp workpad_head_sha_candidates(workpad) do
+    [
+      ~r/\b(?:current\s+head|final\s+head|head)\s+`?([a-f0-9]{6,40})`?/i,
+      ~r/\bgithub\s+checks\s+on\s+`?([a-f0-9]{6,40})`?/i,
+      ~r/\bverified\s+checks\s+for\s+`?([a-f0-9]{6,40})`?/i
+    ]
+    |> Enum.flat_map(fn regex -> Regex.scan(regex, workpad) end)
+    |> Enum.map(fn [_, sha] -> String.downcase(sha) end)
+    |> Enum.uniq()
   end
 
   defp workpad_successful_checks(workpad) do
-    ~r/^\s*-\s*`?([^`:\r\n]+)`?\s+(?:run\s+\d+\s*)?:\s*success\s*\.?\s*$/im
+    ~r/^\s*-\s*`?([^`:\r\n]+?)`?\s*(?:run\s+\d+\s*)?(?::|\s)\s*success\s*\.?\s*$/im
     |> Regex.scan(workpad)
     |> Enum.map(fn [_, check] -> String.trim(check) end)
     |> Enum.reject(&(&1 == ""))

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -61,7 +61,17 @@ defmodule SymphonyElixir.Config.Schema do
       schema
       |> cast(
         attrs,
-        [:kind, :endpoint, :api_key, :project_slug, :assignee, :labels, :dispatch_states, :active_states, :terminal_states],
+        [
+          :kind,
+          :endpoint,
+          :api_key,
+          :project_slug,
+          :assignee,
+          :labels,
+          :dispatch_states,
+          :active_states,
+          :terminal_states
+        ],
         empty_values: []
       )
     end

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -51,6 +51,7 @@ defmodule SymphonyElixir.Config.Schema do
       field(:project_slug, :string)
       field(:assignee, :string)
       field(:labels, {:array, :string}, default: [])
+      field(:dispatch_states, {:array, :string}, default: ["Todo"])
       field(:active_states, {:array, :string}, default: ["Todo", "In Progress"])
       field(:terminal_states, {:array, :string}, default: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"])
     end
@@ -60,7 +61,7 @@ defmodule SymphonyElixir.Config.Schema do
       schema
       |> cast(
         attrs,
-        [:kind, :endpoint, :api_key, :project_slug, :assignee, :labels, :active_states, :terminal_states],
+        [:kind, :endpoint, :api_key, :project_slug, :assignee, :labels, :dispatch_states, :active_states, :terminal_states],
         empty_values: []
       )
     end
@@ -390,7 +391,10 @@ defmodule SymphonyElixir.Config.Schema do
       settings.tracker
       | api_key: resolve_secret_setting(settings.tracker.api_key, System.get_env("LINEAR_API_KEY")),
         assignee: resolve_secret_setting(settings.tracker.assignee, System.get_env("LINEAR_ASSIGNEE")),
-        labels: normalize_label_filter(settings.tracker.labels)
+        labels: normalize_label_filter(settings.tracker.labels),
+        dispatch_states: normalize_issue_states(settings.tracker.dispatch_states),
+        active_states: normalize_issue_states(settings.tracker.active_states),
+        terminal_states: normalize_issue_states(settings.tracker.terminal_states)
     }
 
     workspace = %{
@@ -432,6 +436,16 @@ defmodule SymphonyElixir.Config.Schema do
     |> Enum.reject(&(&1 == ""))
     |> Enum.uniq()
   end
+
+  defp normalize_issue_states(states) when is_list(states) do
+    states
+    |> Enum.map(&to_string/1)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+  end
+
+  defp normalize_issue_states(_states), do: []
 
   defp normalize_repository(repository) when is_binary(repository) do
     repository

--- a/elixir/lib/symphony_elixir/linear/client.ex
+++ b/elixir/lib/symphony_elixir/linear/client.ex
@@ -117,7 +117,7 @@ defmodule SymphonyElixir.Linear.Client do
 
       true ->
         with {:ok, assignee_filter} <- routing_assignee_filter() do
-          do_fetch_by_states(project_slug, tracker.active_states, assignee_filter, routing_label_filter())
+          do_fetch_by_states(project_slug, tracker.dispatch_states, assignee_filter, routing_label_filter())
         end
     end
   end

--- a/elixir/lib/symphony_elixir_web/observability_pubsub.ex
+++ b/elixir/lib/symphony_elixir_web/observability_pubsub.ex
@@ -9,7 +9,10 @@ defmodule SymphonyElixirWeb.ObservabilityPubSub do
 
   @spec subscribe() :: :ok | {:error, term()}
   def subscribe do
-    Phoenix.PubSub.subscribe(@pubsub, @topic)
+    case Process.whereis(@pubsub) do
+      pid when is_pid(pid) -> Phoenix.PubSub.subscribe(@pubsub, @topic)
+      _ -> :ok
+    end
   end
 
   @spec broadcast_update() :: :ok

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -331,6 +331,7 @@ defmodule SymphonyElixir.TestSupport do
           tracker_project_slug: "project",
           tracker_assignee: nil,
           tracker_labels: [],
+          tracker_dispatch_states: ["Todo"],
           tracker_active_states: ["Todo", "In Progress"],
           tracker_terminal_states: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"],
           poll_interval_ms: 30_000,
@@ -376,6 +377,7 @@ defmodule SymphonyElixir.TestSupport do
     tracker_project_slug = Keyword.get(config, :tracker_project_slug)
     tracker_assignee = Keyword.get(config, :tracker_assignee)
     tracker_labels = Keyword.get(config, :tracker_labels)
+    tracker_dispatch_states = Keyword.get(config, :tracker_dispatch_states)
     tracker_active_states = Keyword.get(config, :tracker_active_states)
     tracker_terminal_states = Keyword.get(config, :tracker_terminal_states)
     poll_interval_ms = Keyword.get(config, :poll_interval_ms)
@@ -422,6 +424,7 @@ defmodule SymphonyElixir.TestSupport do
         "  project_slug: #{yaml_value(tracker_project_slug)}",
         "  assignee: #{yaml_value(tracker_assignee)}",
         "  labels: #{yaml_value(tracker_labels)}",
+        "  dispatch_states: #{yaml_value(tracker_dispatch_states)}",
         "  active_states: #{yaml_value(tracker_active_states)}",
         "  terminal_states: #{yaml_value(tracker_terminal_states)}",
         "polling:",

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -22,6 +22,7 @@ defmodule SymphonyElixir.CoreTest do
 
     config = Config.settings!()
     assert config.polling.interval_ms == 30_000
+    assert config.tracker.dispatch_states == ["Todo"]
     assert config.tracker.active_states == ["Todo", "In Progress"]
     assert config.tracker.terminal_states == ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]
     assert config.tracker.assignee == nil
@@ -51,6 +52,9 @@ defmodule SymphonyElixir.CoreTest do
     write_workflow_file!(Workflow.workflow_file_path(), tracker_active_states: "Todo,  Review,")
     assert {:error, {:invalid_workflow_config, message}} = Config.validate!()
     assert message =~ "tracker.active_states"
+
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_dispatch_states: [" Todo ", "Todo", ""])
+    assert Config.settings!().tracker.dispatch_states == ["Todo"]
 
     write_workflow_file!(Workflow.workflow_file_path(),
       tracker_api_token: "token",

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -1769,6 +1769,58 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     refute_received {:workpad_recorded, _}
   end
 
+  test "linear_graphql accepts Workpad connector check evidence with adjacent worker formats" do
+    test_pid = self()
+
+    issue =
+      issue_with_connector_check_evidence("""
+      ## Codex Workpad
+
+      PR: https://github.com/albert-zen/symphony-windows-native/pull/42
+      GitHub connector verified checks for abc123 passed:
+      - make-all run 191: success.
+      - pr-description-lint success.
+      """)
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue),
+        github_client: github_client_with_rate_limited_checks()
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
+    refute_received {:workpad_recorded, _}
+  end
+
+  test "linear_graphql accepts Workpad connector check evidence from GitHub checks heading" do
+    test_pid = self()
+
+    issue =
+      issue_with_connector_check_evidence("""
+      ## Codex Workpad
+
+      PR: https://github.com/albert-zen/symphony-windows-native/pull/42
+      GitHub checks on `abc123`:
+      - `make-all`: success.
+      - `pr-description-lint` run 255: success.
+      """)
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        review_transition_arguments(),
+        linear_client: review_linear_client(test_pid, issue),
+        github_client: github_client_with_rate_limited_checks()
+      )
+
+    assert response["success"] == true
+    assert_received {:linear_mutation_allowed, "issue-1", "state-review"}
+    refute_received {:workpad_recorded, _}
+  end
+
   test "linear_graphql accepts Workpad connector check evidence when branch protection requires auth" do
     test_pid = self()
 
@@ -2129,11 +2181,10 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     ])
   end
 
-  defp issue_with_connector_check_evidence do
-    put_in(issue_with_origin_github_issue(), ["comments", "nodes"], [
-      %{
-        "id" => "comment-1",
-        "body" => """
+  defp issue_with_connector_check_evidence(body \\ nil) do
+    body =
+      body ||
+        """
         ## Codex Workpad
 
         PR: https://github.com/albert-zen/symphony-windows-native/pull/42
@@ -2143,6 +2194,11 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
         - `make-all` run 191: success.
         - `pr-description-lint` run 255: success.
         """
+
+    put_in(issue_with_origin_github_issue(), ["comments", "nodes"], [
+      %{
+        "id" => "comment-1",
+        "body" => body
       }
     ])
   end

--- a/elixir/test/symphony_elixir/observability_pubsub_test.exs
+++ b/elixir/test/symphony_elixir/observability_pubsub_test.exs
@@ -25,4 +25,20 @@ defmodule SymphonyElixir.ObservabilityPubSubTest do
 
     assert :ok = ObservabilityPubSub.broadcast_update()
   end
+
+  test "subscribe is a no-op when pubsub is unavailable" do
+    pubsub_child_id = Phoenix.PubSub.Supervisor
+
+    on_exit(fn ->
+      if Process.whereis(SymphonyElixir.PubSub) == nil do
+        assert {:ok, _pid} =
+                 Supervisor.restart_child(SymphonyElixir.Supervisor, pubsub_child_id)
+      end
+    end)
+
+    assert :ok = Supervisor.terminate_child(SymphonyElixir.Supervisor, pubsub_child_id)
+    refute Process.whereis(SymphonyElixir.PubSub)
+
+    assert :ok = ObservabilityPubSub.subscribe()
+  end
 end


### PR DESCRIPTION
#### Context

Workers were reclaiming In Progress work, and green PRs stayed Blocked when Workpad check evidence used adjacent formats.

#### TL;DR

*Split dispatch polling from active reconciliation and harden review evidence parsing.*

#### Summary

- Add `tracker.dispatch_states` so new dispatch defaults to Todo only.
- Keep `active_states` for already-running worker reconciliation.
- Make review-readiness accept observed Workpad check evidence variants.
- Make dashboard PubSub subscription safe when test order temporarily stops PubSub.
- Document the release-valve split in specs, runbooks, and workflow examples.

#### Alternatives

- Setting `active_states` to Todo only was rejected because it can stop claimed workers after they move to In Progress.
- Creating duplicate review-readiness issues was avoided; #77 remains the canonical rate-limit/evidence thread.

#### Test Plan

- [ ] `make -C elixir all` not run locally because this Windows checkout has unrelated CRLF format-check debt that stops before the full gate can run.
- [x] `mise exec -- mix test test/symphony_elixir/core_test.exs test/symphony_elixir/dynamic_tool_test.exs` -> 125 tests, 0 failures, 1 skipped.
- [x] `mise exec -- mix test test/symphony_elixir/observability_pubsub_test.exs test/symphony_elixir/extensions_test.exs:1670` -> 4 tests, 0 failures.
- [x] `mise exec -- mix credo lib/symphony_elixir/config/schema.ex` -> no issues.
- [x] `git diff --check` -> no whitespace errors.
- [x] `mise exec -- make all` attempted locally; failed before tests at `mix format --check-formatted` because unrelated tracked files in this Windows checkout have CRLF and would be rewritten to LF.