### PR TITLE
fix(preflight): report line-ending friction

### DIFF
--- a/elixir/lib/symphony_elixir/windows_preflight.ex
+++ b/elixir/lib/symphony_elixir/windows_preflight.ex
@@ -38,6 +38,18 @@ defmodule SymphonyElixir.WindowsPreflight do
   """
 
   @required_path_tools ["git", "gh", "node"]
+  @line_ending_attr_paths [
+    ".gitattributes",
+    ".github/workflows/make-all.yml",
+    "elixir/.formatter.exs",
+    "elixir/.gitattributes",
+    "elixir/config/config.exs",
+    "elixir/mix.exs",
+    "elixir/lib/symphony_elixir/orchestrator.ex",
+    "elixir/test/symphony_elixir/orchestrator_status_test.exs",
+    "elixir/test/support/test_support.exs",
+    "elixir/docs/windows-native.md"
+  ]
 
   @spec run(Path.t(), deps()) :: {:ok | :error, [check()]}
   def run(workflow_path, deps \\ %{}) when is_binary(workflow_path) and is_map(deps) do
@@ -61,7 +73,8 @@ defmodule SymphonyElixir.WindowsPreflight do
             tasklist_check(deps),
             linear_check(settings, deps),
             github_cli_check(deps),
-            coverage_policy_check()
+            coverage_policy_check(),
+            line_ending_check(deps)
           ]
 
           if capabilities_only? do
@@ -514,6 +527,146 @@ defmodule SymphonyElixir.WindowsPreflight do
           "Coverage threshold could not be read.",
           "Set test_coverage.summary.threshold in mix.exs."
         )
+    end
+  end
+
+  defp line_ending_check(deps) do
+    local_shell_run = Map.get(deps, :local_shell_run, &LocalShell.run/2)
+
+    with {:ok, repo_root} <- git_repo_root(local_shell_run),
+         {:ok, autocrlf} <- git_config_autocrlf(local_shell_run, repo_root),
+         {:ok, eol_output} <- git_ls_files_eol(local_shell_run, repo_root),
+         {:ok, attr_output} <- git_check_line_ending_attrs(local_shell_run, repo_root) do
+      crlf_files = formatter_managed_crlf_files(eol_output)
+      missing_attr_paths = missing_lf_attr_paths(attr_output)
+
+      cond do
+        crlf_files != [] ->
+          fail(
+            "Git line endings",
+            "formatter-managed files are checked out as CRLF: #{Enum.join(crlf_files, ", ")}.",
+            "Run `git config --local core.autocrlf false`, rewrite the checkout or run `git add --renormalize`, then rerun preflight."
+          )
+
+        missing_attr_paths != [] ->
+          fail(
+            "Git line endings",
+            "repo line-ending attributes are missing LF coverage for: #{Enum.join(missing_attr_paths, ", ")}.",
+            "Update repo-level .gitattributes and elixir/.gitattributes so formatter-managed inputs resolve to eol=lf."
+          )
+
+        autocrlf.value == "true" ->
+          warn(
+            "Git line endings",
+            "core.autocrlf=true from #{autocrlf.source}, but no formatter-managed files are checked out as CRLF.",
+            "Prefer `git config --local core.autocrlf false` for this repo so future checkouts do not reintroduce CRLF formatter friction."
+          )
+
+        true ->
+          pass("Git line endings", "formatter-managed files are LF-normalized and Git attributes resolve to eol=lf.")
+      end
+    else
+      {:error, reason} ->
+        warn(
+          "Git line endings",
+          "Could not inspect repository line endings: #{inspect(reason)}.",
+          "Run preflight from the repository checkout and confirm git is available."
+        )
+    end
+  end
+
+  defp git_repo_root(local_shell_run) do
+    case local_shell_run.("git rev-parse --show-toplevel", cd: File.cwd!()) do
+      {:ok, {output, 0}} -> {:ok, String.trim(output)}
+      {:ok, {output, status}} -> {:error, {"git rev-parse --show-toplevel", status, sanitize_command_output(output)}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp git_config_autocrlf(local_shell_run, repo_root) do
+    local_command = "git -C #{shell_quote(repo_root)} config --local --get core.autocrlf"
+
+    case local_shell_run.(local_command, cd: repo_root) do
+      {:ok, {output, 0}} -> {:ok, %{source: "repo-local Git config", value: normalize_git_config_value(output)}}
+      {:ok, {_output, _status}} -> git_effective_autocrlf(local_shell_run, repo_root)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp git_effective_autocrlf(local_shell_run, repo_root) do
+    command = "git -C #{shell_quote(repo_root)} config --get core.autocrlf"
+
+    case local_shell_run.(command, cd: repo_root) do
+      {:ok, {output, 0}} -> {:ok, %{source: "effective Git config", value: normalize_git_config_value(output)}}
+      {:ok, {_output, _status}} -> {:ok, %{source: "Git config", value: "unset"}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp normalize_git_config_value(output) do
+    output
+    |> String.trim()
+    |> String.downcase()
+  end
+
+  defp git_ls_files_eol(local_shell_run, repo_root) do
+    command = "git -C #{shell_quote(repo_root)} ls-files --eol"
+
+    case local_shell_run.(command, cd: repo_root) do
+      {:ok, {output, 0}} -> {:ok, output}
+      {:ok, {output, status}} -> {:error, {command, status, sanitize_command_output(output)}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp git_check_line_ending_attrs(local_shell_run, repo_root) do
+    command = "git -C #{shell_quote(repo_root)} check-attr eol -- #{Enum.map_join(@line_ending_attr_paths, " ", &shell_quote/1)}"
+
+    case local_shell_run.(command, cd: repo_root) do
+      {:ok, {output, 0}} -> {:ok, output}
+      {:ok, {output, status}} -> {:error, {command, status, sanitize_command_output(output)}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp formatter_managed_crlf_files(eol_output) do
+    eol_output
+    |> String.split("\n", trim: true)
+    |> Enum.flat_map(&formatter_managed_crlf_file/1)
+  end
+
+  defp formatter_managed_crlf_file(line) do
+    case Regex.run(~r/\bw\/crlf\b.*\t(.+)$/, line) do
+      [_match, path] -> formatter_managed_crlf_path(path)
+      _ -> []
+    end
+  end
+
+  defp formatter_managed_crlf_path(path) do
+    if formatter_managed_path?(path), do: [path], else: []
+  end
+
+  defp formatter_managed_path?(path) do
+    String.starts_with?(path, "elixir/") and
+      String.match?(path, ~r/\.(ex|exs|heex|md|yml|yaml|txt|lock)$/)
+  end
+
+  defp missing_lf_attr_paths(attr_output) do
+    attr_output
+    |> String.split("\n", trim: true)
+    |> Enum.flat_map(&missing_lf_attr_path/1)
+  end
+
+  defp missing_lf_attr_path(line) do
+    case String.split(line, ":", parts: 3) do
+      [path, eol_label, value] when eol_label in [" eol", "eol"] ->
+        if String.trim(value) == "lf", do: [], else: [path]
+
+      [path | _rest] ->
+        [String.trim(path)]
+
+      _ ->
+        []
     end
   end
 

--- a/elixir/test/symphony_elixir/windows_preflight_test.exs
+++ b/elixir/test/symphony_elixir/windows_preflight_test.exs
@@ -15,6 +15,9 @@ defmodule SymphonyElixir.WindowsPreflightTest do
       local_shell_run: fn
         hook_probe, _opts when is_binary(hook_probe) ->
           cond do
+            line_ending_command?(hook_probe) ->
+              ready_line_ending_response(hook_probe)
+
             git_main_tracking_command?(hook_probe) ->
               ready_git_main_tracking_response(hook_probe)
 
@@ -62,8 +65,18 @@ defmodule SymphonyElixir.WindowsPreflightTest do
         end,
         os_type: fn -> {:win32, :nt} end,
         local_shell_run: fn
-          "gh auth status", _opts -> {:ok, {"Logged in to github.com\n", 0}}
-          unexpected, _opts -> flunk("capabilities-only should not run #{unexpected}")
+          "gh auth status", _opts ->
+            {:ok, {"Logged in to github.com\n", 0}}
+
+          command, _opts when is_binary(command) ->
+            if line_ending_command?(command) do
+              ready_line_ending_response(command)
+            else
+              flunk("capabilities-only should not run #{command}")
+            end
+
+          unexpected, _opts ->
+            flunk("capabilities-only should not run #{unexpected}")
         end
       })
 
@@ -101,8 +114,18 @@ defmodule SymphonyElixir.WindowsPreflightTest do
           _name -> nil
         end,
         local_shell_run: fn
-          "gh auth status", _opts -> {:ok, {"Logged in with token ghp_secret\n", 0}}
-          unexpected, _opts -> flunk("unexpected command: #{unexpected}")
+          "gh auth status", _opts ->
+            {:ok, {"Logged in with token ghp_secret\n", 0}}
+
+          command, _opts when is_binary(command) ->
+            if line_ending_command?(command) do
+              ready_line_ending_response(command)
+            else
+              flunk("unexpected command: #{command}")
+            end
+
+          unexpected, _opts ->
+            flunk("unexpected command: #{unexpected}")
         end
       })
 
@@ -126,6 +149,13 @@ defmodule SymphonyElixir.WindowsPreflightTest do
           "gh auth status", _opts ->
             {:ok, {"failed with ghp_secret and https://token:secret@github.com/example/repo.git", 1}}
 
+          command, _opts when is_binary(command) ->
+            if line_ending_command?(command) do
+              ready_line_ending_response(command)
+            else
+              flunk("unexpected command: #{command}")
+            end
+
           unexpected, _opts ->
             flunk("unexpected command: #{unexpected}")
         end
@@ -138,6 +168,145 @@ defmodule SymphonyElixir.WindowsPreflightTest do
     refute output =~ "token"
     refute output =~ "secret"
     assert output =~ "[redacted]"
+  end
+
+  test "warns when repo autocrlf is true but formatter-managed files are LF-normalized" do
+    workflow_path = workflow_with_preflight_config()
+
+    deps =
+      ready_deps(%{
+        local_shell_run: fn
+          command, _opts when is_binary(command) ->
+            cond do
+              line_ending_command?(command) ->
+                ready_line_ending_response(command, core_autocrlf: "true")
+
+              command == "gh auth status" ->
+                {:ok, {"Logged in\n", 0}}
+
+              true ->
+                flunk("unexpected command: #{command}")
+            end
+        end
+      })
+
+    assert {:ok, checks} = WindowsPreflight.run(workflow_path, deps, capabilities_only: true)
+
+    assert %WindowsPreflight.Check{status: :warn, message: message, remediation: remediation} =
+             Enum.find(checks, &(&1.name == "Git line endings"))
+
+    assert message =~ "core.autocrlf=true"
+    assert message =~ "no formatter-managed files are checked out as CRLF"
+    assert remediation =~ "git config --local core.autocrlf false"
+  end
+
+  test "warns when effective autocrlf is true from global config" do
+    workflow_path = workflow_with_preflight_config()
+
+    deps =
+      ready_deps(%{
+        local_shell_run: fn
+          command, _opts when is_binary(command) ->
+            cond do
+              line_ending_command?(command) ->
+                ready_line_ending_response(command,
+                  local_core_autocrlf: nil,
+                  effective_core_autocrlf: "true"
+                )
+
+              command == "gh auth status" ->
+                {:ok, {"Logged in\n", 0}}
+
+              true ->
+                flunk("unexpected command: #{command}")
+            end
+        end
+      })
+
+    assert {:ok, checks} = WindowsPreflight.run(workflow_path, deps, capabilities_only: true)
+
+    assert %WindowsPreflight.Check{status: :warn, message: message, remediation: remediation} =
+             Enum.find(checks, &(&1.name == "Git line endings"))
+
+    assert message =~ "core.autocrlf=true"
+    assert message =~ "effective Git config"
+    assert remediation =~ "git config --local core.autocrlf false"
+  end
+
+  test "fails when formatter-managed files are checked out with CRLF worktree endings" do
+    workflow_path = workflow_with_preflight_config()
+
+    deps =
+      ready_deps(%{
+        local_shell_run: fn
+          command, _opts when is_binary(command) ->
+            cond do
+              line_ending_command?(command) ->
+                ready_line_ending_response(command,
+                  core_autocrlf: "false",
+                  eol_output: """
+                  i/lf    w/lf    attr/text eol=lf      \t.gitattributes
+                  i/lf    w/crlf  attr/text eol=lf      \telixir/lib/symphony_elixir/windows_preflight.ex
+                  i/lf    w/lf    attr/text eol=lf      \telixir/docs/windows-native.md
+                  """
+                )
+
+              command == "gh auth status" ->
+                {:ok, {"Logged in\n", 0}}
+
+              true ->
+                flunk("unexpected command: #{command}")
+            end
+        end
+      })
+
+    assert {:error, checks} = WindowsPreflight.run(workflow_path, deps, capabilities_only: true)
+
+    assert %WindowsPreflight.Check{status: :fail, message: message, remediation: remediation} =
+             Enum.find(checks, &(&1.name == "Git line endings"))
+
+    assert message =~ "formatter-managed files are checked out as CRLF"
+    assert message =~ "elixir/lib/symphony_elixir/windows_preflight.ex"
+    assert remediation =~ "git add --renormalize"
+  end
+
+  test "fails when repo attributes do not force formatter-managed files to LF" do
+    workflow_path = workflow_with_preflight_config()
+
+    deps =
+      ready_deps(%{
+        local_shell_run: fn
+          command, _opts when is_binary(command) ->
+            cond do
+              line_ending_command?(command) ->
+                ready_line_ending_response(command,
+                  attr_output: """
+                  .gitattributes: eol: lf
+                  elixir/.formatter.exs: eol: lf
+                  elixir/.gitattributes: eol: lf
+                  elixir/mix.exs: eol: unspecified
+                  elixir/docs/windows-native.md: eol: lf
+                  .github/workflows/make-all.yml: eol: lf
+                  """
+                )
+
+              command == "gh auth status" ->
+                {:ok, {"Logged in\n", 0}}
+
+              true ->
+                flunk("unexpected command: #{command}")
+            end
+        end
+      })
+
+    assert {:error, checks} = WindowsPreflight.run(workflow_path, deps, capabilities_only: true)
+
+    assert %WindowsPreflight.Check{status: :fail, message: message, remediation: remediation} =
+             Enum.find(checks, &(&1.name == "Git line endings"))
+
+    assert message =~ "missing LF coverage"
+    assert message =~ "elixir/mix.exs"
+    assert remediation =~ ".gitattributes"
   end
 
   test "returns an error and remediation when required checks fail" do
@@ -153,6 +322,9 @@ defmodule SymphonyElixir.WindowsPreflightTest do
       local_shell_run: fn
         hook_probe, _opts when is_binary(hook_probe) ->
           cond do
+            line_ending_command?(hook_probe) ->
+              ready_line_ending_response(hook_probe)
+
             git_main_tracking_command?(hook_probe) ->
               ready_git_main_tracking_response(hook_probe)
 
@@ -195,6 +367,9 @@ defmodule SymphonyElixir.WindowsPreflightTest do
       local_shell_run: fn
         hook_probe, _opts when is_binary(hook_probe) ->
           cond do
+            line_ending_command?(hook_probe) ->
+              ready_line_ending_response(hook_probe)
+
             git_main_tracking_command?(hook_probe) ->
               ready_git_main_tracking_response(hook_probe)
 
@@ -236,6 +411,9 @@ defmodule SymphonyElixir.WindowsPreflightTest do
         local_shell_run: fn
           command, _opts when is_binary(command) ->
             cond do
+              line_ending_command?(command) ->
+                ready_line_ending_response(command)
+
               git_main_tracking_command?(command) ->
                 ready_git_main_tracking_response(command)
 
@@ -275,6 +453,9 @@ defmodule SymphonyElixir.WindowsPreflightTest do
         local_shell_run: fn
           command, _opts when is_binary(command) ->
             cond do
+              line_ending_command?(command) ->
+                ready_line_ending_response(command)
+
               git_main_tracking_command?(command) ->
                 ready_git_main_tracking_response(command)
 
@@ -322,6 +503,9 @@ defmodule SymphonyElixir.WindowsPreflightTest do
         local_shell_run: fn
           command, _opts when is_binary(command) ->
             cond do
+              line_ending_command?(command) ->
+                ready_line_ending_response(command)
+
               git_main_tracking_command?(command) ->
                 ready_git_main_tracking_response(command)
 
@@ -355,6 +539,9 @@ defmodule SymphonyElixir.WindowsPreflightTest do
         local_shell_run: fn
           command, _opts when is_binary(command) ->
             cond do
+              line_ending_command?(command) ->
+                ready_line_ending_response(command)
+
               command == "git rev-parse --show-toplevel" ->
                 {:ok, {"C:/repo/symphony-windows-native\n", 0}}
 
@@ -457,6 +644,57 @@ defmodule SymphonyElixir.WindowsPreflightTest do
       String.contains?(command, "rev-parse --verify origin/main") or
       String.contains?(command, "rev-parse --abbrev-ref main@{upstream}") or
       String.contains?(command, "merge-base --is-ancestor main origin/main")
+  end
+
+  defp line_ending_command?(command) do
+    command == "git rev-parse --show-toplevel" or
+      (String.contains?(command, "git -C") and
+         (String.contains?(command, "config --local --get core.autocrlf") or
+            String.contains?(command, "config --get core.autocrlf") or
+            String.contains?(command, "ls-files --eol") or
+            String.contains?(command, "check-attr eol --")))
+  end
+
+  defp ready_line_ending_response(command, opts \\ []) do
+    local_core_autocrlf = Keyword.get(opts, :local_core_autocrlf, Keyword.get(opts, :core_autocrlf, "false"))
+    effective_core_autocrlf = Keyword.get(opts, :effective_core_autocrlf, local_core_autocrlf || "false")
+
+    eol_output =
+      Keyword.get(opts, :eol_output, """
+      i/lf    w/lf    attr/text eol=lf      \t.gitattributes
+      i/lf    w/lf    attr/text eol=lf      \telixir/lib/symphony_elixir/windows_preflight.ex
+      i/lf    w/lf    attr/text eol=lf      \telixir/docs/windows-native.md
+      """)
+
+    attr_output =
+      Keyword.get(opts, :attr_output, """
+      .gitattributes: eol: lf
+      elixir/.formatter.exs: eol: lf
+      elixir/.gitattributes: eol: lf
+      elixir/mix.exs: eol: lf
+      elixir/docs/windows-native.md: eol: lf
+      .github/workflows/make-all.yml: eol: lf
+      """)
+
+    cond do
+      command == "git rev-parse --show-toplevel" ->
+        {:ok, {"C:/repo/symphony-windows-native\n", 0}}
+
+      String.contains?(command, "config --local --get core.autocrlf") ->
+        case local_core_autocrlf do
+          nil -> {:ok, {"", 1}}
+          value -> {:ok, {value <> "\n", 0}}
+        end
+
+      String.contains?(command, "config --get core.autocrlf") ->
+        {:ok, {effective_core_autocrlf <> "\n", 0}}
+
+      String.contains?(command, "ls-files --eol") ->
+        {:ok, {eol_output, 0}}
+
+      String.contains?(command, "check-attr eol --") ->
+        {:ok, {attr_output, 0}}
+    end
   end
 
   defp ready_git_main_tracking_response("git rev-parse --show-toplevel") do


### PR DESCRIPTION
#### Context

GH #28 tracks repeated Windows CRLF formatter friction surfacing too late in broad gates.

#### TL;DR

*Add preflight line-ending evidence before workers hit formatter failures.*

#### Summary

- Add a Git line-ending capability check to Windows preflight.
- Report effective `core.autocrlf`, formatter-managed `w/crlf`, and LF attribute coverage.
- Fail on checked-out CRLF formatter inputs; warn on risky effective `core.autocrlf=true`.
- Keep existing `.gitattributes` and normalized formatter behavior unchanged.

#### Alternatives

- Normalize the whole tree in this PR: rejected because index/worktree are already LF clean.
- Leave this to `mix format.check_normalized`: rejected because preflight should explain the environment.

#### Test Plan

- [ ] `make -C elixir all`
- [x] `mise exec -- mix test test/symphony_elixir/windows_preflight_test.exs test/symphony_elixir/repository_line_endings_test.exs --trace` passed; 15 tests, 0 failures.
- [x] `mise exec -- mix lint` passed; no issues.
- [x] `mise exec -- mix format.check_normalized` passed.
- [x] `mise exec -- mix symphony.preflight.windows --capabilities-only --json D:\desktop\symphony-runtime\WORKFLOW.optimization.windows.no-startup-cleanup.md` passed; Git line endings reported PASS.
- [x] `git diff --check` passed.
- `make -C elixir all` was not run locally for this narrow PR because focused preflight and repository line-ending tests cover the behavior; CI will run the broad gate.

Refs #28