### PR TITLE
Group dashboard rate-limit fields

### DIFF
--- a/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
@@ -404,28 +404,41 @@ defmodule SymphonyElixirWeb.DashboardLive do
                 <div class="rate-limit-main">
                   <div>
                     <p class="rate-limit-name"><%= limit.label %></p>
-                    <p class="rate-limit-detail">
-                      <%= limit.window %>
-                      <%= if limit.reset do %>
-                        · <%= limit.reset %>
-                      <% end %>
-                    </p>
+                    <p class="rate-limit-detail"><%= limit.status %></p>
                   </div>
                   <span class={limit.badge_class}><%= limit.used_label %></span>
                 </div>
+                <dl class="rate-limit-fields">
+                  <div>
+                    <dt>Window</dt>
+                    <dd><%= limit.window %></dd>
+                  </div>
+                  <div>
+                    <dt>Reset countdown</dt>
+                    <dd><%= limit.reset || "n/a" %></dd>
+                  </div>
+                  <div>
+                    <dt>Used</dt>
+                    <dd><%= limit.used_label %></dd>
+                  </div>
+                  <div>
+                    <dt>Reset time</dt>
+                    <dd>
+                      <%= if limit.reset_absolute do %>
+                        <time
+                          id={limit.reset_id}
+                          phx-hook="LocalTime"
+                          datetime={limit.reset_absolute.iso}
+                        ><%= limit.reset_absolute.fallback %></time>
+                      <% else %>
+                        n/a
+                      <% end %>
+                    </dd>
+                  </div>
+                </dl>
                 <div class="rate-limit-bar" aria-label={limit.progress_label}>
                   <span class={limit.bar_class} style={"width: #{limit.progress_width}%"}></span>
                 </div>
-                <%= if limit.reset_absolute do %>
-                  <p class="rate-limit-absolute">
-                    Reset at
-                    <time
-                      id={limit.reset_id}
-                      phx-hook="LocalTime"
-                      datetime={limit.reset_absolute.iso}
-                    ><%= limit.reset_absolute.fallback %></time>
-                  </p>
-                <% end %>
               </article>
             </div>
 
@@ -830,6 +843,7 @@ defmodule SymphonyElixirWeb.DashboardLive do
       badge_class: rate_limit_badge_class(used_percent),
       bar_class: rate_limit_bar_class(used_percent),
       tone_class: rate_limit_tone_class(label),
+      status: rate_limit_status(used_percent),
       window: window_label(field_value(bucket, [:window_duration_mins, :windowDurationMins, "window_duration_mins", "windowDurationMins"])),
       reset: reset_relative(reset_at, now),
       reset_absolute: reset_absolute(reset_at)
@@ -846,6 +860,7 @@ defmodule SymphonyElixirWeb.DashboardLive do
       badge_class: "rate-limit-badge",
       bar_class: "rate-limit-bar-fill",
       tone_class: rate_limit_tone_class(label),
+      status: "Snapshot unavailable",
       window: "window n/a",
       reset: nil,
       reset_absolute: nil
@@ -903,6 +918,11 @@ defmodule SymphonyElixirWeb.DashboardLive do
   defp rate_limit_bar_class(_value), do: "rate-limit-bar-fill"
 
   defp rate_limit_tone_class(label), do: "rate-limit-row-#{String.downcase(label)}"
+
+  defp rate_limit_status(value) when is_integer(value) and value >= 90, do: "Critical usage"
+  defp rate_limit_status(value) when is_integer(value) and value >= 70, do: "Elevated usage"
+  defp rate_limit_status(value) when is_integer(value), do: "Operational"
+  defp rate_limit_status(_value), do: "Usage unavailable"
 
   defp window_label(minutes) when is_integer(minutes), do: "#{duration_label(minutes)} window"
   defp window_label(minutes) when is_float(minutes), do: "#{duration_label(round(minutes))} window"

--- a/elixir/priv/static/dashboard.css
+++ b/elixir/priv/static/dashboard.css
@@ -448,10 +448,10 @@ pre,
 .rate-limit-row {
   display: grid;
   gap: 0.8rem;
-  min-height: 11rem;
+  min-height: 14rem;
   padding: 1rem;
   border: 1px solid var(--line);
-  border-radius: 18px;
+  border-radius: 8px;
   background: white;
   box-shadow: var(--shadow-sm);
 }
@@ -481,10 +481,38 @@ pre,
 }
 
 .rate-limit-detail,
-.rate-limit-absolute {
+.rate-limit-fields dd {
   margin: 0.22rem 0 0;
   color: var(--muted);
   font-size: 0.88rem;
+}
+
+.rate-limit-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin: 0;
+}
+
+.rate-limit-fields div {
+  min-width: 0;
+  padding: 0.62rem 0.7rem;
+  border: 1px solid rgba(217, 217, 227, 0.85);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.rate-limit-fields dt {
+  margin: 0;
+  color: #5f6368;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.rate-limit-fields dd {
+  overflow-wrap: anywhere;
+  font-weight: 700;
 }
 
 .rate-limit-badge {
@@ -538,6 +566,12 @@ pre,
 
 .rate-limit-debug {
   margin-top: 0.85rem;
+}
+
+@media (max-width: 560px) {
+  .rate-limit-fields {
+    grid-template-columns: 1fr;
+  }
 }
 
 .worker-detail-workspace {

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -2005,13 +2005,20 @@ defmodule SymphonyElixir.ExtensionsTest do
     {:ok, _view, html} = live(build_conn(), "/")
     assert html =~ "Latest upstream rate-limit snapshot for codex · prolite."
     assert html =~ "Primary"
+    assert html =~ "Operational"
     assert html =~ "57% used"
+    assert html =~ "Window"
     assert html =~ "5h window"
+    assert html =~ "Reset time"
     assert html =~ "2099-05-02 07:05:00 UTC"
     assert html =~ "Secondary"
+    assert html =~ "Critical usage"
     assert html =~ "92% used"
     assert html =~ "7d window"
+    assert html =~ "Reset countdown"
     assert html =~ "resets in 4m 10s"
+    assert html =~ "<details"
+    refute html =~ ~s(<details class="raw-details rate-limit-debug" open>)
     assert html =~ "Raw rate-limit payload"
   end
 
@@ -2037,10 +2044,13 @@ defmodule SymphonyElixir.ExtensionsTest do
     {:ok, _view, html} = live(build_conn(), "/")
     assert html =~ "Latest upstream rate-limit snapshot for codex-lite."
     assert html =~ "Primary"
+    assert html =~ "Operational"
     assert html =~ "40% used"
     assert html =~ "window n/a"
     assert html =~ "Secondary"
+    assert html =~ "Usage unavailable"
     assert html =~ "n/a"
+    assert html =~ "Reset time"
     assert html =~ "2099-05-02 08:10:00 UTC"
     assert html =~ "Raw rate-limit payload"
     refute html =~ "Latest upstream rate-limit snapshot, when available."


### PR DESCRIPTION
#### Context

Operators need the dashboard rate-limit card to separate primary and secondary quota windows for faster scanning.

#### TL;DR

*Group rate-limit quota fields into compact, labeled dashboard sections.*

#### Summary

- Render primary and secondary quota windows with labeled fields for key operator data.
- Keep raw rate-limit JSON in the existing collapsed debug disclosure.
- Add focused LiveView assertions for grouped fields and unavailable states.

#### Alternatives

- Kept the existing data extraction path unchanged to avoid altering rate-limit semantics.
- Avoided a new component because the dashboard renderer already owns this small card.

#### Test Plan

- [ ] `make -C elixir all` not completed locally because unrelated Windows terminal output capture tests fail; details below.
- [x] `mix test test/symphony_elixir/extensions_test.exs:1977 test/symphony_elixir/extensions_test.exs:2024 test/symphony_elixir/extensions_test.exs:2059` - passed.
- [x] `mix format.check_normalized` - passed.
- [x] `git diff --check` - passed.
- [x] SubAgent review - no blocking findings; one non-blocking assertion concern fixed.

`make -C elixir all` was attempted from the repo root and failed in unrelated terminal offline marker tests:
`test/symphony_elixir/orchestrator_status_test.exs:1731` and `:2338` both captured empty output while expecting `app_status=offline`.
The failures reproduce with `mix test test/symphony_elixir/orchestrator_status_test.exs:1731 test/symphony_elixir/orchestrator_status_test.exs:2338`.
Capability preflight passed with `mise exec -- mix symphony.preflight.windows --capabilities-only --json .\WORKFLOW.md`; only `core.autocrlf=true` was reported as a warning.
