### PR TITLE
docs(manager): clarify orchestration handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,9 @@ mise exec -- mix symphony.preflight.windows .\WORKFLOW.optimization.windows.md
 - Use exactly one Linear comment whose first line is `## Codex Workpad`; update
   it instead of creating progress spam.
 - Use the linked GitHub issue as the public implementation spec.
+- Do not accept or continue work labeled `manager-owned`, or whose Workpad says
+  `Manager classification: manager-owned`, unless the manager has decomposed a
+  narrow worker-safe subtask for you.
 - Open the PR against `main`, link it in the Workpad, and wait for required
   GitHub checks before moving Linear to `In Review`.
 - If checks are pending, failing, or unverifiable, record the exact reason in the
@@ -124,3 +127,7 @@ Workpad. Blocking findings keep the issue in `In Progress` or return it to
   tests to reach mechanical perfection.
 - Path and environment handling must preserve Windows drive paths, forward-slash
   compatibility, `$VAR` workflow expansion rules, and secret redaction.
+- The human worker page and `GET /api/v1/<issue>` expose a processed
+  `conversation` projection for agent messages. Raw timeline/debug endpoints are
+  diagnostic surfaces and may include system warnings, streaming deltas, and
+  other low-level events.

--- a/elixir/docs/manager-agent-runbook.md
+++ b/elixir/docs/manager-agent-runbook.md
@@ -32,6 +32,30 @@ system defects into durable issues.
   auth, rate-limit, deployment, or queue-control failure, stop feeding that wall
   and fix the shared path.
 
+## Quick start on a fresh machine
+
+Before releasing work, establish the current truth across all three control
+planes:
+
+1. Open the dashboard and confirm active workers, token/rate-limit status,
+   runtime commit, PID file, and workflow path.
+2. Check GitHub open PRs, required checks, and recently updated optimization
+   issues.
+3. Check Linear states for the optimization project across `Backlog`, `Todo`,
+   `In Progress`, `In Review`, `Blocked`, and terminal states.
+4. Confirm the running runtime commit matches `origin/main` after any recently
+   merged system PR. If not, rebuild and restart before launching more work.
+5. Review completed or `In Review` work before releasing another issue.
+6. Inspect `Blocked` work to root cause. Do not let new workers rediscover a
+   shared blocker.
+7. Only then choose the next Backlog issue, complete its spec/testing/acceptance,
+   classify it as worker-safe or manager-owned, and move it to `Todo`.
+
+The useful default rhythm is review, triage, release, wait, then repeat. Worker
+runs often take 10 to 20 minutes; the manager should use that time to review
+finished work or root-cause shared friction instead of launching speculative
+issues.
+
 ## Manager-owned work
 
 Some issues should stay with the manager instead of being released to an
@@ -50,11 +74,22 @@ Examples:
   old code.
 - Changing manager automation, concurrency policy, release criteria, or review
   policy.
+- Designing risk-tiered worker profiles, validation policy, or other rules that
+  change how future issues are released to workers.
 
 Workers are a good fit for bounded implementation tasks with a complete public
 spec, test intent, acceptance criteria, and no need to decide cross-system
 policy. If a manager-owned issue can be decomposed, create narrower worker-safe
 subtasks and keep the policy decision in the manager Workpad.
+
+Mark manager-owned work explicitly so it is not released accidentally:
+
+- Add the GitHub label `manager-owned` when it exists.
+- Record `Manager classification: manager-owned` in the Linear `## Codex
+  Workpad`.
+- Keep the issue in `Backlog` until a manager handles it or creates narrower
+  worker-safe subtasks.
+- Do not move manager-owned issues to `Todo` merely to keep concurrency high.
 
 ## Worker blocker handoff
 
@@ -103,6 +138,11 @@ Run this loop until the operator deliberately pauses the flywheel.
      `Blocked`, and terminal states.
    - Check runtime logs, PID files, workflow config, and the deployed commit
      when the runtime may be stale.
+   - For worker detail pages, use the processed conversation surface for normal
+     reading. `GET /api/v1/<issue>` and the `/workers/<issue>` page use the
+     `conversation` projection, which filters streaming deltas and system
+     warnings into completed agent messages. Use
+     `/api/v1/workers/<issue>/timeline` or debug events only for diagnosis.
 2. Review completed work first.
    - Read the original human request, the GitHub issue, the Linear Workpad, the
      PR diff, CI results, and review evidence.


### PR DESCRIPTION
#### Context

The current runtime is deployed and open-source main is up to date, but the manager/worker docs needed two small handoff clarifications from the latest flywheel run.

#### TL;DR

*Clarify manager startup, manager-owned issue handling, and processed worker conversation surfaces.*

#### Summary

- Add a fresh-machine manager quick-start checklist to the manager runbook.
- Document the explicit `manager-owned` classification convention.
- Clarify that normal worker reading should use the processed `conversation` projection, while timeline/debug endpoints are diagnostic surfaces.
- Warn workers not to continue issues labeled or marked manager-owned unless decomposed by a manager.

#### Alternatives

- Left risk-tiered worker profiles as GH #112 / ALB-65 rather than encoding that policy fully in docs before the design is agreed.
- Did not change runtime code or workflow prompts in this docs-only update.

#### Test Plan

- [x] `git diff --check`
