### PR TITLE
docs(worker): require capability evidence for blockers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,11 @@ Workpad. Blocking findings keep the issue in `In Progress` or return it to
 - For a true blocker, state what failed, the command/subsystem, recovery status,
   and the next operator action in the Workpad and, when useful for public review,
   the linked GitHub issue or PR.
+- For environment or pipeline blockers, run or cite capability/preflight
+  evidence before handoff. Prefer:
+  `mise exec -- mix symphony.preflight.windows --capabilities-only --json <WORKFLOW>`.
+  The Workpad must include the failed command, capability result, local recovery
+  attempted, and manager action needed.
 - If the blocker is shared pipeline friction, such as CI OS mismatch, GitHub
   auth/rate-limit verification, stale runtime deployment, durable-claim
   confusion, or manager-owned policy scope, do not keep retrying blindly. Record

--- a/elixir/WORKFLOW.optimization.windows.example.md
+++ b/elixir/WORKFLOW.optimization.windows.example.md
@@ -124,7 +124,15 @@ Operating model:
       the next operator's attention.
     - Problem comments must include what failed, the command/subsystem involved, whether recovery
       succeeded, and the next thing an operator should inspect.
-14. If a true blocker prevents completion, update the workpad, then try to move the issue to
+14. For environment or pipeline blockers, include capability/preflight evidence before handoff:
+    - Run or cite `mix symphony.preflight.windows --capabilities-only --json <WORKFLOW>` when the
+      blocker may involve OS, shell, PowerShell, tasklist, GitHub CLI, Linear auth, coverage policy,
+      or line endings.
+    - Write these exact Workpad fields: failed command, capability result, local recovery attempted,
+      and manager action needed.
+    - If a canonical issue exists for the same shared friction, comment there with the new evidence
+      instead of creating a duplicate.
+15. If a true blocker prevents completion, update the workpad, then try to move the issue to
     `Blocked`. If the Linear team has no `Blocked` state, record `Blocked state missing` in the
     workpad/problem comment and keep the issue in its active state unless a manager explicitly moves
     it elsewhere.

--- a/elixir/docs/agent-quality-flywheel.md
+++ b/elixir/docs/agent-quality-flywheel.md
@@ -94,6 +94,13 @@ the issue to `Blocked` when that state exists. If Linear returns `:state_not_fou
 has no `Blocked` state, the agent must record `Blocked state missing` and keep the issue active for
 manager triage.
 
+Environment and pipeline blockers need capability evidence, not repeated blind retries. Before
+handoff, run or cite `mix symphony.preflight.windows --capabilities-only --json <WORKFLOW>` when the
+failure may involve OS, shell, PowerShell, `tasklist`, GitHub CLI, Linear auth, coverage policy, or
+line endings. The Workpad entry must state the failed command, capability result, local recovery
+attempted, and manager action needed. If the blocker matches an existing canonical system issue,
+comment there with the new evidence instead of creating a duplicate.
+
 Human triage for agent-written blocker comments:
 
 - Read the latest `## Codex Workpad` first, then any separate problem comment.

--- a/elixir/docs/manager-agent-runbook.md
+++ b/elixir/docs/manager-agent-runbook.md
@@ -65,6 +65,11 @@ handoff is:
 1. Update the single `## Codex Workpad` with the exact failure, command or
    subsystem, affected PR/check/log, local recovery attempted, and the next
    operator action needed.
+   For environment or pipeline blockers, the Workpad should also include
+   capability/preflight evidence from
+   `mix symphony.preflight.windows --capabilities-only --json <WORKFLOW>` or a
+   manager-approved equivalent. The minimum fields are failed command,
+   capability result, local recovery attempted, and manager action needed.
 2. Add a short Linear comment only when the Workpad is not enough to make the
    blocker visible to a manager scanning the board.
 3. Move the issue to `Blocked` when that state exists, then release any durable
@@ -81,6 +86,10 @@ Good blocker reports are small and concrete. They name the failed command or
 API, include the PR/check URL when available, distinguish local pass from CI
 failure, and say whether the current worker can continue after an operator
 action. Vague reports such as "GitHub failed" or "CI flaky" are not enough.
+Reports for shared environment friction should cite the relevant capability
+result, such as missing `tasklist`, unauthenticated `gh`, unavailable Linear
+viewer probe, risky `core.autocrlf`, CRLF formatter inputs, or coverage policy
+evidence.
 
 ## Main loop
 

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -1473,6 +1473,26 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     end
   end
 
+  test "optimization Windows workflow prompt requires capability evidence for blockers" do
+    path = Path.expand(Path.join([__DIR__, "..", "..", "WORKFLOW.optimization.windows.example.md"]))
+
+    assert {:ok, workflow} = Workflow.load(path)
+    assert {:ok, settings} = Schema.parse(workflow.config)
+    assert settings.tracker.dispatch_states == ["Todo"]
+    assert settings.codex.review_readiness_required_checks == ["make-all", "validate-pr-description", "windows-native-test"]
+
+    assert workflow.prompt =~ "## Codex Workpad"
+    assert workflow.prompt =~ "capability/preflight evidence"
+    assert workflow.prompt =~ "Run or cite"
+    assert workflow.prompt =~ "mix symphony.preflight.windows --capabilities-only --json"
+    assert workflow.prompt =~ "failed command"
+    assert workflow.prompt =~ "capability result"
+    assert workflow.prompt =~ "local recovery attempted"
+    assert workflow.prompt =~ "manager action needed"
+    assert workflow.prompt =~ "canonical issue exists"
+    assert workflow.prompt =~ "If a true blocker prevents completion"
+  end
+
   test "workflow prompt is used when building base prompt" do
     workflow_prompt = "Workflow prompt body used as codex instruction."
 


### PR DESCRIPTION
#### Context

GH #28 tracks repeated worker friction where blockers lacked capability evidence for manager handoff.

#### TL;DR

*Require capability evidence in worker blocker handoffs.*

#### Summary

- Update the optimization workflow prompt with capability/preflight blocker evidence rules.
- Require Workpad fields for failed command, capability result, recovery attempted, and manager action.
- Mirror the protocol in AGENTS, the quality policy, and the manager runbook.
- Add a workflow example parse test asserting the optimization prompt includes the protocol.

#### Alternatives

- Leave this as manager-only tribal knowledge: rejected because every worker run needs the protocol.
- Require full preflight for every failure: rejected because workers may cite existing equivalent evidence.

#### Test Plan

- [ ] `make -C elixir all`
- [x] `mise exec -- mix test test/symphony_elixir/workspace_and_config_test.exs:1477 --trace` passed; 1 test, 0 failures.
- [x] `mise exec -- mix format.check_normalized` passed.
- [x] `git diff --check` passed.
- `make -C elixir all` was not run locally because this PR changes docs/workflow prompt text with one focused parse test; CI will run the broad gate.

Refs #28