### PR TITLE
docs(flywheel): require canonical defect dedupe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,9 +93,14 @@ Workpad. Blocking findings keep the issue in `In Progress` or return it to
   the evidence and hand it to the manager as a system defect.
 - Move the issue to `Blocked` when that state exists. If it does not, record
   `Blocked state missing` and keep the issue active for manager triage.
-- If you discover a Symphony automation/system defect, create a GitHub issue
-  labeled `symphony-optimization` and mirror it into the Linear project when the
-  Linear tool is available.
+- If you discover a Symphony automation/system defect, search existing open and
+  recently closed GitHub issues plus Linear mirrors for the same root cause
+  before creating anything new. If a canonical issue exists, add the new
+  evidence there instead of creating a duplicate. If no canonical issue exists,
+  create a GitHub issue labeled `symphony-optimization` and mirror it into the
+  Linear project when the Linear tool is available. If duplicates already exist,
+  link them back to the canonical issue and let the manager move redundant
+  mirrors to `Duplicate`.
 
 ## Known Pitfalls
 

--- a/elixir/WORKFLOW.optimization.windows.example.md
+++ b/elixir/WORKFLOW.optimization.windows.example.md
@@ -107,7 +107,16 @@ Operating model:
     `- validate-pr-description run <run-id>: success.`
     `- windows-native-test run <run-id>: success.`
 11. Do not move unrelated Backlog issues to Todo.
-12. If you discover an automation/system defect, create a GitHub issue with the configured optimization label and add a Linear mirror in the configured Linear project if the Linear tool is available.
+12. If you discover an automation/system defect:
+    - Search existing open and recently closed GitHub issues plus Linear mirrors for the same root
+      cause before creating anything new.
+    - If a canonical issue exists, add a concise comment there with the new evidence, affected
+      issue/PR/log, and impact instead of creating a duplicate.
+    - If no canonical issue exists, create a GitHub issue with the configured optimization label,
+      including observed symptoms, suspected root cause, impact, and acceptance criteria, then add a
+      Linear mirror in the configured Linear project if the Linear tool is available.
+    - If you discover duplicates, link them back to the canonical issue and leave final duplicate
+      cleanup to the manager.
 13. Leave problem breadcrumbs without spamming:
     - Update the `## Codex Workpad` for recovered transient noise, retries, or routine validation fixes.
     - Add a separate concise Linear problem comment only for notable environment, validation, auth,


### PR DESCRIPTION
#### Context

GH #84 asks for canonical defect dedupe so parallel workers stop filing repeat system-defect issues.

#### TL;DR

*Tell workers to search first and comment on canonical system defects before creating duplicates.*

#### Summary

- Add search-first duplicate guidance to the worker entrypoint playbook.
- Update the Windows optimization workflow prompt with canonical issue behavior.
- Keep final duplicate cleanup manager-owned while preserving worker evidence.

#### Alternatives

- Leave this only in the manager runbook: rejected because workers need the rule before filing defects.
- Build automated duplicate search now: deferred because this issue can first fix the agent-visible protocol.

#### Test Plan

- [ ] `make -C elixir all`
- [x] `mise exec -- mix test test/symphony_elixir/workspace_and_config_test.exs:1457 --trace` passed; 1 test, 0 failures.
- [x] `mise exec -- mix format.check_normalized` passed.
- [x] `git diff --check` passed.
- `make -C elixir all` was not run locally because this is a docs/prompt-only policy update; the narrower workflow parse and formatting checks cover the touched behavior.

Fixes #84
