### PR TITLE
ci(test): separate Windows-native test lane

### DIFF
--- a/elixir/Makefile
+++ b/elixir/Makefile
@@ -38,7 +38,7 @@ test:
 	$(MIX) test
 
 windows-native-test:
-	$(MIX) test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs test/symphony_elixir/windows_lifecycle_scripts_test.exs test/symphony_elixir/repository_line_endings_test.exs test/symphony_elixir/ssh_test.exs test/mix/tasks/workspace_before_remove_test.exs test/mix/tasks/pr_body_check_test.exs test/mix/tasks/format_check_normalized_test.exs test/symphony_elixir/specs_check_test.exs
+	$(MIX) test --include windows_native test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs test/symphony_elixir/windows_lifecycle_scripts_test.exs test/symphony_elixir/repository_line_endings_test.exs test/symphony_elixir/ssh_test.exs test/mix/tasks/workspace_before_remove_test.exs test/mix/tasks/pr_body_check_test.exs test/mix/tasks/format_check_normalized_test.exs test/symphony_elixir/specs_check_test.exs
 
 dialyzer:
 	$(MIX) deps.get

--- a/elixir/make.cmd
+++ b/elixir/make.cmd
@@ -74,7 +74,7 @@ exit /b %ERRORLEVEL%
 exit /b %ERRORLEVEL%
 
 :windows_native_test
-"%MIX_CMD%" test test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs test/symphony_elixir/windows_lifecycle_scripts_test.exs test/symphony_elixir/repository_line_endings_test.exs test/symphony_elixir/ssh_test.exs test/mix/tasks/workspace_before_remove_test.exs test/mix/tasks/pr_body_check_test.exs test/mix/tasks/format_check_normalized_test.exs test/symphony_elixir/specs_check_test.exs
+"%MIX_CMD%" test --include windows_native test/symphony_elixir/local_shell_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/windows_preflight_test.exs test/symphony_elixir/windows_lifecycle_scripts_test.exs test/symphony_elixir/repository_line_endings_test.exs test/symphony_elixir/ssh_test.exs test/mix/tasks/workspace_before_remove_test.exs test/mix/tasks/pr_body_check_test.exs test/mix/tasks/format_check_normalized_test.exs test/symphony_elixir/specs_check_test.exs
 exit /b %ERRORLEVEL%
 
 :coverage

--- a/elixir/test/symphony_elixir/test_lane_contract_test.exs
+++ b/elixir/test/symphony_elixir/test_lane_contract_test.exs
@@ -1,0 +1,22 @@
+defmodule SymphonyElixir.TestLaneContractTest do
+  use ExUnit.Case, async: true
+
+  @repo_root Path.expand("../../..", __DIR__)
+
+  test "default test lane excludes true Windows-native tests" do
+    assert File.read!(Path.join(@repo_root, "elixir/test/test_helper.exs")) =~
+             "exclude: [windows_native: true]"
+
+    assert File.read!(Path.join(@repo_root, "elixir/test/symphony_elixir/windows_lifecycle_scripts_test.exs")) =~
+             "@moduletag :windows_native"
+  end
+
+  test "windows-native-test lane opts true Windows-native tests back in" do
+    makefile = File.read!(Path.join(@repo_root, "elixir/Makefile"))
+    make_cmd = File.read!(Path.join(@repo_root, "elixir/make.cmd"))
+
+    assert makefile =~ ~r/windows-native-test:\s*\n\t\$\(MIX\) test --include windows_native .*windows_lifecycle_scripts_test\.exs/
+
+    assert make_cmd =~ ~r/:windows_native_test\s*\r?\n"%MIX_CMD%" test --include windows_native .*windows_lifecycle_scripts_test\.exs/
+  end
+end

--- a/elixir/test/symphony_elixir/windows_lifecycle_scripts_test.exs
+++ b/elixir/test/symphony_elixir/windows_lifecycle_scripts_test.exs
@@ -1,6 +1,8 @@
 defmodule SymphonyElixir.WindowsLifecycleScriptsTest do
   use SymphonyElixir.TestSupport, async: false
 
+  @moduletag :windows_native
+
   defp powershell do
     Enum.find(["pwsh", "powershell"], fn command ->
       System.find_executable(command)

--- a/elixir/test/test_helper.exs
+++ b/elixir/test/test_helper.exs
@@ -1,3 +1,4 @@
 ExUnit.start()
+ExUnit.configure(exclude: [windows_native: true])
 Code.require_file("support/snapshot_support.exs", __DIR__)
 Code.require_file("support/test_support.exs", __DIR__)


### PR DESCRIPTION
#### Context

GH #28 tracks CI friction where platform-specific tests can leak into shared gates.

#### TL;DR

*Keep make-all platform-neutral while Windows CI explicitly runs Windows-native tests.*

#### Summary

- Exclude true Windows-native tests from the default ExUnit lane.
- Mark PowerShell lifecycle script tests as `:windows_native`.
- Include `:windows_native` in `windows-native-test` for Makefile and make.cmd.
- Add a lane contract test covering the default and Windows-native test lanes.

#### Alternatives

- Skip Windows lifecycle tests entirely: rejected because Windows CI should keep real coverage.
- Leave the default lane implicit: rejected because platform boundaries should be encoded.

#### Test Plan

- [ ] `make -C elixir all`
- [x] `mise exec -- mix test test/symphony_elixir/test_lane_contract_test.exs --trace` passed; 2 tests, 0 failures.
- [x] `mise exec -- mix test test/symphony_elixir/windows_lifecycle_scripts_test.exs --trace` passed; 0 tests, 0 failures, 7 excluded.
- [x] `mise exec -- mix test --include windows_native test/symphony_elixir/windows_lifecycle_scripts_test.exs --trace` passed; 7 tests, 0 failures.
- [x] `mise exec -- mix test test/symphony_elixir/extensions_test.exs:550 test/symphony_elixir/extensions_test.exs:564 test/symphony_elixir/extensions_test.exs:599 --trace` passed; 2 tasklist fallback tests, 0 failures.
- [x] `mise exec -- mix format.check_normalized` passed.
- [x] `mise exec -- mix lint` passed; no issues.
- [x] `mise exec -- cmd /c make.cmd windows-native-test` passed; 122 tests, 0 failures, 2 skipped.
- [x] `git diff --check` passed.
- `make -C elixir all` was not run locally because this PR targets lane boundaries; CI will run the broad gate.

Refs #28