### PR TITLE
Project worker PR and conversation status

### DIFF
--- a/elixir/lib/symphony_elixir_web/controllers/observability_api_controller.ex
+++ b/elixir/lib/symphony_elixir_web/controllers/observability_api_controller.ex
@@ -46,6 +46,23 @@ defmodule SymphonyElixirWeb.ObservabilityApiController do
     end
   end
 
+  @spec worker_conversation(Conn.t(), map()) :: Conn.t()
+  def worker_conversation(conn, %{"issue_identifier" => issue_identifier}) do
+    case Presenter.conversation_payload(issue_identifier, orchestrator(), snapshot_timeout_ms()) do
+      {:ok, payload} ->
+        json(conn, %{
+          issue_identifier: issue_identifier,
+          status: payload.status,
+          source: "conversation",
+          session: payload.session,
+          items: payload.items
+        })
+
+      {:error, :issue_not_found} ->
+        error_response(conn, 404, "worker_not_found", "Worker not found")
+    end
+  end
+
   @spec worker_diff(Conn.t(), map()) :: Conn.t()
   def worker_diff(conn, %{"issue_identifier" => issue_identifier} = params) do
     case WorkerApi.diff_payload(issue_identifier, params, orchestrator(), snapshot_timeout_ms()) do

--- a/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
@@ -170,8 +170,17 @@ defmodule SymphonyElixirWeb.DashboardLive do
               </div>
               <div class="sidebar-section">
                 <p class="metric-label">Branch / Checks</p>
-                <p class="metric-value detail-path"><%= detail.retry && detail.retry.branch_name || "n/a" %></p>
-                <p class="metric-detail"><%= if detail.url, do: detail.url, else: "PR and checks unavailable" %></p>
+                <p class="metric-value detail-path"><%= detail.workspace.branch || "branch unknown" %></p>
+                <p class="metric-detail">
+                  <%= cond do %>
+                    <% detail.pull_request && detail.checks -> %>
+                      <%= detail.pull_request.url %> · checks <%= detail.checks.summary %>
+                    <% detail.pull_request -> %>
+                      <%= detail.pull_request.url %> · checks unknown
+                    <% true -> %>
+                      PR/checks unavailable
+                  <% end %>
+                </p>
               </div>
               <details class="debug-drawer">
                 <summary>Worker debug payload</summary>

--- a/elixir/lib/symphony_elixir_web/presenter.ex
+++ b/elixir/lib/symphony_elixir_web/presenter.ex
@@ -3,7 +3,8 @@ defmodule SymphonyElixirWeb.Presenter do
   Shared projections for the observability API and dashboard.
   """
 
-  alias SymphonyElixir.{Config, Deployment.Reload, Orchestrator, Redactor, RuntimeInfo, StatusDashboard}
+  alias SymphonyElixir.{Deployment.Reload, Orchestrator, Redactor, RuntimeInfo, StatusDashboard}
+  alias SymphonyElixirWeb.WorkerApi
 
   @conversation_display_limit 120
   @conversation_event_scan_limit 400
@@ -57,6 +58,30 @@ defmodule SymphonyElixirWeb.Presenter do
           {:error, :issue_not_found}
         else
           {:ok, issue_payload_body(issue_identifier, running, retry)}
+        end
+
+      _ ->
+        {:error, :issue_not_found}
+    end
+  end
+
+  @spec conversation_payload(String.t(), GenServer.name(), timeout()) :: {:ok, map()} | {:error, :issue_not_found}
+  def conversation_payload(issue_identifier, orchestrator, snapshot_timeout_ms) when is_binary(issue_identifier) do
+    case Orchestrator.snapshot(orchestrator, snapshot_timeout_ms) do
+      %{} = snapshot ->
+        running = Enum.find(snapshot.running, &(&1.identifier == issue_identifier))
+        retry = Enum.find(snapshot.retrying, &(&1.identifier == issue_identifier))
+
+        if is_nil(running) and is_nil(retry) do
+          {:error, :issue_not_found}
+        else
+          {:ok,
+           %{
+             issue_identifier: issue_identifier,
+             status: issue_status(running, retry),
+             session: optional_conversation_session(running),
+             items: optional_conversation(running)
+           }}
         end
 
       _ ->
@@ -123,16 +148,17 @@ defmodule SymphonyElixirWeb.Presenter do
   end
 
   defp issue_payload_body(issue_identifier, running, retry) do
+    metadata = WorkerApi.worker_metadata(issue_identifier, running, retry)
+
     %{
       issue_identifier: issue_identifier,
       issue_id: issue_id_from_entries(running, retry),
       title: issue_title(running),
       url: issue_url(running),
       status: issue_status(running, retry),
-      workspace: %{
-        path: workspace_path(issue_identifier, running, retry),
-        host: workspace_host(running, retry)
-      },
+      workspace: metadata.workspace,
+      pull_request: metadata.pull_request,
+      checks: metadata.checks,
       attempts: %{
         restart_count: restart_count(retry),
         current_retry_attempt: retry_attempt(retry)
@@ -185,6 +211,17 @@ defmodule SymphonyElixirWeb.Presenter do
       [_ | _] = messages -> messages
       _ -> Map.get(running, :recent_codex_events, [])
     end
+  end
+
+  defp optional_conversation_session(nil), do: nil
+
+  defp optional_conversation_session(running) do
+    %{
+      session_id: running.session_id,
+      thread_id: running.thread_id,
+      turn_id: running.turn_id,
+      turn_count: running.turn_count
+    }
   end
 
   defp retry_error(nil), do: nil
@@ -274,16 +311,6 @@ defmodule SymphonyElixirWeb.Presenter do
       workspace_path: Map.get(retry, :workspace_path),
       branch_name: Map.get(retry, :branch_name)
     }
-  end
-
-  defp workspace_path(issue_identifier, running, retry) do
-    (running && Map.get(running, :workspace_path)) ||
-      (retry && Map.get(retry, :workspace_path)) ||
-      Path.join(Config.settings!().workspace.root, issue_identifier)
-  end
-
-  defp workspace_host(running, retry) do
-    (running && Map.get(running, :worker_host)) || (retry && Map.get(retry, :worker_host))
   end
 
   defp recent_events_payload(running) do

--- a/elixir/lib/symphony_elixir_web/router.ex
+++ b/elixir/lib/symphony_elixir_web/router.ex
@@ -41,6 +41,8 @@ defmodule SymphonyElixirWeb.Router do
     match(:*, "/api/v1/runtime/reload", ObservabilityApiController, :method_not_allowed)
     get("/api/v1/workers/:issue_identifier/status", ObservabilityApiController, :worker_status)
     match(:*, "/api/v1/workers/:issue_identifier/status", ObservabilityApiController, :method_not_allowed)
+    get("/api/v1/workers/:issue_identifier/conversation", ObservabilityApiController, :worker_conversation)
+    match(:*, "/api/v1/workers/:issue_identifier/conversation", ObservabilityApiController, :method_not_allowed)
     get("/api/v1/workers/:issue_identifier/timeline", ObservabilityApiController, :worker_timeline)
     match(:*, "/api/v1/workers/:issue_identifier/timeline", ObservabilityApiController, :method_not_allowed)
     get("/api/v1/workers/:issue_identifier/diff", ObservabilityApiController, :worker_diff)

--- a/elixir/lib/symphony_elixir_web/worker_api.ex
+++ b/elixir/lib/symphony_elixir_web/worker_api.ex
@@ -15,6 +15,7 @@ defmodule SymphonyElixirWeb.WorkerApi do
   @debug_string_bytes 4_000
   @default_patch_bytes 65_536
   @max_patch_bytes 1_048_576
+  @default_pr_lookup_timeout_ms 1_500
 
   @spec status_payload(String.t(), GenServer.name(), timeout()) ::
           {:ok, map()} | {:error, :worker_not_found}
@@ -22,6 +23,18 @@ defmodule SymphonyElixirWeb.WorkerApi do
     with {:ok, _snapshot, running, retry} <- worker_entries(issue_identifier, orchestrator, snapshot_timeout_ms) do
       {:ok, status_body(issue_identifier, running, retry)}
     end
+  end
+
+  @spec worker_metadata(String.t(), map() | nil, map() | nil) :: map()
+  def worker_metadata(issue_identifier, running, retry) do
+    workspace = workspace_summary(issue_identifier, running, retry)
+    pull_request = pull_request_summary(running, retry, workspace)
+
+    %{
+      workspace: workspace,
+      pull_request: pull_request_without_checks(pull_request),
+      checks: checks_summary(pull_request)
+    }
   end
 
   @spec timeline_payload(String.t(), map(), GenServer.name(), timeout()) ::
@@ -110,13 +123,15 @@ defmodule SymphonyElixirWeb.WorkerApi do
   end
 
   defp status_body(issue_identifier, running, retry) do
+    metadata = worker_metadata(issue_identifier, running, retry)
+
     %{
       issue: issue_summary(issue_identifier, running, retry),
       status: worker_status(running, retry),
       session: session_summary(running, retry),
-      workspace: workspace_summary(issue_identifier, running, retry),
-      pull_request: nil,
-      checks: nil,
+      workspace: metadata.workspace,
+      pull_request: metadata.pull_request,
+      checks: metadata.checks,
       rate_limits: rate_limit_summary(running),
       tokens: token_summary(running),
       command_watchdog: command_watchdog_payload(Map.get(running || %{}, :command_watchdog)),
@@ -145,11 +160,177 @@ defmodule SymphonyElixirWeb.WorkerApi do
   end
 
   defp workspace_summary(issue_identifier, running, retry) do
+    path = workspace_path(issue_identifier, running, retry)
+
     %{
-      path: workspace_path(issue_identifier, running, retry),
+      path: path,
       host: entry_value(running, retry, :worker_host),
-      branch: entry_value(running, retry, :branch_name)
+      branch: entry_value(running, retry, :branch_name) || workspace_branch(path)
     }
+  end
+
+  defp pull_request_summary(running, retry, workspace) do
+    explicit =
+      entry_value(running, retry, :pull_request) ||
+        entry_value(running, retry, :pull_request_url)
+
+    case normalize_pull_request(explicit) do
+      nil -> discover_pull_request(workspace)
+      pull_request -> pull_request
+    end
+  end
+
+  defp discover_pull_request(%{path: workspace_path, branch: branch})
+       when is_binary(workspace_path) and is_binary(branch) and branch != "" do
+    if File.dir?(workspace_path) do
+      case safe_pr_lookup(workspace_path, branch) do
+        {:ok, pull_request} -> normalize_pull_request(pull_request)
+        _ -> nil
+      end
+    end
+  end
+
+  defp discover_pull_request(_workspace), do: nil
+
+  defp pull_request_without_checks(nil), do: nil
+
+  defp pull_request_without_checks(pull_request) do
+    pull_request
+    |> Map.take([:number, :url, :state, :head_ref, :head_sha])
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+
+  defp checks_summary(nil), do: nil
+
+  defp checks_summary(pull_request) do
+    items = Map.get(pull_request, :checks, []) |> Enum.map(&check_item/1) |> Enum.reject(&is_nil/1)
+    if items == [], do: nil, else: %{summary: checks_state(items), items: items}
+  end
+
+  defp checks_state(items) do
+    cond do
+      Enum.any?(items, &(String.downcase(to_string(&1.status || "")) not in ["completed", "success"])) ->
+        "pending"
+
+      Enum.any?(items, &(String.downcase(to_string(&1.conclusion || "")) not in ["success", "neutral", "skipped"])) ->
+        "failing"
+
+      true ->
+        "passing"
+    end
+  end
+
+  defp normalize_pull_request(nil), do: nil
+
+  defp normalize_pull_request(url) when is_binary(url) do
+    %{url: Redactor.redact(url), checks: []}
+  end
+
+  defp normalize_pull_request(pull_request) when is_map(pull_request) do
+    checks =
+      value(pull_request, :checks) ||
+        value(pull_request, :status_check_rollup) ||
+        value(pull_request, :statusCheckRollup) ||
+        []
+
+    %{
+      number: value(pull_request, :number),
+      url: Redactor.redact(value(pull_request, :url)),
+      state: value(pull_request, :state),
+      head_ref: value(pull_request, :head_ref) || value(pull_request, :headRefName),
+      head_sha: value(pull_request, :head_sha) || value(pull_request, :headRefOid),
+      checks: checks
+    }
+  end
+
+  defp normalize_pull_request(_pull_request), do: nil
+
+  defp check_item(check) when is_map(check) do
+    state = value(check, :state)
+
+    %{
+      name: value(check, :name) || value(check, :context),
+      status: value(check, :status) || status_context_status(state),
+      conclusion: blank_to_nil(value(check, :conclusion) || status_context_conclusion(state)),
+      details_url: Redactor.redact(value(check, :details_url) || value(check, :detailsUrl) || value(check, :targetUrl))
+    }
+  end
+
+  defp check_item(_check), do: nil
+
+  defp workspace_branch(path) when is_binary(path) do
+    if File.dir?(path) do
+      case git_output(path, ["branch", "--show-current"]) do
+        {:ok, output} ->
+          output |> String.trim() |> blank_to_nil()
+
+        _ ->
+          nil
+      end
+    end
+  end
+
+  defp workspace_branch(_path), do: nil
+
+  defp pr_lookup_fun do
+    Application.get_env(:symphony_elixir, :worker_api_pr_lookup, &default_pr_lookup/2)
+  end
+
+  defp pr_lookup_timeout_ms do
+    Application.get_env(:symphony_elixir, :worker_api_pr_lookup_timeout_ms, @default_pr_lookup_timeout_ms)
+  end
+
+  defp safe_pr_lookup(workspace_path, branch) do
+    task =
+      Task.async(fn ->
+        try do
+          pr_lookup_fun().(workspace_path, branch)
+        rescue
+          _ -> {:error, :pull_request_unavailable}
+        catch
+          :exit, _ -> {:error, :pull_request_unavailable}
+          _kind, _reason -> {:error, :pull_request_unavailable}
+        end
+      end)
+
+    case Task.yield(task, pr_lookup_timeout_ms()) || Task.shutdown(task, :brutal_kill) do
+      {:ok, result} -> result
+      _ -> {:error, :pull_request_unavailable}
+    end
+  end
+
+  defp default_pr_lookup(workspace_path, branch) do
+    args = ["pr", "view", branch, "--json", "number,url,state,headRefName,headRefOid,statusCheckRollup"]
+
+    case System.cmd("gh", args, cd: workspace_path, stderr_to_stdout: true) do
+      {output, 0} ->
+        output
+        |> Redactor.redact()
+        |> Jason.decode()
+
+      _ ->
+        {:error, :pull_request_unavailable}
+    end
+  end
+
+  defp status_context_status(state) do
+    case String.downcase(to_string(state || "")) do
+      value when value in ["success", "failure", "error", "neutral", "skipped"] -> "COMPLETED"
+      value when value in ["pending", "expected"] -> "PENDING"
+      _ -> nil
+    end
+  end
+
+  defp status_context_conclusion(state) do
+    case String.downcase(to_string(state || "")) do
+      "success" -> "SUCCESS"
+      "failure" -> "FAILURE"
+      "error" -> "FAILURE"
+      "neutral" -> "NEUTRAL"
+      "skipped" -> "SKIPPED"
+      _ -> nil
+    end
   end
 
   defp rate_limit_summary(running) do
@@ -577,6 +758,19 @@ defmodule SymphonyElixirWeb.WorkerApi do
   end
 
   defp entry_value(running, retry, key), do: Map.get(running || %{}, key) || Map.get(retry || %{}, key)
+
+  defp value(map, key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  defp blank_to_nil(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp blank_to_nil(value), do: value
 
   defp retry_payload(nil), do: nil
 

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -1156,8 +1156,11 @@ defmodule SymphonyElixir.ExtensionsTest do
              "status" => "running",
              "workspace" => %{
                "path" => Path.join(Config.settings!().workspace.root, "MT-HTTP"),
-               "host" => nil
+               "host" => nil,
+               "branch" => nil
              },
+             "pull_request" => nil,
+             "checks" => nil,
              "attempts" => %{"restart_count" => 0, "current_retry_attempt" => 0},
              "running" => %{
                "worker_host" => nil,
@@ -1436,6 +1439,371 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert debug_payload["debug_only"] == true
     assert debug_payload["limit"] == 1
     refute inspect(debug_payload) =~ "sk-live-secret"
+  end
+
+  test "agent worker status and detail APIs project branch pull request and checks" do
+    orchestrator_name = Module.concat(__MODULE__, :WorkerPrProjectionOrchestrator)
+
+    pr_projection = %{
+      number: 110,
+      url: "https://github.com/albert-zen/symphony-windows-native/pull/110",
+      state: "OPEN",
+      head_ref: "codex/ALB-63-rate-limit-card",
+      head_sha: "03b64e1a85f678d000af4904e8fed084013efece",
+      checks: [
+        %{name: "make-all", status: "COMPLETED", conclusion: "SUCCESS"},
+        %{name: "windows-native-test", status: "IN_PROGRESS", conclusion: nil}
+      ]
+    }
+
+    snapshot =
+      worker_api_snapshot(%{
+        branch_name: "codex/ALB-63-rate-limit-card",
+        pull_request: pr_projection
+      })
+
+    {:ok, _pid} = StaticOrchestrator.start_link(name: orchestrator_name, snapshot: snapshot)
+
+    start_test_endpoint(orchestrator: orchestrator_name, snapshot_timeout_ms: 50)
+
+    status_payload = json_response(get(build_conn(), "/api/v1/workers/MT-API/status"), 200)
+
+    assert status_payload["workspace"]["branch"] == "codex/ALB-63-rate-limit-card"
+
+    assert status_payload["pull_request"] == %{
+             "number" => 110,
+             "url" => "https://github.com/albert-zen/symphony-windows-native/pull/110",
+             "state" => "OPEN",
+             "head_ref" => "codex/ALB-63-rate-limit-card",
+             "head_sha" => "03b64e1a85f678d000af4904e8fed084013efece"
+           }
+
+    assert status_payload["checks"] == %{
+             "summary" => "pending",
+             "items" => [
+               %{"name" => "make-all", "status" => "COMPLETED", "conclusion" => "SUCCESS", "details_url" => nil},
+               %{"name" => "windows-native-test", "status" => "IN_PROGRESS", "conclusion" => nil, "details_url" => nil}
+             ]
+           }
+
+    detail_payload = json_response(get(build_conn(), "/api/v1/MT-API"), 200)
+    assert detail_payload["workspace"]["branch"] == "codex/ALB-63-rate-limit-card"
+    assert detail_payload["pull_request"]["number"] == 110
+    assert detail_payload["checks"]["summary"] == "pending"
+
+    {:ok, _view, html} = live(build_conn(), "/workers/MT-API")
+    assert html =~ "codex/ALB-63-rate-limit-card"
+    assert html =~ "https://github.com/albert-zen/symphony-windows-native/pull/110"
+    assert html =~ "pending"
+  end
+
+  test "agent worker status discovers branch and PR checks from workspace git and authenticated lookup" do
+    workspace_root = Config.settings!().workspace.root
+    workspace_path = Path.join(workspace_root, "MT-API-PR-#{System.unique_integer([:positive])}")
+    branch = "codex/alb-66-worker-observability"
+    test_pid = self()
+
+    File.rm_rf!(workspace_path)
+    File.mkdir_p!(workspace_path)
+    {_, 0} = System.cmd("git", ["init"], cd: workspace_path, stderr_to_stdout: true)
+    {_, 0} = System.cmd("git", ["checkout", "-b", branch], cd: workspace_path, stderr_to_stdout: true)
+
+    previous_lookup = Application.get_env(:symphony_elixir, :worker_api_pr_lookup)
+
+    Application.put_env(:symphony_elixir, :worker_api_pr_lookup, fn ^workspace_path, ^branch ->
+      send(test_pid, {:worker_pr_lookup, workspace_path, branch})
+
+      {:ok,
+       %{
+         "number" => 115,
+         "url" => "https://github.com/albert-zen/symphony-windows-native/pull/115",
+         "state" => "OPEN",
+         "headRefName" => branch,
+         "headRefOid" => "c39bc199cfc4efc6bb9edd258acecb2bc0f598f0",
+         "statusCheckRollup" => [
+           %{
+             "name" => "make-all",
+             "status" => "COMPLETED",
+             "conclusion" => "FAILURE",
+             "detailsUrl" => "https://example.org/check?token=sk-live-secret"
+           },
+           %{
+             "context" => "legacy-status",
+             "state" => "SUCCESS",
+             "targetUrl" => "https://example.org/status"
+           }
+         ]
+       }}
+    end)
+
+    on_exit(fn ->
+      if previous_lookup do
+        Application.put_env(:symphony_elixir, :worker_api_pr_lookup, previous_lookup)
+      else
+        Application.delete_env(:symphony_elixir, :worker_api_pr_lookup)
+      end
+
+      File.rm_rf!(workspace_path)
+    end)
+
+    snapshot = worker_api_snapshot(%{branch_name: nil, workspace_path: workspace_path})
+    orchestrator_name = Module.concat(__MODULE__, :WorkerPrDiscoveryOrchestrator)
+    {:ok, _pid} = StaticOrchestrator.start_link(name: orchestrator_name, snapshot: snapshot)
+
+    start_test_endpoint(orchestrator: orchestrator_name, snapshot_timeout_ms: 50)
+
+    status_payload = json_response(get(build_conn(), "/api/v1/workers/MT-API/status"), 200)
+
+    assert_receive {:worker_pr_lookup, ^workspace_path, ^branch}
+    assert status_payload["workspace"]["branch"] == branch
+    assert status_payload["pull_request"]["number"] == 115
+    assert status_payload["pull_request"]["head_ref"] == branch
+    assert status_payload["checks"]["summary"] == "failing"
+
+    assert [%{"details_url" => details_url}, %{"name" => "legacy-status", "status" => "COMPLETED", "conclusion" => "SUCCESS"}] =
+             status_payload["checks"]["items"]
+
+    refute details_url =~ "sk-live-secret"
+  end
+
+  test "agent worker status treats slow PR lookup as unavailable without blocking indefinitely" do
+    workspace_root = Config.settings!().workspace.root
+    workspace_path = Path.join(workspace_root, "MT-API-SLOW-PR-#{System.unique_integer([:positive])}")
+    branch = "codex/alb-66-slow-lookup"
+
+    File.rm_rf!(workspace_path)
+    File.mkdir_p!(workspace_path)
+    {_, 0} = System.cmd("git", ["init"], cd: workspace_path, stderr_to_stdout: true)
+    {_, 0} = System.cmd("git", ["checkout", "-b", branch], cd: workspace_path, stderr_to_stdout: true)
+
+    previous_lookup = Application.get_env(:symphony_elixir, :worker_api_pr_lookup)
+    previous_timeout = Application.get_env(:symphony_elixir, :worker_api_pr_lookup_timeout_ms)
+
+    Application.put_env(:symphony_elixir, :worker_api_pr_lookup, fn ^workspace_path, ^branch ->
+      Process.sleep(100)
+      {:ok, %{url: "https://example.org/too-late"}}
+    end)
+
+    Application.put_env(:symphony_elixir, :worker_api_pr_lookup_timeout_ms, 5)
+
+    on_exit(fn ->
+      if previous_lookup do
+        Application.put_env(:symphony_elixir, :worker_api_pr_lookup, previous_lookup)
+      else
+        Application.delete_env(:symphony_elixir, :worker_api_pr_lookup)
+      end
+
+      if previous_timeout do
+        Application.put_env(:symphony_elixir, :worker_api_pr_lookup_timeout_ms, previous_timeout)
+      else
+        Application.delete_env(:symphony_elixir, :worker_api_pr_lookup_timeout_ms)
+      end
+
+      File.rm_rf!(workspace_path)
+    end)
+
+    snapshot = worker_api_snapshot(%{branch_name: nil, workspace_path: workspace_path})
+    orchestrator_name = Module.concat(__MODULE__, :WorkerSlowPrLookupOrchestrator)
+    {:ok, _pid} = StaticOrchestrator.start_link(name: orchestrator_name, snapshot: snapshot)
+
+    start_test_endpoint(orchestrator: orchestrator_name, snapshot_timeout_ms: 50)
+
+    status_payload = json_response(get(build_conn(), "/api/v1/workers/MT-API/status"), 200)
+
+    assert status_payload["workspace"]["branch"] == branch
+    assert status_payload["pull_request"] == nil
+    assert status_payload["checks"] == nil
+  end
+
+  test "agent worker status handles PR lookup failures as unavailable" do
+    workspace_root = Config.settings!().workspace.root
+    workspace_path = Path.join(workspace_root, "MT-API-RAISE-PR-#{System.unique_integer([:positive])}")
+    branch = "codex/alb-66-lookup-failure"
+
+    File.rm_rf!(workspace_path)
+    File.mkdir_p!(workspace_path)
+    {_, 0} = System.cmd("git", ["init"], cd: workspace_path, stderr_to_stdout: true)
+    {_, 0} = System.cmd("git", ["checkout", "-b", branch], cd: workspace_path, stderr_to_stdout: true)
+
+    previous_lookup = Application.get_env(:symphony_elixir, :worker_api_pr_lookup)
+
+    Application.put_env(:symphony_elixir, :worker_api_pr_lookup, fn ^workspace_path, ^branch ->
+      raise "gh unavailable"
+    end)
+
+    on_exit(fn ->
+      if previous_lookup do
+        Application.put_env(:symphony_elixir, :worker_api_pr_lookup, previous_lookup)
+      else
+        Application.delete_env(:symphony_elixir, :worker_api_pr_lookup)
+      end
+
+      File.rm_rf!(workspace_path)
+    end)
+
+    snapshot = worker_api_snapshot(%{branch_name: nil, workspace_path: workspace_path})
+    orchestrator_name = Module.concat(__MODULE__, :WorkerFailedPrLookupOrchestrator)
+    {:ok, _pid} = StaticOrchestrator.start_link(name: orchestrator_name, snapshot: snapshot)
+
+    start_test_endpoint(orchestrator: orchestrator_name, snapshot_timeout_ms: 50)
+
+    status_payload = json_response(get(build_conn(), "/api/v1/workers/MT-API/status"), 200)
+
+    assert status_payload["workspace"]["branch"] == branch
+    assert status_payload["pull_request"] == nil
+    assert status_payload["checks"] == nil
+  end
+
+  test "agent worker status normalizes successful GitHub status contexts" do
+    snapshot =
+      worker_api_snapshot(%{
+        branch_name: "codex/alb-66-status-contexts",
+        pull_request: %{
+          "number" => 115,
+          "url" => "https://github.com/albert-zen/symphony-windows-native/pull/115",
+          "statusCheckRollup" => [
+            %{"context" => "legacy-success", "state" => "SUCCESS", "targetUrl" => "https://example.org/success"},
+            %{"context" => "legacy-neutral", "state" => "NEUTRAL"},
+            %{"context" => "legacy-skipped", "state" => "SKIPPED"}
+          ]
+        }
+      })
+
+    orchestrator_name = Module.concat(__MODULE__, :WorkerStatusContextProjectionOrchestrator)
+    {:ok, _pid} = StaticOrchestrator.start_link(name: orchestrator_name, snapshot: snapshot)
+
+    start_test_endpoint(orchestrator: orchestrator_name, snapshot_timeout_ms: 50)
+
+    status_payload = json_response(get(build_conn(), "/api/v1/workers/MT-API/status"), 200)
+
+    assert status_payload["checks"] == %{
+             "summary" => "passing",
+             "items" => [
+               %{
+                 "name" => "legacy-success",
+                 "status" => "COMPLETED",
+                 "conclusion" => "SUCCESS",
+                 "details_url" => "https://example.org/success"
+               },
+               %{"name" => "legacy-neutral", "status" => "COMPLETED", "conclusion" => "NEUTRAL", "details_url" => nil},
+               %{"name" => "legacy-skipped", "status" => "COMPLETED", "conclusion" => "SKIPPED", "details_url" => nil}
+             ]
+           }
+  end
+
+  test "agent worker status projects explicit PR URL while leaving checks unavailable" do
+    snapshot =
+      worker_api_snapshot(%{
+        branch_name: "codex/alb-66-worker-observability",
+        pull_request_url: "https://github.com/albert-zen/symphony-windows-native/pull/115"
+      })
+
+    orchestrator_name = Module.concat(__MODULE__, :WorkerPrUrlProjectionOrchestrator)
+    {:ok, _pid} = StaticOrchestrator.start_link(name: orchestrator_name, snapshot: snapshot)
+
+    start_test_endpoint(orchestrator: orchestrator_name, snapshot_timeout_ms: 50)
+
+    status_payload = json_response(get(build_conn(), "/api/v1/workers/MT-API/status"), 200)
+
+    assert status_payload["pull_request"] == %{
+             "url" => "https://github.com/albert-zen/symphony-windows-native/pull/115"
+           }
+
+    assert status_payload["checks"] == nil
+  end
+
+  test "agent worker conversation API does not perform PR discovery" do
+    workspace_root = Config.settings!().workspace.root
+    workspace_path = Path.join(workspace_root, "MT-API-CONV-#{System.unique_integer([:positive])}")
+    branch = "codex/alb-66-conversation"
+    test_pid = self()
+
+    File.rm_rf!(workspace_path)
+    File.mkdir_p!(workspace_path)
+    {_, 0} = System.cmd("git", ["init"], cd: workspace_path, stderr_to_stdout: true)
+    {_, 0} = System.cmd("git", ["checkout", "-b", branch], cd: workspace_path, stderr_to_stdout: true)
+
+    previous_lookup = Application.get_env(:symphony_elixir, :worker_api_pr_lookup)
+
+    Application.put_env(:symphony_elixir, :worker_api_pr_lookup, fn _, _ ->
+      send(test_pid, :unexpected_worker_pr_lookup)
+      {:ok, %{url: "https://example.org/unexpected"}}
+    end)
+
+    on_exit(fn ->
+      if previous_lookup do
+        Application.put_env(:symphony_elixir, :worker_api_pr_lookup, previous_lookup)
+      else
+        Application.delete_env(:symphony_elixir, :worker_api_pr_lookup)
+      end
+
+      File.rm_rf!(workspace_path)
+    end)
+
+    snapshot =
+      worker_api_snapshot(%{
+        branch_name: nil,
+        workspace_path: workspace_path,
+        completed_agent_messages: [
+          agent_completed_event("msg-processed", "Processed manager update.", ~U[2026-01-01 00:00:10Z])
+        ]
+      })
+
+    orchestrator_name = Module.concat(__MODULE__, :WorkerConversationNoLookupOrchestrator)
+    {:ok, _pid} = StaticOrchestrator.start_link(name: orchestrator_name, snapshot: snapshot)
+
+    start_test_endpoint(orchestrator: orchestrator_name, snapshot_timeout_ms: 50)
+
+    payload = json_response(get(build_conn(), "/api/v1/workers/MT-API/conversation"), 200)
+
+    assert [%{"excerpt" => "Processed manager update."}] = payload["items"]
+    refute_receive :unexpected_worker_pr_lookup
+  end
+
+  test "agent worker conversation API exposes processed agent messages without noisy timeline items" do
+    snapshot =
+      worker_api_snapshot(%{
+        completed_agent_messages: [
+          agent_completed_event("msg-processed", "Processed manager update.", ~U[2026-01-01 00:00:10Z])
+        ],
+        recent_codex_events: [
+          notification_event("item/agentMessage/delta", %{"textDelta" => "streaming noise"}, 1),
+          %{event: :unexpected_worker_event, message: "icon path warning", raw: %{}, timestamp: ~U[2026-01-01 00:00:02Z]}
+        ]
+      })
+
+    orchestrator_name = Module.concat(__MODULE__, :WorkerConversationApiOrchestrator)
+    {:ok, _pid} = StaticOrchestrator.start_link(name: orchestrator_name, snapshot: snapshot)
+
+    start_test_endpoint(orchestrator: orchestrator_name, snapshot_timeout_ms: 50)
+
+    payload = json_response(get(build_conn(), "/api/v1/workers/MT-API/conversation"), 200)
+
+    assert payload == %{
+             "issue_identifier" => "MT-API",
+             "status" => "running",
+             "source" => "conversation",
+             "session" => %{
+               "session_id" => "session-api",
+               "thread_id" => "thread-api",
+               "turn_count" => 3,
+               "turn_id" => "turn-api"
+             },
+             "items" => [
+               %{
+                 "type" => "assistant",
+                 "key" => "msg-processed",
+                 "at" => "2026-01-01T00:00:10Z",
+                 "title" => "Agent",
+                 "excerpt" => "Processed manager update.",
+                 "truncated?" => false
+               }
+             ]
+           }
+
+    rendered = inspect(payload, limit: :infinity)
+    refute rendered =~ "streaming noise"
+    refute rendered =~ "icon path warning"
   end
 
   test "agent worker debug events bound nested payload rendering before truncation" do


### PR DESCRIPTION
#### Context

Closes #113. Also adds a processed worker conversation API for the rough agent page path without closing #62.

#### TL;DR

*Show worker branch, PR, checks, and clean agent messages in manager-facing APIs.*

#### Summary

- Surface worker branch, PR metadata, and check summaries in status/detail payloads.
- Render Branch / Checks from the projected metadata on the worker detail page.
- Add `/api/v1/workers/:issue_identifier/conversation` for processed agent messages.
- Keep conversation independent from PR discovery; timeline/debug remains diagnostic-only.
- Bound authenticated `gh pr view` discovery with timeout/rescue and normalize StatusContext checks.

#### Alternatives

- Only updating the LiveView would leave API consumers blind to PR/check state.
- Reusing timeline data would keep system/debug events mixed into human messages.
- Running live GitHub calls in tests was avoided; snapshots and fake lookup cover the contract.

#### Test Plan

- [ ] `make -C elixir all` not run locally because focused API/UI tests plus `mix test --cover` and `mix dialyzer` validated the touched observability paths.
- [x] `mise exec -- mix test test/symphony_elixir/extensions_test.exs` passed: 74 tests, 0 failures.
- [x] `mise exec -- mix test --cover` passed locally; coverage log reported total 95.28% before the final Dialyzer-only cleanup.
- [x] `mise exec -- mix dialyzer --format short` passed locally: 0 errors.
- [x] `mise exec -- mix format.check_normalized lib/symphony_elixir_web/worker_api.ex lib/symphony_elixir_web/presenter.ex lib/symphony_elixir_web/controllers/observability_api_controller.ex lib/symphony_elixir_web/router.ex lib/symphony_elixir_web/live/dashboard_live.ex test/symphony_elixir/extensions_test.exs` passed.
- [x] `git diff --check` passed.