### PR TITLE
Redesign worker detail as rollout-backed agent chat

### DIFF
--- a/elixir/lib/symphony_elixir.ex
+++ b/elixir/lib/symphony_elixir.ex
@@ -35,6 +35,8 @@ defmodule SymphonyElixir.Application do
       SymphonyElixir.WorkflowStore,
       SymphonyElixir.Orchestrator,
       SymphonyElixir.Codex.RolloutIndex,
+      {Registry, keys: :unique, name: SymphonyElixirWeb.CodexTailRegistry},
+      {DynamicSupervisor, strategy: :one_for_one, name: SymphonyElixirWeb.CodexTailSupervisor},
       SymphonyElixir.HttpServer,
       SymphonyElixir.StatusDashboard
     ]

--- a/elixir/lib/symphony_elixir.ex
+++ b/elixir/lib/symphony_elixir.ex
@@ -34,6 +34,7 @@ defmodule SymphonyElixir.Application do
       {Task.Supervisor, name: SymphonyElixir.TaskSupervisor},
       SymphonyElixir.WorkflowStore,
       SymphonyElixir.Orchestrator,
+      SymphonyElixir.Codex.RolloutIndex,
       SymphonyElixir.HttpServer,
       SymphonyElixir.StatusDashboard
     ]

--- a/elixir/lib/symphony_elixir/codex/rollout_index.ex
+++ b/elixir/lib/symphony_elixir/codex/rollout_index.ex
@@ -1,0 +1,313 @@
+defmodule SymphonyElixir.Codex.RolloutIndex do
+  @moduledoc """
+  In-memory index of Codex rollout JSONL files on disk, grouped by Symphony
+  `issue_identifier`.
+
+  ## Why
+
+  Codex writes a complete append-only transcript per session at
+  `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`. The first line of each file
+  is a `session_meta` record whose `payload.cwd` is the workspace path. Per
+  the Symphony spec the workspace directory name equals the sanitized
+  `issue_identifier`, so `Path.basename(cwd)` gives us a free, durable
+  mapping back to a Symphony issue — no separate mapping table needed.
+
+  This index lets the Worker Details page resolve historical (and active)
+  worker transcripts even after the worker has exited and the orchestrator's
+  in-memory state is gone, fixing the previous "404 on terminated worker"
+  behaviour of `Presenter.issue_payload/3`.
+
+  ## Configuration
+
+  The sessions root is read from `Application.get_env/3`:
+
+      Application.get_env(:symphony_elixir, :codex_sessions_root, default)
+
+  where `default` is `Path.expand("~/.codex/sessions")`. We also restrict
+  to rollouts whose `cwd` falls under the configured workspace root, so we
+  do not index unrelated Codex Desktop sessions running on the same
+  machine.
+
+  ## Refresh model
+
+  An initial scan runs on `init/1`. After that, `refresh/0` rescans on
+  demand. A periodic refresh runs every `@refresh_interval_ms` to catch
+  files written by other processes (e.g. Codex during an active run).
+  Adopting a filesystem watcher (e.g. `:file_system`) is a future
+  improvement and is intentionally not part of this module.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias SymphonyElixir.Codex.RolloutReader
+  alias SymphonyElixir.Config
+
+  @refresh_interval_ms 30_000
+
+  @typedoc """
+  Per-rollout metadata cached in the index.
+  """
+  @type entry :: %{
+          path: Path.t(),
+          session_id: String.t() | nil,
+          cwd: Path.t() | nil,
+          issue_identifier: String.t() | nil,
+          started_at: DateTime.t() | nil,
+          model: String.t() | nil,
+          mtime: integer() | nil
+        }
+
+  defmodule State do
+    @moduledoc false
+    defstruct sessions_root: nil,
+              workspace_root: nil,
+              # %{issue_identifier => [entry, newest first]}
+              by_issue: %{},
+              # %{path => entry}
+              by_path: %{}
+  end
+
+  ## Public API ----------------------------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: name(opts))
+  end
+
+  @doc """
+  Look up all known rollouts for a given Symphony issue identifier.
+
+  Returns a list of entries newest-first (by `started_at`). Returns `[]`
+  when the issue is unknown.
+  """
+  @spec lookup(String.t(), keyword()) :: [entry()]
+  def lookup(issue_identifier, opts \\ []) when is_binary(issue_identifier) do
+    server = name(opts)
+
+    case Process.whereis(server) do
+      pid when is_pid(pid) -> GenServer.call(server, {:lookup, issue_identifier})
+      _ -> []
+    end
+  end
+
+  @doc """
+  Look up a single rollout by its on-disk path.
+  """
+  @spec get(Path.t(), keyword()) :: entry() | nil
+  def get(path, opts \\ []) when is_binary(path) do
+    server = name(opts)
+
+    case Process.whereis(server) do
+      pid when is_pid(pid) -> GenServer.call(server, {:get, path})
+      _ -> nil
+    end
+  end
+
+  @doc """
+  Force a synchronous rescan of the sessions root.
+  """
+  @spec refresh(keyword()) :: :ok
+  def refresh(opts \\ []) do
+    server = name(opts)
+
+    case Process.whereis(server) do
+      pid when is_pid(pid) -> GenServer.call(server, :refresh, 30_000)
+      _ -> :ok
+    end
+  end
+
+  @doc """
+  Default sessions root: `Path.expand("~/.codex/sessions")` overridable via
+  `Application.put_env(:symphony_elixir, :codex_sessions_root, path)`.
+  """
+  @spec default_sessions_root() :: Path.t()
+  def default_sessions_root do
+    Application.get_env(:symphony_elixir, :codex_sessions_root, default_sessions_root_path())
+  end
+
+  ## GenServer callbacks --------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    sessions_root =
+      opts
+      |> Keyword.get(:sessions_root, default_sessions_root())
+      |> normalize_path()
+
+    workspace_root = opts |> Keyword.get(:workspace_root, resolve_workspace_root()) |> normalize_path()
+
+    state = %State{sessions_root: sessions_root, workspace_root: workspace_root}
+    state = rescan(state)
+
+    schedule_refresh()
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call({:lookup, issue_identifier}, _from, %State{} = state) do
+    {:reply, Map.get(state.by_issue, issue_identifier, []), state}
+  end
+
+  def handle_call({:get, path}, _from, %State{} = state) do
+    {:reply, Map.get(state.by_path, path), state}
+  end
+
+  def handle_call(:refresh, _from, %State{} = state) do
+    {:reply, :ok, rescan(state)}
+  end
+
+  @impl true
+  def handle_info(:refresh, %State{} = state) do
+    schedule_refresh()
+    {:noreply, rescan(state)}
+  end
+
+  def handle_info(_other, state), do: {:noreply, state}
+
+  ## Internals ------------------------------------------------------------
+
+  defp name(opts), do: Keyword.get(opts, :name, __MODULE__)
+
+  defp schedule_refresh do
+    Process.send_after(self(), :refresh, @refresh_interval_ms)
+  end
+
+  defp rescan(%State{sessions_root: nil} = state), do: state
+
+  defp rescan(%State{sessions_root: root} = state) do
+    case File.dir?(root) do
+      true ->
+        entries =
+          root
+          |> list_rollout_files()
+          |> Enum.map(&entry_for_path(&1, state))
+          |> Enum.reject(&is_nil/1)
+
+        index_entries(state, entries)
+
+      false ->
+        Logger.debug(
+          "rollout_index: sessions root does not exist yet, skipping scan: #{inspect(root)}"
+        )
+
+        state
+    end
+  end
+
+  defp index_entries(%State{} = state, entries) do
+    by_path =
+      entries
+      |> Enum.reduce(%{}, fn entry, acc -> Map.put(acc, entry.path, entry) end)
+
+    by_issue =
+      entries
+      |> Enum.reject(fn e -> is_nil(e.issue_identifier) end)
+      |> Enum.group_by(& &1.issue_identifier)
+      |> Enum.into(%{}, fn {issue_id, list} ->
+        sorted =
+          Enum.sort_by(list, fn e -> e.started_at || DateTime.from_unix!(0) end, {:desc, DateTime})
+
+        {issue_id, sorted}
+      end)
+
+    %{state | by_path: by_path, by_issue: by_issue}
+  end
+
+  defp list_rollout_files(root) do
+    root
+    |> Path.join("**/rollout-*.jsonl")
+    |> Path.wildcard()
+  end
+
+  defp entry_for_path(path, %State{} = state) do
+    case RolloutReader.read_meta(path) do
+      {:ok, meta} ->
+        cwd = meta.cwd
+        issue_identifier = derive_issue_identifier(cwd, state.workspace_root)
+
+        %{
+          path: path,
+          session_id: meta.session_id,
+          cwd: cwd,
+          issue_identifier: issue_identifier,
+          started_at: meta.started_at,
+          model: meta.model,
+          mtime: file_mtime(path)
+        }
+
+      {:error, _reason} ->
+        nil
+    end
+  end
+
+  defp file_mtime(path) do
+    case File.stat(path, time: :posix) do
+      {:ok, %File.Stat{mtime: mtime}} -> mtime
+      _ -> nil
+    end
+  end
+
+  @doc false
+  @spec derive_issue_identifier(Path.t() | nil, Path.t() | nil) :: String.t() | nil
+  def derive_issue_identifier(nil, _), do: nil
+
+  def derive_issue_identifier(cwd, workspace_root) when is_binary(cwd) do
+    normalized_cwd = normalize_path(cwd)
+
+    cond do
+      is_binary(workspace_root) and not within_root?(normalized_cwd, workspace_root) ->
+        nil
+
+      true ->
+        candidate = normalized_cwd |> Path.basename() |> sanitize_identifier()
+        if candidate == "", do: nil, else: candidate
+    end
+  end
+
+  defp within_root?(path, root) do
+    p = downcase_for_match(path)
+    r = downcase_for_match(root) |> ensure_trailing_separator()
+    String.starts_with?(p, r) or p == String.trim_trailing(r, "/")
+  end
+
+  defp downcase_for_match(path) do
+    path
+    |> normalize_path()
+    |> String.replace("\\", "/")
+    |> String.downcase()
+  end
+
+  defp ensure_trailing_separator(path) do
+    if String.ends_with?(path, "/"), do: path, else: path <> "/"
+  end
+
+  defp sanitize_identifier(value) when is_binary(value) do
+    String.replace(value, ~r/[^a-zA-Z0-9._-]/, "_")
+  end
+
+  defp sanitize_identifier(_), do: ""
+
+  defp normalize_path(nil), do: nil
+
+  defp normalize_path(path) when is_binary(path) do
+    path
+    |> Path.expand()
+  end
+
+  defp default_sessions_root_path do
+    home = System.user_home() || System.get_env("USERPROFILE") || "."
+    Path.join([home, ".codex", "sessions"]) |> Path.expand()
+  end
+
+  defp resolve_workspace_root do
+    try do
+      Config.settings!().workspace.root
+    rescue
+      _ -> nil
+    catch
+      _, _ -> nil
+    end
+  end
+end

--- a/elixir/lib/symphony_elixir/codex/rollout_index.ex
+++ b/elixir/lib/symphony_elixir/codex/rollout_index.ex
@@ -222,7 +222,18 @@ defmodule SymphonyElixir.Codex.RolloutIndex do
 
   defp entry_for_path(path, %State{} = state) do
     path = normalize_path(path)
+    mtime = file_mtime(path)
 
+    case Map.get(state.by_path, path) do
+      %{mtime: ^mtime} = entry when not is_nil(mtime) ->
+        entry
+
+      _ ->
+        read_entry(path, state, mtime)
+    end
+  end
+
+  defp read_entry(path, %State{} = state, mtime) do
     case RolloutReader.read_meta(path) do
       {:ok, meta} ->
         cwd = meta.cwd
@@ -235,7 +246,7 @@ defmodule SymphonyElixir.Codex.RolloutIndex do
           issue_identifier: issue_identifier,
           started_at: meta.started_at,
           model: meta.model,
-          mtime: file_mtime(path)
+          mtime: mtime
         }
 
       {:error, _reason} ->
@@ -257,13 +268,11 @@ defmodule SymphonyElixir.Codex.RolloutIndex do
   def derive_issue_identifier(cwd, workspace_root) when is_binary(cwd) do
     normalized_cwd = normalize_path(cwd)
 
-    cond do
-      is_binary(workspace_root) and not within_root?(normalized_cwd, workspace_root) ->
-        nil
-
-      true ->
-        candidate = normalized_cwd |> Path.basename() |> sanitize_identifier()
-        if candidate == "", do: nil, else: candidate
+    if is_binary(workspace_root) and not within_root?(normalized_cwd, workspace_root) do
+      nil
+    else
+      candidate = normalized_cwd |> Path.basename() |> sanitize_identifier()
+      if candidate == "", do: nil, else: candidate
     end
   end
 
@@ -301,12 +310,10 @@ defmodule SymphonyElixir.Codex.RolloutIndex do
   end
 
   defp resolve_workspace_root do
-    try do
-      Config.settings!().workspace.root
-    rescue
-      _ -> nil
-    catch
-      _, _ -> nil
-    end
+    Config.settings!().workspace.root
+  rescue
+    _ -> nil
+  catch
+    _, _ -> nil
   end
 end

--- a/elixir/lib/symphony_elixir/codex/rollout_index.ex
+++ b/elixir/lib/symphony_elixir/codex/rollout_index.ex
@@ -98,6 +98,7 @@ defmodule SymphonyElixir.Codex.RolloutIndex do
   @spec get(Path.t(), keyword()) :: entry() | nil
   def get(path, opts \\ []) when is_binary(path) do
     server = name(opts)
+    path = normalize_path(path)
 
     case Process.whereis(server) do
       pid when is_pid(pid) -> GenServer.call(server, {:get, path})
@@ -188,9 +189,7 @@ defmodule SymphonyElixir.Codex.RolloutIndex do
         index_entries(state, entries)
 
       false ->
-        Logger.debug(
-          "rollout_index: sessions root does not exist yet, skipping scan: #{inspect(root)}"
-        )
+        Logger.debug("rollout_index: sessions root does not exist yet, skipping scan: #{inspect(root)}")
 
         state
     end
@@ -222,6 +221,8 @@ defmodule SymphonyElixir.Codex.RolloutIndex do
   end
 
   defp entry_for_path(path, %State{} = state) do
+    path = normalize_path(path)
+
     case RolloutReader.read_meta(path) do
       {:ok, meta} ->
         cwd = meta.cwd
@@ -286,8 +287,6 @@ defmodule SymphonyElixir.Codex.RolloutIndex do
   defp sanitize_identifier(value) when is_binary(value) do
     String.replace(value, ~r/[^a-zA-Z0-9._-]/, "_")
   end
-
-  defp sanitize_identifier(_), do: ""
 
   defp normalize_path(nil), do: nil
 

--- a/elixir/lib/symphony_elixir/codex/rollout_reader.ex
+++ b/elixir/lib/symphony_elixir/codex/rollout_reader.ex
@@ -97,6 +97,26 @@ defmodule SymphonyElixir.Codex.RolloutReader do
   end
 
   @doc """
+  Read projected conversation items from a rollout file.
+
+  Pass `limit: n` to return only the latest `n` projected items. This keeps
+  Worker Details initial renders bounded even when a Codex session has a long
+  JSONL history.
+  """
+  @spec conversation_items(Path.t(), keyword()) :: [conversation_item()]
+  def conversation_items(path, opts \\ []) when is_binary(path) do
+    limit = Keyword.get(opts, :limit, :all)
+
+    path
+    |> stream()
+    |> Stream.map(&to_conversation_item/1)
+    |> Stream.reject(&is_nil/1)
+    |> take_latest(limit)
+  rescue
+    _ -> []
+  end
+
+  @doc """
   Project a parsed line to a `t:conversation_item/0`.
 
   Returns `nil` for items that should be hidden from the human transcript
@@ -117,6 +137,13 @@ defmodule SymphonyElixir.Codex.RolloutReader do
   def to_conversation_item(_), do: nil
 
   # ---- internals ----------------------------------------------------------
+
+  defp take_latest(stream, :all), do: Enum.to_list(stream)
+
+  defp take_latest(stream, limit) when is_integer(limit) and limit > 0,
+    do: Enum.take(stream, -limit)
+
+  defp take_latest(_stream, _limit), do: []
 
   defp read_meta_from_io(io, path) do
     case IO.binread(io, :line) do
@@ -140,29 +167,27 @@ defmodule SymphonyElixir.Codex.RolloutReader do
   defp decode_line(line, path) do
     trimmed = String.trim(line)
 
-    cond do
-      trimmed == "" ->
-        nil
+    if trimmed == "" do
+      nil
+    else
+      case Jason.decode(trimmed) do
+        {:ok, %{"type" => "session_meta"} = obj} ->
+          {:meta, obj}
 
-      true ->
-        case Jason.decode(trimmed) do
-          {:ok, %{"type" => "session_meta"} = obj} ->
-            {:meta, obj}
+        {:ok, %{"type" => "event_msg"} = obj} ->
+          {:event, obj}
 
-          {:ok, %{"type" => "event_msg"} = obj} ->
-            {:event, obj}
+        {:ok, %{"type" => "response_item"} = obj} ->
+          {:response, obj}
 
-          {:ok, %{"type" => "response_item"} = obj} ->
-            {:response, obj}
+        {:ok, _other} ->
+          :unknown
 
-          {:ok, _other} ->
-            :unknown
+        {:error, reason} ->
+          Logger.debug("rollout_reader: skipping malformed line in #{path}: #{inspect(reason)}")
 
-          {:error, reason} ->
-            Logger.debug("rollout_reader: skipping malformed line in #{path}: #{inspect(reason)}")
-
-            nil
-        end
+          nil
+      end
     end
   end
 

--- a/elixir/lib/symphony_elixir/codex/rollout_reader.ex
+++ b/elixir/lib/symphony_elixir/codex/rollout_reader.ex
@@ -1,0 +1,335 @@
+defmodule SymphonyElixir.Codex.RolloutReader do
+  @moduledoc """
+  Pure module for reading Codex rollout JSONL files written by the Codex
+  app-server (default location `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`).
+
+  Each line is a JSON object of the form `{"timestamp", "type", "payload"}`
+  with three known types:
+
+    * `"session_meta"`   — emitted once at the top of the file; `payload.cwd`
+                          is the workspace path and `payload.id` is the
+                          session id.
+    * `"event_msg"`      — protocol-level events like `task_started`,
+                          `task_completed`, `error`.
+    * `"response_item"`  — message items (`role: user|assistant|developer|
+                          system`), tool calls, tool outputs, etc.
+
+  This module is responsible for parsing those lines and projecting them
+  into a stable `t:conversation_item/0` shape consumed by the dashboard UI.
+  It does not own any process state — readers are streams.
+  """
+
+  require Logger
+
+  @type rollout_meta :: %{
+          path: Path.t(),
+          session_id: String.t() | nil,
+          cwd: Path.t() | nil,
+          started_at: DateTime.t() | nil,
+          model: String.t() | nil,
+          originator: String.t() | nil,
+          cli_version: String.t() | nil
+        }
+
+  @type parsed_line ::
+          {:meta, map()}
+          | {:event, map()}
+          | {:response, map()}
+          | :unknown
+
+  @typedoc """
+  Normalized chat-style item used by the Worker Details transcript view.
+
+  `kind` values: `:assistant_message`, `:user_message`, `:reasoning`,
+  `:tool_call`, `:state_change`, `:error`, `:system_note`.
+  """
+  @type conversation_item :: %{
+          required(:kind) => atom(),
+          required(:at) => DateTime.t() | nil,
+          required(:text) => String.t(),
+          required(:meta) => map()
+        }
+
+  @max_text_bytes 8_000
+
+  @doc """
+  Parse the first `session_meta` line of a rollout file and return its
+  metadata. Returns `{:error, reason}` if the file is missing, unreadable,
+  or the first line is not a valid `session_meta` record.
+  """
+  @spec read_meta(Path.t()) :: {:ok, rollout_meta()} | {:error, atom()}
+  def read_meta(path) when is_binary(path) do
+    case File.open(path, [:read, :binary]) do
+      {:ok, io} ->
+        try do
+          read_meta_from_io(io, path)
+        after
+          File.close(io)
+        end
+
+      {:error, reason} ->
+        {:error, {:open_failed, reason}}
+    end
+  end
+
+  @doc """
+  Stream parsed lines from a rollout file, oldest-first.
+
+  Malformed lines are logged and skipped. The returned stream emits
+  `t:parsed_line/0` values; pair with `to_conversation_item/1` to project
+  to the chat shape.
+  """
+  @spec stream(Path.t()) :: Enumerable.t()
+  def stream(path) when is_binary(path) do
+    path
+    |> File.stream!([:read_ahead], :line)
+    |> Stream.map(&decode_line(&1, path))
+    |> Stream.reject(&is_nil/1)
+  end
+
+  @doc """
+  Project a parsed line to a `t:conversation_item/0`.
+
+  Returns `nil` for items that should be hidden from the human transcript
+  view (e.g. developer/system roles, low-signal protocol events). Callers
+  should `Enum.reject(&is_nil/1)`.
+  """
+  @spec to_conversation_item(parsed_line()) :: conversation_item() | nil
+  def to_conversation_item({:response, %{"timestamp" => ts, "payload" => payload}}) do
+    response_item_to_conversation_item(payload, ts)
+  end
+
+  def to_conversation_item({:event, %{"timestamp" => ts, "payload" => payload}}) do
+    event_to_conversation_item(payload, ts)
+  end
+
+  def to_conversation_item({:meta, _}), do: nil
+  def to_conversation_item(:unknown), do: nil
+  def to_conversation_item(_), do: nil
+
+  # ---- internals ----------------------------------------------------------
+
+  defp read_meta_from_io(io, path) do
+    case IO.binread(io, :line) do
+      :eof ->
+        {:error, :empty_file}
+
+      {:error, reason} ->
+        {:error, {:read_failed, reason}}
+
+      line when is_binary(line) ->
+        case decode_line(line, path) do
+          {:meta, %{"timestamp" => ts, "payload" => payload}} when is_map(payload) ->
+            {:ok, build_meta(path, payload, ts)}
+
+          _ ->
+            {:error, :no_session_meta}
+        end
+    end
+  end
+
+  defp decode_line(line, path) do
+    trimmed = String.trim(line)
+
+    cond do
+      trimmed == "" ->
+        nil
+
+      true ->
+        case Jason.decode(trimmed) do
+          {:ok, %{"type" => "session_meta"} = obj} ->
+            {:meta, obj}
+
+          {:ok, %{"type" => "event_msg"} = obj} ->
+            {:event, obj}
+
+          {:ok, %{"type" => "response_item"} = obj} ->
+            {:response, obj}
+
+          {:ok, _other} ->
+            :unknown
+
+          {:error, reason} ->
+            Logger.debug(
+              "rollout_reader: skipping malformed line in #{path}: #{inspect(reason)}"
+            )
+
+            nil
+        end
+    end
+  end
+
+  defp build_meta(path, payload, ts) when is_map(payload) do
+    %{
+      path: path,
+      session_id: read_string(payload, "id"),
+      cwd: read_string(payload, "cwd"),
+      started_at: parse_timestamp(payload["timestamp"] || ts),
+      model: extract_model(payload),
+      originator: read_string(payload, "originator"),
+      cli_version: read_string(payload, "cli_version")
+    }
+  end
+
+  defp extract_model(payload) do
+    cond do
+      is_binary(payload["model"]) -> payload["model"]
+      is_binary(payload["model_provider"]) -> payload["model_provider"]
+      true -> nil
+    end
+  end
+
+  defp read_string(map, key) do
+    case Map.get(map, key) do
+      v when is_binary(v) -> v
+      _ -> nil
+    end
+  end
+
+  defp parse_timestamp(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, dt, _offset} -> dt
+      _ -> nil
+    end
+  end
+
+  defp parse_timestamp(_), do: nil
+
+  defp truncate_text(text) when is_binary(text) do
+    if byte_size(text) <= @max_text_bytes do
+      text
+    else
+      :binary.part(text, 0, @max_text_bytes) <> " …[truncated]"
+    end
+  end
+
+  defp truncate_text(_), do: ""
+
+  # response_item dispatch
+  defp response_item_to_conversation_item(%{"type" => "message"} = payload, ts) do
+    role = payload["role"]
+    text = extract_message_text(payload["content"])
+
+    cond do
+      role == "assistant" and text != "" ->
+        %{
+          kind: :assistant_message,
+          at: parse_timestamp(ts),
+          text: truncate_text(text),
+          meta: %{}
+        }
+
+      role == "user" and text != "" ->
+        %{
+          kind: :user_message,
+          at: parse_timestamp(ts),
+          text: truncate_text(text),
+          meta: %{}
+        }
+
+      role in ["developer", "system"] ->
+        # Hidden by default — UI can choose to surface via "show system" toggle.
+        nil
+
+      true ->
+        nil
+    end
+  end
+
+  defp response_item_to_conversation_item(%{"type" => "reasoning"} = payload, ts) do
+    text = extract_message_text(payload["content"]) |> default_to(payload["text"])
+
+    if text == "" do
+      nil
+    else
+      %{
+        kind: :reasoning,
+        at: parse_timestamp(ts),
+        text: truncate_text(text),
+        meta: %{}
+      }
+    end
+  end
+
+  defp response_item_to_conversation_item(
+         %{"type" => "function_call"} = payload,
+         ts
+       ) do
+    %{
+      kind: :tool_call,
+      at: parse_timestamp(ts),
+      text: truncate_text(read_string(payload, "name") || "tool_call"),
+      meta: %{
+        name: read_string(payload, "name"),
+        arguments: payload["arguments"],
+        call_id: read_string(payload, "call_id")
+      }
+    }
+  end
+
+  defp response_item_to_conversation_item(
+         %{"type" => "function_call_output"} = payload,
+         ts
+       ) do
+    output_text = extract_function_output(payload["output"])
+
+    %{
+      kind: :tool_call,
+      at: parse_timestamp(ts),
+      text: truncate_text(output_text),
+      meta: %{
+        call_id: read_string(payload, "call_id"),
+        is_output: true
+      }
+    }
+  end
+
+  defp response_item_to_conversation_item(_, _), do: nil
+
+  defp event_to_conversation_item(%{"type" => type} = payload, ts)
+       when type in ["task_started", "task_completed", "thread_started", "turn_completed"] do
+    %{
+      kind: :state_change,
+      at: parse_timestamp(ts),
+      text: type,
+      meta: Map.take(payload, ["turn_id", "thread_id"])
+    }
+  end
+
+  defp event_to_conversation_item(%{"type" => "error"} = payload, ts) do
+    %{
+      kind: :error,
+      at: parse_timestamp(ts),
+      text: truncate_text(read_string(payload, "message") || "error"),
+      meta: payload
+    }
+  end
+
+  defp event_to_conversation_item(_, _), do: nil
+
+  defp default_to("", fallback) when is_binary(fallback), do: fallback
+  defp default_to(value, _fallback), do: value
+
+  # `content` from response_item.message looks like:
+  #   [%{"type" => "input_text"|"output_text", "text" => "..."}]
+  defp extract_message_text(content) when is_list(content) do
+    content
+    |> Enum.map(fn
+      %{"text" => text} when is_binary(text) -> text
+      %{"type" => "input_text", "text" => text} when is_binary(text) -> text
+      %{"type" => "output_text", "text" => text} when is_binary(text) -> text
+      _ -> ""
+    end)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n")
+  end
+
+  defp extract_message_text(text) when is_binary(text), do: text
+  defp extract_message_text(_), do: ""
+
+  defp extract_function_output(%{"content" => content}) when is_list(content),
+    do: extract_message_text(content)
+
+  defp extract_function_output(text) when is_binary(text), do: text
+  defp extract_function_output(_), do: ""
+end

--- a/elixir/lib/symphony_elixir/codex/rollout_reader.ex
+++ b/elixir/lib/symphony_elixir/codex/rollout_reader.ex
@@ -81,8 +81,17 @@ defmodule SymphonyElixir.Codex.RolloutReader do
   """
   @spec stream(Path.t()) :: Enumerable.t()
   def stream(path) when is_binary(path) do
-    path
-    |> File.stream!([:read_ahead], :line)
+    Stream.resource(
+      fn -> File.open!(path, [:read, :binary]) end,
+      fn io ->
+        case IO.binread(io, :line) do
+          :eof -> {:halt, io}
+          {:error, reason} -> raise File.Error, reason: reason, action: "read", path: path
+          line when is_binary(line) -> {[line], io}
+        end
+      end,
+      &File.close/1
+    )
     |> Stream.map(&decode_line(&1, path))
     |> Stream.reject(&is_nil/1)
   end
@@ -150,9 +159,7 @@ defmodule SymphonyElixir.Codex.RolloutReader do
             :unknown
 
           {:error, reason} ->
-            Logger.debug(
-              "rollout_reader: skipping malformed line in #{path}: #{inspect(reason)}"
-            )
+            Logger.debug("rollout_reader: skipping malformed line in #{path}: #{inspect(reason)}")
 
             nil
         end
@@ -202,8 +209,6 @@ defmodule SymphonyElixir.Codex.RolloutReader do
       :binary.part(text, 0, @max_text_bytes) <> " …[truncated]"
     end
   end
-
-  defp truncate_text(_), do: ""
 
   # response_item dispatch
   defp response_item_to_conversation_item(%{"type" => "message"} = payload, ts) do
@@ -316,8 +321,6 @@ defmodule SymphonyElixir.Codex.RolloutReader do
     content
     |> Enum.map(fn
       %{"text" => text} when is_binary(text) -> text
-      %{"type" => "input_text", "text" => text} when is_binary(text) -> text
-      %{"type" => "output_text", "text" => text} when is_binary(text) -> text
       _ -> ""
     end)
     |> Enum.reject(&(&1 == ""))

--- a/elixir/lib/symphony_elixir_web/components/layouts.ex
+++ b/elixir/lib/symphony_elixir_web/components/layouts.ex
@@ -63,6 +63,21 @@ defmodule SymphonyElixirWeb.Layouts do
                 scrollToBottom: function () {
                   this.el.scrollTop = this.el.scrollHeight;
                 }
+              },
+              StickyScroll: {
+                mounted: function () {
+                  this.atBottom = true;
+                  this.el.addEventListener("scroll", () => {
+                    var threshold = 64;
+                    this.atBottom = (this.el.scrollHeight - this.el.scrollTop - this.el.clientHeight) < threshold;
+                  });
+                  this.el.scrollTop = this.el.scrollHeight;
+                },
+                updated: function () {
+                  if (this.atBottom !== false) {
+                    this.el.scrollTop = this.el.scrollHeight;
+                  }
+                }
               }
             };
 

--- a/elixir/lib/symphony_elixir_web/live/codex_tail_server.ex
+++ b/elixir/lib/symphony_elixir_web/live/codex_tail_server.ex
@@ -130,6 +130,7 @@ defmodule SymphonyElixirWeb.CodexTailServer do
 
       true ->
         Process.send_after(self(), :poll, @poll_interval_ms)
+
         state =
           if no_subscribers?(state),
             do: state,

--- a/elixir/lib/symphony_elixir_web/live/codex_tail_server.ex
+++ b/elixir/lib/symphony_elixir_web/live/codex_tail_server.ex
@@ -87,6 +87,7 @@ defmodule SymphonyElixirWeb.CodexTailServer do
     PubSub.unsubscribe(pubsub, topic(rollout_id))
   end
 
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
   def child_spec(opts) do
     %{
       id: {__MODULE__, Keyword.fetch!(opts, :rollout_id)},

--- a/elixir/lib/symphony_elixir_web/live/codex_tail_server.ex
+++ b/elixir/lib/symphony_elixir_web/live/codex_tail_server.ex
@@ -74,9 +74,19 @@ defmodule SymphonyElixirWeb.CodexTailServer do
     rollout_id = Keyword.fetch!(opts, :rollout_id)
     pubsub = Keyword.get(opts, :pubsub, SymphonyElixir.PubSub)
 
-    with {:ok, _pid} <- start(opts),
-         :ok <- PubSub.subscribe(pubsub, topic(rollout_id)) do
-      :ok
+    case PubSub.subscribe(pubsub, topic(rollout_id)) do
+      :ok ->
+        case start(opts) do
+          {:ok, _pid} ->
+            :ok
+
+          {:error, reason} ->
+            PubSub.unsubscribe(pubsub, topic(rollout_id))
+            {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -113,11 +123,13 @@ defmodule SymphonyElixirWeb.CodexTailServer do
       rollout_id: Keyword.fetch!(opts, :rollout_id),
       path: Keyword.fetch!(opts, :path),
       pubsub: Keyword.get(opts, :pubsub, SymphonyElixir.PubSub),
-      offset: 0,
+      offset: Keyword.get(opts, :start_offset, 0),
+      poll_interval_ms: Keyword.get(opts, :poll_interval_ms, @poll_interval_ms),
+      idle_timeout_ms: Keyword.get(opts, :idle_timeout_ms, @idle_timeout_ms),
       idle_since: System.monotonic_time(:millisecond)
     }
 
-    Process.send_after(self(), :poll, @poll_interval_ms)
+    schedule_poll(state)
     {:ok, state}
   end
 
@@ -125,25 +137,25 @@ defmodule SymphonyElixirWeb.CodexTailServer do
   def handle_info(:poll, state) do
     state = poll(state)
 
-    cond do
-      no_subscribers?(state) and idle_too_long?(state) ->
-        {:stop, :normal, state}
+    if no_subscribers?(state) and idle_too_long?(state) do
+      {:stop, :normal, state}
+    else
+      schedule_poll(state)
 
-      true ->
-        Process.send_after(self(), :poll, @poll_interval_ms)
+      state =
+        if no_subscribers?(state),
+          do: state,
+          else: %{state | idle_since: System.monotonic_time(:millisecond)}
 
-        state =
-          if no_subscribers?(state),
-            do: state,
-            else: %{state | idle_since: System.monotonic_time(:millisecond)}
-
-        {:noreply, state}
+      {:noreply, state}
     end
   end
 
   def handle_info(_other, state), do: {:noreply, state}
 
   # ---- internals ---------------------------------------------------------
+
+  defp schedule_poll(%{poll_interval_ms: interval}), do: Process.send_after(self(), :poll, interval)
 
   defp poll(%{path: path, offset: offset} = state) do
     case File.stat(path) do
@@ -227,20 +239,15 @@ defmodule SymphonyElixirWeb.CodexTailServer do
   end
 
   defp no_subscribers?(%{pubsub: pubsub, rollout_id: rid}) do
-    case Registry.lookup(pubsub_registry(pubsub), topic(rid)) do
+    case Registry.lookup(pubsub, topic(rid)) do
       [] -> true
       _ -> false
     end
   rescue
-    # If the PubSub adapter doesn't expose a Registry, fall back to "always
-    # has subscribers" — the idle-timeout still bounds memory because the
-    # supervisor restarts the tailer on demand.
-    _ -> false
+    _ -> true
   end
 
-  defp pubsub_registry(pubsub), do: Module.concat(pubsub, "Registry")
-
-  defp idle_too_long?(%{idle_since: since}) do
-    System.monotonic_time(:millisecond) - since > @idle_timeout_ms
+  defp idle_too_long?(%{idle_since: since, idle_timeout_ms: timeout}) do
+    System.monotonic_time(:millisecond) - since > timeout
   end
 end

--- a/elixir/lib/symphony_elixir_web/live/codex_tail_server.ex
+++ b/elixir/lib/symphony_elixir_web/live/codex_tail_server.ex
@@ -1,0 +1,244 @@
+defmodule SymphonyElixirWeb.CodexTailServer do
+  @moduledoc """
+  Per-rollout GenServer that tails a Codex JSONL rollout file and broadcasts
+  new conversation items to subscribers over `Phoenix.PubSub`.
+
+  ## Why poll instead of a file watcher?
+
+  Codex writes lines as the session progresses. We could subscribe to OS-level
+  filesystem events (`:file_system`), but for the dashboard's needs a small
+  polling interval is simpler, watcher-less, cross-platform, and avoids a new
+  dependency. The polling interval is short enough (~250ms) that the
+  perceived latency is well under the round-trip a human would notice.
+
+  ## Lifecycle
+
+  Started on demand via `start/1`. Stops itself when no subscribers remain
+  for `@idle_timeout_ms` after a tick (so abandoned LiveView mounts don't
+  keep file handles forever).
+
+  ## Topic
+
+  Subscribers listen on `Phoenix.PubSub` topic
+  `"codex_rollout:" <> rollout_id`. Each new line projects through
+  `RolloutReader.to_conversation_item/1`; non-nil items are broadcast as
+  `{:rollout_item, rollout_id, item}`. We also broadcast
+  `{:rollout_state, rollout_id, :truncated}` if the file shrinks
+  (Codex compaction or file rotation), so the LiveView can re-load.
+  """
+
+  use GenServer
+  require Logger
+
+  alias Phoenix.PubSub
+  alias SymphonyElixir.Codex.RolloutReader
+
+  @poll_interval_ms 250
+  @idle_timeout_ms 30_000
+
+  # ---- API ---------------------------------------------------------------
+
+  @spec topic(String.t()) :: String.t()
+  def topic(rollout_id), do: "codex_rollout:" <> rollout_id
+
+  @doc """
+  Start (or look up) a tail server for the given rollout id.
+
+  `opts`:
+    * `:rollout_id` (required) — usually the JSONL file path or a session id
+    * `:path` (required) — absolute path to the rollout file
+    * `:pubsub` — defaults to `SymphonyElixir.PubSub`
+    * `:supervisor` — defaults to `SymphonyElixirWeb.CodexTailSupervisor`
+  """
+  @spec start(keyword()) :: {:ok, pid()} | {:error, term()}
+  def start(opts) do
+    rollout_id = Keyword.fetch!(opts, :rollout_id)
+    sup = Keyword.get(opts, :supervisor, SymphonyElixirWeb.CodexTailSupervisor)
+    name = via(rollout_id)
+
+    case GenServer.whereis(name) do
+      pid when is_pid(pid) ->
+        {:ok, pid}
+
+      _ ->
+        DynamicSupervisor.start_child(sup, {__MODULE__, opts})
+    end
+  end
+
+  @doc """
+  Subscribe the calling process to a rollout's events. Starts the tailer
+  on demand.
+  """
+  @spec subscribe(keyword()) :: :ok | {:error, term()}
+  def subscribe(opts) do
+    rollout_id = Keyword.fetch!(opts, :rollout_id)
+    pubsub = Keyword.get(opts, :pubsub, SymphonyElixir.PubSub)
+
+    with {:ok, _pid} <- start(opts),
+         :ok <- PubSub.subscribe(pubsub, topic(rollout_id)) do
+      :ok
+    end
+  end
+
+  @spec unsubscribe(keyword()) :: :ok
+  def unsubscribe(opts) do
+    rollout_id = Keyword.fetch!(opts, :rollout_id)
+    pubsub = Keyword.get(opts, :pubsub, SymphonyElixir.PubSub)
+    PubSub.unsubscribe(pubsub, topic(rollout_id))
+  end
+
+  def child_spec(opts) do
+    %{
+      id: {__MODULE__, Keyword.fetch!(opts, :rollout_id)},
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :temporary,
+      shutdown: 5_000
+    }
+  end
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    rollout_id = Keyword.fetch!(opts, :rollout_id)
+    GenServer.start_link(__MODULE__, opts, name: via(rollout_id))
+  end
+
+  defp via(rollout_id), do: {:via, Registry, {SymphonyElixirWeb.CodexTailRegistry, rollout_id}}
+
+  # ---- GenServer ---------------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    state = %{
+      rollout_id: Keyword.fetch!(opts, :rollout_id),
+      path: Keyword.fetch!(opts, :path),
+      pubsub: Keyword.get(opts, :pubsub, SymphonyElixir.PubSub),
+      offset: 0,
+      idle_since: System.monotonic_time(:millisecond)
+    }
+
+    Process.send_after(self(), :poll, @poll_interval_ms)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:poll, state) do
+    state = poll(state)
+
+    cond do
+      no_subscribers?(state) and idle_too_long?(state) ->
+        {:stop, :normal, state}
+
+      true ->
+        Process.send_after(self(), :poll, @poll_interval_ms)
+        state =
+          if no_subscribers?(state),
+            do: state,
+            else: %{state | idle_since: System.monotonic_time(:millisecond)}
+
+        {:noreply, state}
+    end
+  end
+
+  def handle_info(_other, state), do: {:noreply, state}
+
+  # ---- internals ---------------------------------------------------------
+
+  defp poll(%{path: path, offset: offset} = state) do
+    case File.stat(path) do
+      {:ok, %File.Stat{size: size}} when size < offset ->
+        # File was truncated/rotated. Tell subscribers to reload from scratch.
+        broadcast(state, {:rollout_state, state.rollout_id, :truncated})
+        %{state | offset: 0}
+
+      {:ok, %File.Stat{size: size}} when size > offset ->
+        read_new_lines(state, size)
+
+      _ ->
+        state
+    end
+  end
+
+  defp read_new_lines(%{path: path, offset: offset} = state, size) do
+    case File.open(path, [:read, :binary]) do
+      {:ok, io} ->
+        try do
+          {:ok, _} = :file.position(io, offset)
+          read_loop(io, state, size)
+        after
+          File.close(io)
+        end
+
+      {:error, reason} ->
+        Logger.debug("codex_tail: open failed for #{path}: #{inspect(reason)}")
+        state
+    end
+  end
+
+  defp read_loop(io, state, target) do
+    case IO.binread(io, :line) do
+      :eof ->
+        # Re-stat in case the file grew while we were reading.
+        case :file.position(io, :cur) do
+          {:ok, pos} -> %{state | offset: max(pos, target)}
+          _ -> %{state | offset: target}
+        end
+
+      {:error, _} ->
+        state
+
+      line when is_binary(line) ->
+        case decode_and_project(line, state.path) do
+          nil -> :ok
+          item -> broadcast(state, {:rollout_item, state.rollout_id, item})
+        end
+
+        read_loop(io, state, target)
+    end
+  end
+
+  defp decode_and_project(line, path) do
+    case parse_line(line, path) do
+      nil -> nil
+      parsed -> RolloutReader.to_conversation_item(parsed)
+    end
+  end
+
+  # Mirrors `RolloutReader.decode_line/2`'s behaviour but is intentionally
+  # local so the tail server doesn't depend on private parsing helpers.
+  defp parse_line(line, _path) do
+    trimmed = String.trim(line)
+
+    if trimmed == "" do
+      nil
+    else
+      case Jason.decode(trimmed) do
+        {:ok, %{"type" => "session_meta"} = obj} -> {:meta, obj}
+        {:ok, %{"type" => "event_msg"} = obj} -> {:event, obj}
+        {:ok, %{"type" => "response_item"} = obj} -> {:response, obj}
+        _ -> nil
+      end
+    end
+  end
+
+  defp broadcast(%{pubsub: pubsub, rollout_id: rid}, message) do
+    PubSub.broadcast(pubsub, topic(rid), message)
+  end
+
+  defp no_subscribers?(%{pubsub: pubsub, rollout_id: rid}) do
+    case Registry.lookup(pubsub_registry(pubsub), topic(rid)) do
+      [] -> true
+      _ -> false
+    end
+  rescue
+    # If the PubSub adapter doesn't expose a Registry, fall back to "always
+    # has subscribers" — the idle-timeout still bounds memory because the
+    # supervisor restarts the tailer on demand.
+    _ -> false
+  end
+
+  defp pubsub_registry(pubsub), do: Module.concat(pubsub, "Registry")
+
+  defp idle_too_long?(%{idle_since: since}) do
+    System.monotonic_time(:millisecond) - since > @idle_timeout_ms
+  end
+end

--- a/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
@@ -120,140 +120,6 @@ defmodule SymphonyElixirWeb.DashboardLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <%= if @live_action == :worker_detail do %>
-      <section class="dashboard-shell">
-        <header class="hero-card">
-          <div class="hero-grid">
-            <div>
-              <p class="eyebrow">Worker Detail</p>
-              <h1 class="hero-title"><%= @issue_identifier %></h1>
-              <p class="hero-copy">Agent conversation view for the active Symphony worker session.</p>
-            </div>
-            <div class="status-stack">
-              <a class="subtle-button" href="/">Dashboard</a>
-            </div>
-          </div>
-        </header>
-
-        <%= if @detail_error do %>
-          <section class="error-card">
-            <h2 class="error-title">Worker unavailable</h2>
-            <p class="error-copy"><%= @detail_error %></p>
-          </section>
-        <% else %>
-          <% detail = @detail_payload %>
-          <% running =
-            detail.running ||
-              %{
-                state: detail.status,
-                session_id: nil,
-                turn_count: 0,
-                tokens: %{input_tokens: nil, output_tokens: nil, total_tokens: nil}
-              } %>
-
-          <section class="worker-detail-workspace">
-            <aside class="worker-status-sidebar">
-              <div class="sidebar-section">
-                <p class="metric-label">State</p>
-                <p class="metric-value"><%= running.state %></p>
-                <p class="metric-detail"><%= detail.title || detail.issue_identifier %></p>
-              </div>
-              <div class="sidebar-section">
-                <p class="metric-label">Session</p>
-                <p class="metric-value mono detail-session"><%= running.session_id || "n/a" %></p>
-                <p class="metric-detail">Turn <%= running.turn_count %></p>
-              </div>
-              <div class="sidebar-section">
-                <p class="metric-label">Workspace</p>
-                <p class="metric-value detail-path"><%= detail.workspace.path %></p>
-                <p class="metric-detail"><%= detail.workspace.host || "local" %></p>
-              </div>
-              <div class="sidebar-section">
-                <p class="metric-label">Branch / Checks</p>
-                <p class="metric-value detail-path"><%= detail.workspace.branch || "branch unknown" %></p>
-                <p class="metric-detail">
-                  <%= cond do %>
-                    <% detail.pull_request && detail.checks -> %>
-                      <%= detail.pull_request.url %> · checks <%= detail.checks.summary %>
-                    <% detail.pull_request -> %>
-                      <%= detail.pull_request.url %> · checks unknown
-                    <% true -> %>
-                      PR/checks unavailable
-                  <% end %>
-                </p>
-              </div>
-              <details class="debug-drawer">
-                <summary>Worker debug payload</summary>
-                <pre class="code-panel"><%= detail.debug.payload_excerpt %><%= if detail.debug.payload_truncated?, do: "\n[truncated]" %></pre>
-              </details>
-            </aside>
-
-            <section class="agent-panel">
-              <div class="agent-panel-header">
-                <div>
-                  <h2 class="section-title">Agent Messages</h2>
-                  <p class="section-copy">
-                    <%= if detail.running do %>
-                      <%= if @steer_auth_required and not @steer_token_configured do %>
-                        Steering is locked because this dashboard is exposed without an operator token.
-                      <% else %>
-                        Completed agent messages for this worker session.
-                      <% end %>
-                    <% else %>
-                      This worker is not running, so steering is disabled.
-                    <% end %>
-                  </p>
-                </div>
-                <span class="state-badge"><%= length(detail.conversation) %> messages</span>
-              </div>
-
-              <div id="worker-conversation-scroll" class="conversation-scroll" phx-hook="AutoScroll">
-                <%= if detail.conversation == [] do %>
-                  <p class="empty-state">No completed agent messages yet.</p>
-                <% else %>
-                  <ol class="conversation-list">
-                    <li :for={item <- detail.conversation} class={conversation_item_class(item)}>
-                      <div class="conversation-meta">
-                        <span><%= item.title %></span>
-                        <span class="mono"><%= item.at || "pending" %></span>
-                      </div>
-                      <p class="message-bubble-text"><%= item.excerpt || "Worker update" %></p>
-                    </li>
-                  </ol>
-                <% end %>
-              </div>
-
-              <.form for={%{}} as={:steer} phx-submit="steer" class="composer-form">
-                <input type="hidden" name="steer[session_id]" value={running.session_id || ""} />
-                <%= if @steer_auth_required and @steer_token_configured do %>
-                  <input
-                    type="password"
-                    name="steer[operator_token]"
-                    class="steer-token"
-                    placeholder="Operator token"
-                    autocomplete="off"
-                    disabled={is_nil(running.session_id)}
-                  />
-                <% end %>
-                <div class="composer-row">
-                  <textarea
-                    name="steer[message]"
-                    class="composer-input"
-                    rows="2"
-                    placeholder="Send a targeted instruction to this running worker"
-                    disabled={is_nil(running.session_id) or steer_locked?(@steer_auth_required, @steer_token_configured)}
-                  ></textarea>
-                  <button
-                    type="submit"
-                    disabled={is_nil(running.session_id) or steer_locked?(@steer_auth_required, @steer_token_configured)}
-                  >Send</button>
-                </div>
-              </.form>
-            </section>
-          </section>
-        <% end %>
-      </section>
-    <% else %>
     <section class="dashboard-shell">
       <header class="hero-card">
         <div class="hero-grid">
@@ -606,7 +472,6 @@ defmodule SymphonyElixirWeb.DashboardLive do
         </section>
       <% end %>
     </section>
-    <% end %>
     """
   end
 
@@ -686,9 +551,6 @@ defmodule SymphonyElixirWeb.DashboardLive do
 
   defp non_blank_binary?(value) when is_binary(value), do: String.trim(value) != ""
   defp non_blank_binary?(_value), do: false
-
-  defp steer_locked?(true, false), do: true
-  defp steer_locked?(_required, _configured), do: false
 
   defp total_runtime_seconds(payload, now) do
     base_seconds = payload.codex_totals.seconds_running || 0
@@ -1060,9 +922,6 @@ defmodule SymphonyElixirWeb.DashboardLive do
   end
 
   defp format_watchdog_age(_age_ms), do: "n/a"
-
-  defp conversation_item_class(%{type: "assistant"}), do: "conversation-item conversation-item-assistant"
-  defp conversation_item_class(_item), do: "conversation-item conversation-item-system"
 
   defp schedule_runtime_tick do
     Process.send_after(self(), :runtime_tick, @runtime_tick_ms)

--- a/elixir/lib/symphony_elixir_web/live/worker_detail_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/worker_detail_live.ex
@@ -1,0 +1,703 @@
+defmodule SymphonyElixirWeb.WorkerDetailLive do
+  @moduledoc """
+  Worker Details page — chat-style view of a Codex worker session backed by
+  on-disk Codex rollout JSONL files.
+
+  ## Why this is its own module (vs staying in DashboardLive)
+
+  The detail action grew complex enough — sidebar, tabs, streamed transcript,
+  per-rollout PubSub subscriptions, file-tail server lifecycle — that mixing
+  it with the index dashboard was hurting both. Splitting follows the
+  general LiveView guidance of one module per route.
+
+  ## Data flow
+
+  ```
+  mount -> Presenter.issue_payload/3 (orchestrator + RolloutIndex fallback)
+        -> assigns: detail_payload, rollouts list, current_rollout
+        -> stream :transcript = RolloutReader.stream(current_rollout.path)
+                                |> map(to_conversation_item) |> reject(nil)
+        -> CodexTailServer.subscribe(rollout_id: ..., path: ...)
+  ```
+
+  Live updates arrive as `{:rollout_item, _, item}` and are streamed in
+  with `phx-update="stream"`. Switching rollouts is a `stream(..., reset:
+  true)` plus an unsubscribe/subscribe cycle.
+
+  Hidden by design: developer/system role messages, low-signal protocol
+  events. The classifier in `RolloutReader.to_conversation_item/1` is the
+  single source of truth for that taxonomy.
+  """
+
+  use Phoenix.LiveView, layout: {SymphonyElixirWeb.Layouts, :app}
+
+  alias SymphonyElixir.Codex.RolloutReader
+  alias SymphonyElixirWeb.{CodexTailServer, Endpoint, ObservabilityPubSub, Presenter}
+
+  @runtime_tick_ms 1_000
+
+  @impl true
+  def mount(%{"issue_identifier" => issue_identifier} = params, _session, socket) do
+    socket =
+      socket
+      |> assign(:issue_identifier, issue_identifier)
+      |> assign(:tab, normalize_tab(params["tab"]))
+      |> assign(:detail_payload, nil)
+      |> assign(:detail_error, nil)
+      |> assign(:current_rollout, nil)
+      |> assign(:rollouts, [])
+      |> assign(:transcript_count, 0)
+      |> assign(:steer_auth_required, steer_auth_required?())
+      |> assign(:steer_token_configured, steer_token_configured?())
+      |> assign(:now, DateTime.utc_now())
+      |> stream(:transcript, [])
+
+    socket =
+      if connected?(socket) do
+        :ok = ObservabilityPubSub.subscribe()
+        schedule_runtime_tick()
+        load_detail(socket, params["rollout"])
+      else
+        socket
+      end
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    socket =
+      socket
+      |> assign(:tab, normalize_tab(params["tab"]))
+      |> maybe_switch_rollout(params["rollout"])
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_info(:runtime_tick, socket) do
+    schedule_runtime_tick()
+    {:noreply, assign(socket, :now, DateTime.utc_now())}
+  end
+
+  def handle_info(:observability_updated, socket) do
+    # Refresh sidebar / sidebar metrics; do not reset the transcript stream.
+    {:noreply, refresh_payload(socket)}
+  end
+
+  def handle_info({:rollout_item, rid, item}, socket) do
+    if current_rollout_id(socket) == rid do
+      {:noreply,
+       socket
+       |> stream_insert(:transcript, conversation_item_to_row(item, socket.assigns.transcript_count))
+       |> update(:transcript_count, &(&1 + 1))}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_info({:rollout_state, rid, :truncated}, socket) do
+    if current_rollout_id(socket) == rid,
+      do: {:noreply, reload_transcript(socket)},
+      else: {:noreply, socket}
+  end
+
+  def handle_info(_other, socket), do: {:noreply, socket}
+
+  # ---- events ------------------------------------------------------------
+
+  @impl true
+  def handle_event("steer", %{"steer" => steer_params}, socket) do
+    issue_identifier = socket.assigns.issue_identifier
+    message = Map.get(steer_params, "message", "")
+    session_id = Map.get(steer_params, "session_id")
+    operator_token = Map.get(steer_params, "operator_token")
+
+    case authorize_steer(operator_token) do
+      :ok -> submit_steer(socket, issue_identifier, message, session_id)
+      {:error, reason} -> {:noreply, put_flash(socket, :error, steer_error_message(reason))}
+    end
+  end
+
+  defp submit_steer(socket, issue_identifier, message, session_id) do
+    cond do
+      not non_blank_binary?(message) ->
+        {:noreply, put_flash(socket, :error, steer_error_message(:blank_message))}
+
+      not non_blank_binary?(session_id) ->
+        {:noreply, put_flash(socket, :error, steer_error_message(:session_mismatch))}
+
+      true ->
+        case Presenter.steer_payload(issue_identifier, message, session_id, orchestrator()) do
+          {:ok, _payload} ->
+            {:noreply, put_flash(socket, :info, "Steer queued for #{issue_identifier}.")}
+
+          {:error, reason} ->
+            {:noreply, put_flash(socket, :error, steer_error_message(reason))}
+        end
+    end
+  end
+
+  # ---- view --------------------------------------------------------------
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <section class="worker-shell">
+      <header class="worker-header">
+        <a class="worker-back" href="/">‹ Dashboard</a>
+        <span class="worker-id"><%= @issue_identifier %></span>
+        <%= if @detail_payload do %>
+          <span class="worker-title"><%= @detail_payload.title || @detail_payload.workspace.path %></span>
+          <span class={state_badge_class(@detail_payload.status)}><%= @detail_payload.status %></span>
+          <%= if @detail_payload.status in ["running", "retrying"] do %>
+            <span class="worker-live"><span class="worker-live-dot"></span>live</span>
+          <% end %>
+        <% end %>
+      </header>
+
+      <%= if @detail_error do %>
+        <section class="worker-error">
+          <h2 class="error-title">Worker unavailable</h2>
+          <p class="error-copy"><%= @detail_error %></p>
+        </section>
+      <% else %>
+        <% detail = @detail_payload || empty_detail(@issue_identifier) %>
+
+        <div class="worker-grid">
+          <aside class="worker-sidebar">
+            <section class="worker-sidebar-section">
+              <h3 class="worker-section-title">Rollouts</h3>
+              <%= if @rollouts == [] do %>
+                <p class="worker-section-empty">No rollouts on disk.</p>
+              <% else %>
+                <ol class="rollout-list">
+                  <li
+                    :for={r <- @rollouts}
+                    class={["rollout-row", current_rollout_class(@current_rollout, r)]}
+                  >
+                    <a
+                      class="rollout-link"
+                      href={rollout_link(@issue_identifier, r, @tab)}
+                    >
+                      <span class="rollout-row-title"><%= rollout_label(r) %></span>
+                      <span class="rollout-row-meta"><%= r.started_at || "—" %></span>
+                    </a>
+                  </li>
+                </ol>
+              <% end %>
+            </section>
+
+            <section class="worker-sidebar-section">
+              <h3 class="worker-section-title">Status</h3>
+              <dl class="worker-kv">
+                <div><dt>State</dt><dd><%= detail.status %></dd></div>
+                <div><dt>Session</dt><dd class="mono"><%= session_id_label(detail) %></dd></div>
+                <div><dt>Turn</dt><dd><%= turn_label(detail) %></dd></div>
+                <div><dt>Branch</dt><dd class="detail-path"><%= detail.workspace.branch || "—" %></dd></div>
+                <div><dt>Workspace</dt><dd class="detail-path"><%= detail.workspace.path || "—" %></dd></div>
+                <div :if={detail.pull_request}><dt>PR</dt><dd><a href={detail.pull_request.url} target="_blank" rel="noopener"><%= detail.pull_request.url %></a></dd></div>
+                <div :if={tokens(detail)}><dt>Tokens</dt><dd class="numeric"><%= format_tokens(tokens(detail)) %></dd></div>
+              </dl>
+            </section>
+          </aside>
+
+          <section class="worker-main">
+            <nav class="worker-tabs" aria-label="Worker views">
+              <a
+                :for={tab <- tabs()}
+                class={tab_class(@tab, tab.id)}
+                href={tab_link(@issue_identifier, @current_rollout, tab.id)}
+              ><%= tab.label %></a>
+            </nav>
+
+            <%= case @tab do %>
+              <% :transcript -> %>
+                <.transcript_panel
+                  detail={detail}
+                  current_rollout={@current_rollout}
+                  transcript_count={@transcript_count}
+                  steer_auth_required={@steer_auth_required}
+                  steer_token_configured={@steer_token_configured}
+                  streams={@streams}
+                />
+
+              <% :logs -> %>
+                <.logs_panel detail={detail} />
+
+              <% :workspace -> %>
+                <.workspace_panel detail={detail} />
+
+              <% :pr -> %>
+                <.pr_panel detail={detail} />
+            <% end %>
+          </section>
+        </div>
+      <% end %>
+    </section>
+    """
+  end
+
+  # ---- panels ------------------------------------------------------------
+
+  attr :detail, :map, required: true
+  attr :current_rollout, :map, default: nil
+  attr :transcript_count, :integer, default: 0
+  attr :steer_auth_required, :boolean, required: true
+  attr :steer_token_configured, :boolean, required: true
+  attr :streams, :map, required: true
+
+  defp transcript_panel(assigns) do
+    ~H"""
+    <div class="transcript-shell">
+      <div class="transcript-meta">
+        <span><%= @transcript_count %> items</span>
+        <%= if @current_rollout do %>
+          · <span class="mono"><%= rollout_label(@current_rollout) %></span>
+          <%= if @current_rollout.started_at do %>
+            · <span class="mono"><%= @current_rollout.started_at %></span>
+          <% end %>
+        <% end %>
+      </div>
+
+      <div
+        id="worker-transcript-scroll"
+        class="transcript-scroll"
+        phx-hook="StickyScroll"
+      >
+        <ol id="worker-transcript" phx-update="stream" class="transcript">
+          <%= if @transcript_count == 0 and @current_rollout == nil do %>
+            <li id="transcript-empty" class="transcript-empty">No rollout selected. The orchestrator has nothing on disk for this issue yet.</li>
+          <% end %>
+          <li
+            :for={{dom_id, item} <- @streams.transcript}
+            id={dom_id}
+            class={["transcript-item", "tr-" <> Atom.to_string(item.kind)]}
+          >
+            <div class="transcript-marker"><%= marker_for(item.kind) %></div>
+            <div class="transcript-body">
+              <div class="transcript-meta-row">
+                <span class="transcript-kind"><%= label_for(item.kind) %></span>
+                <span class="transcript-time mono"><%= format_at(item.at) %></span>
+              </div>
+              <%= cond do %>
+                <% item.kind == :reasoning and String.length(item.text) > 200 -> %>
+                  <details class="transcript-details">
+                    <summary class="transcript-summary"><%= preview_text(item.text) %></summary>
+                    <pre class="transcript-pre"><%= item.text %></pre>
+                  </details>
+                <% item.kind == :tool_call -> %>
+                  <details class="transcript-details">
+                    <summary class="transcript-summary"><%= item.text %></summary>
+                    <pre class="transcript-pre"><%= format_tool_meta(item) %></pre>
+                  </details>
+                <% true -> %>
+                  <p class="transcript-text"><%= item.text %></p>
+              <% end %>
+            </div>
+          </li>
+        </ol>
+      </div>
+
+      <%= if @detail.running do %>
+        <.form for={%{}} as={:steer} phx-submit="steer" class="composer-form">
+          <input type="hidden" name="steer[session_id]" value={session_id_or_empty(@detail)} />
+          <%= if @steer_auth_required and @steer_token_configured do %>
+            <input
+              type="password"
+              name="steer[operator_token]"
+              class="steer-token"
+              placeholder="Operator token"
+              autocomplete="off"
+            />
+          <% end %>
+          <div class="composer-row">
+            <textarea
+              name="steer[message]"
+              class="composer-input"
+              rows="2"
+              placeholder="Steer the agent…"
+              disabled={steer_locked?(@steer_auth_required, @steer_token_configured)}
+            ></textarea>
+            <button type="submit" disabled={steer_locked?(@steer_auth_required, @steer_token_configured)}>Send</button>
+          </div>
+        </.form>
+      <% else %>
+        <p class="composer-disabled">Worker is not running — steering is disabled.</p>
+      <% end %>
+    </div>
+    """
+  end
+
+  attr :detail, :map, required: true
+
+  defp logs_panel(assigns) do
+    ~H"""
+    <div class="panel-shell">
+      <h3 class="worker-section-title">Codex session logs</h3>
+      <%= if logs(@detail) == [] do %>
+        <p class="empty-state">No logs registered for this issue.</p>
+      <% else %>
+        <ul class="log-list">
+          <li :for={log <- logs(@detail)}>
+            <span class="mono"><%= log.label || "(unnamed)" %></span>
+            <code class="detail-path"><%= log.path %></code>
+          </li>
+        </ul>
+      <% end %>
+    </div>
+    """
+  end
+
+  attr :detail, :map, required: true
+
+  defp workspace_panel(assigns) do
+    ~H"""
+    <div class="panel-shell">
+      <h3 class="worker-section-title">Workspace</h3>
+      <dl class="worker-kv worker-kv-wide">
+        <div><dt>Path</dt><dd class="detail-path"><%= @detail.workspace.path || "—" %></dd></div>
+        <div><dt>Host</dt><dd><%= @detail.workspace.host || "local" %></dd></div>
+        <div><dt>Branch</dt><dd class="detail-path"><%= @detail.workspace.branch || "—" %></dd></div>
+      </dl>
+    </div>
+    """
+  end
+
+  attr :detail, :map, required: true
+
+  defp pr_panel(assigns) do
+    ~H"""
+    <div class="panel-shell">
+      <h3 class="worker-section-title">Pull request</h3>
+      <%= if @detail.pull_request do %>
+        <p><a href={@detail.pull_request.url} target="_blank" rel="noopener"><%= @detail.pull_request.url %></a></p>
+        <%= if @detail.checks do %>
+          <p class="muted">Checks: <%= inspect(@detail.checks.summary) %></p>
+        <% end %>
+      <% else %>
+        <p class="empty-state">No pull request linked.</p>
+      <% end %>
+    </div>
+    """
+  end
+
+  # ---- data helpers ------------------------------------------------------
+
+  defp load_detail(socket, requested_rollout) do
+    case Presenter.issue_payload(socket.assigns.issue_identifier, orchestrator(), snapshot_timeout_ms()) do
+      {:ok, payload} ->
+        rollouts = Map.get(payload, :rollouts, [])
+        current = pick_rollout(rollouts, requested_rollout) || Map.get(payload, :current_rollout)
+
+        socket
+        |> assign(:detail_payload, payload)
+        |> assign(:detail_error, nil)
+        |> assign(:rollouts, rollouts)
+        |> set_current_rollout(current)
+
+      {:error, :issue_not_found} ->
+        socket
+        |> assign(:detail_payload, nil)
+        |> assign(:detail_error, "No worker history found for #{socket.assigns.issue_identifier}.")
+    end
+  end
+
+  defp refresh_payload(socket) do
+    case Presenter.issue_payload(socket.assigns.issue_identifier, orchestrator(), snapshot_timeout_ms()) do
+      {:ok, payload} ->
+        socket
+        |> assign(:detail_payload, payload)
+        |> assign(:rollouts, Map.get(payload, :rollouts, []))
+
+      {:error, _} ->
+        socket
+    end
+  end
+
+  defp maybe_switch_rollout(socket, requested) do
+    target = pick_rollout(socket.assigns.rollouts, requested) || socket.assigns.current_rollout
+
+    cond do
+      is_nil(target) -> socket
+      same_rollout?(socket.assigns.current_rollout, target) -> socket
+      true -> set_current_rollout(socket, target)
+    end
+  end
+
+  defp set_current_rollout(socket, nil) do
+    socket
+    |> assign(:current_rollout, nil)
+    |> stream(:transcript, [], reset: true)
+    |> assign(:transcript_count, 0)
+  end
+
+  defp set_current_rollout(socket, rollout) do
+    previous = socket.assigns.current_rollout
+    rid = rollout_id(rollout)
+
+    if previous && rollout_id(previous) != rid do
+      _ = CodexTailServer.unsubscribe(rollout_id: rollout_id(previous))
+    end
+
+    items = load_initial_items(rollout)
+
+    rows =
+      items
+      |> Enum.with_index()
+      |> Enum.map(fn {item, idx} -> conversation_item_to_row(item, idx) end)
+
+    if connected?(socket) do
+      _ = CodexTailServer.subscribe(rollout_id: rid, path: rollout.path)
+    end
+
+    socket
+    |> assign(:current_rollout, rollout)
+    |> stream(:transcript, rows, reset: true)
+    |> assign(:transcript_count, length(rows))
+  end
+
+  defp reload_transcript(socket) do
+    case socket.assigns.current_rollout do
+      nil -> socket
+      rollout -> set_current_rollout(socket, rollout)
+    end
+  end
+
+  defp load_initial_items(rollout) do
+    rollout.path
+    |> RolloutReader.stream()
+    |> Stream.map(&RolloutReader.to_conversation_item/1)
+    |> Stream.reject(&is_nil/1)
+    |> Enum.to_list()
+  rescue
+    _ -> []
+  end
+
+  defp conversation_item_to_row(item, idx) do
+    Map.put(item, :id, "tr-#{idx}-#{System.unique_integer([:positive])}")
+  end
+
+  defp pick_rollout(_rollouts, nil), do: nil
+
+  defp pick_rollout(rollouts, requested) do
+    Enum.find(rollouts, fn r -> rollout_id(r) == requested end)
+  end
+
+  defp rollout_id(%{session_id: sid}) when is_binary(sid), do: sid
+  defp rollout_id(%{path: path}) when is_binary(path), do: Path.basename(path)
+  defp rollout_id(_), do: nil
+
+  defp current_rollout_id(socket), do: rollout_id(socket.assigns.current_rollout)
+
+  defp same_rollout?(a, b), do: rollout_id(a) == rollout_id(b)
+
+  defp rollout_label(%{session_id: sid}) when is_binary(sid),
+    do: String.slice(sid, 0, 8)
+
+  defp rollout_label(%{path: path}) when is_binary(path), do: Path.basename(path)
+  defp rollout_label(_), do: "(unknown)"
+
+  defp current_rollout_class(nil, _), do: ""
+  defp current_rollout_class(current, row), do: if(rollout_id(current) == rollout_id(row), do: "rollout-row-active", else: "")
+
+  defp tabs do
+    [
+      %{id: :transcript, label: "Transcript"},
+      %{id: :logs, label: "Logs"},
+      %{id: :workspace, label: "Workspace"},
+      %{id: :pr, label: "PR & Linear"}
+    ]
+  end
+
+  defp tab_class(current, current), do: "worker-tab worker-tab-active"
+  defp tab_class(_, _), do: "worker-tab"
+
+  defp normalize_tab("logs"), do: :logs
+  defp normalize_tab("workspace"), do: :workspace
+  defp normalize_tab("pr"), do: :pr
+  defp normalize_tab(_), do: :transcript
+
+  defp tab_link(issue, rollout, tab) do
+    base = "/workers/#{issue}"
+    qs = build_qs(rollout, tab)
+    if qs == "", do: base, else: base <> "?" <> qs
+  end
+
+  defp rollout_link(issue, rollout, tab) do
+    qs = build_qs(rollout, tab)
+    "/workers/#{issue}" <> if qs == "", do: "", else: "?" <> qs
+  end
+
+  defp build_qs(rollout, tab) do
+    parts =
+      []
+      |> maybe_add_param("rollout", rollout && rollout_id(rollout))
+      |> maybe_add_param("tab", if(tab == :transcript, do: nil, else: Atom.to_string(tab)))
+
+    Enum.join(parts, "&")
+  end
+
+  defp maybe_add_param(parts, _key, nil), do: parts
+  defp maybe_add_param(parts, key, value), do: parts ++ ["#{key}=#{URI.encode_www_form(to_string(value))}"]
+
+  defp empty_detail(issue) do
+    %{
+      issue_identifier: issue,
+      status: "unknown",
+      title: nil,
+      workspace: %{path: nil, host: nil, branch: nil},
+      pull_request: nil,
+      checks: nil,
+      running: nil,
+      logs: %{codex_session_logs: []}
+    }
+  end
+
+  defp marker_for(:assistant_message), do: "▸"
+  defp marker_for(:user_message), do: "↪"
+  defp marker_for(:tool_call), do: "⌘"
+  defp marker_for(:reasoning), do: "·"
+  defp marker_for(:state_change), do: "—"
+  defp marker_for(:error), do: "⚠"
+  defp marker_for(_), do: "·"
+
+  defp label_for(:assistant_message), do: "Agent"
+  defp label_for(:user_message), do: "You"
+  defp label_for(:tool_call), do: "tool"
+  defp label_for(:reasoning), do: "thought"
+  defp label_for(:state_change), do: "state"
+  defp label_for(:error), do: "error"
+  defp label_for(other), do: Atom.to_string(other)
+
+  defp format_at(nil), do: "—"
+  defp format_at(%DateTime{} = dt), do: Calendar.strftime(dt, "%H:%M:%S")
+
+  defp preview_text(text) do
+    text
+    |> String.split("\n", parts: 2)
+    |> List.first()
+    |> String.slice(0, 200)
+    |> Kernel.<>(" ▾")
+  end
+
+  defp format_tool_meta(%{meta: %{is_output: true}, text: text}), do: text
+
+  defp format_tool_meta(%{meta: meta}) when is_map(meta) do
+    args =
+      case meta[:arguments] do
+        a when is_binary(a) -> a
+        a when is_map(a) -> Jason.encode!(a, pretty: true)
+        a -> inspect(a)
+      end
+
+    "name: #{meta[:name] || "?"}\ncall_id: #{meta[:call_id] || "?"}\narguments:\n#{args}"
+  end
+
+  defp format_tool_meta(%{text: text}), do: text
+
+  defp session_id_label(%{running: %{session_id: sid}}) when is_binary(sid), do: sid
+  defp session_id_label(_), do: "—"
+
+  defp turn_label(%{running: %{turn_count: n}}) when is_integer(n), do: Integer.to_string(n)
+  defp turn_label(_), do: "—"
+
+  defp tokens(%{running: %{tokens: t}}) when is_map(t), do: t
+  defp tokens(_), do: nil
+
+  defp format_tokens(%{input_tokens: i, output_tokens: o, total_tokens: t}) do
+    "#{format_int(t)} (in #{format_int(i)} / out #{format_int(o)})"
+  end
+
+  defp format_tokens(_), do: "—"
+
+  defp format_int(n) when is_integer(n), do: Integer.to_string(n)
+  defp format_int(_), do: "—"
+
+  defp logs(%{logs: %{codex_session_logs: list}}), do: list
+  defp logs(_), do: []
+
+  defp session_id_or_empty(%{running: %{session_id: sid}}) when is_binary(sid), do: sid
+  defp session_id_or_empty(_), do: ""
+
+  defp state_badge_class(state) do
+    base = "state-badge"
+    n = state |> to_string() |> String.downcase()
+
+    cond do
+      n in ["running", "active"] -> "#{base} state-badge-active"
+      n in ["retrying", "queued", "pending", "todo"] -> "#{base} state-badge-warning"
+      n in ["error", "failed", "blocked"] -> "#{base} state-badge-danger"
+      n == "ended" -> "#{base}"
+      true -> base
+    end
+  end
+
+  # ---- auth / config helpers --------------------------------------------
+
+  defp orchestrator do
+    Endpoint.config(:orchestrator) || SymphonyElixir.Orchestrator
+  end
+
+  defp snapshot_timeout_ms do
+    Endpoint.config(:snapshot_timeout_ms) || 15_000
+  end
+
+  defp steer_auth_required?, do: Endpoint.config(:steer_auth_required) == true
+
+  defp steer_token_configured? do
+    case Endpoint.config(:steer_token) do
+      token when is_binary(token) -> String.trim(token) != ""
+      _ -> false
+    end
+  end
+
+  defp authorize_steer(operator_token) do
+    if steer_auth_required?(), do: authorize_exposed_steer(operator_token), else: :ok
+  end
+
+  defp authorize_exposed_steer(operator_token) do
+    case Endpoint.config(:steer_token) do
+      token when is_binary(token) ->
+        case String.trim(token) do
+          "" -> {:error, :steer_auth_required}
+          expected -> compare_steer_token(operator_token, expected)
+        end
+
+      _ ->
+        {:error, :steer_auth_required}
+    end
+  end
+
+  defp compare_steer_token(operator_token, expected) do
+    submitted = String.trim(operator_token || "")
+
+    cond do
+      submitted == "" ->
+        {:error, :steer_auth_required}
+
+      byte_size(submitted) == byte_size(expected) and Plug.Crypto.secure_compare(submitted, expected) ->
+        :ok
+
+      true ->
+        {:error, :invalid_steer_token}
+    end
+  end
+
+  defp non_blank_binary?(value) when is_binary(value), do: String.trim(value) != ""
+  defp non_blank_binary?(_), do: false
+
+  defp steer_locked?(true, false), do: true
+  defp steer_locked?(_required, _configured), do: false
+
+  defp steer_error_message(:blank_message), do: "Steer message cannot be blank."
+  defp steer_error_message(:worker_not_running), do: "Worker is no longer running."
+  defp steer_error_message(:session_mismatch), do: "Worker session changed before the steer was sent."
+  defp steer_error_message(:steer_auth_required), do: "Operator token is required."
+  defp steer_error_message(:invalid_steer_token), do: "Operator token is invalid."
+  defp steer_error_message(reason), do: "Steer failed: #{inspect(reason)}"
+
+  defp schedule_runtime_tick do
+    Process.send_after(self(), :runtime_tick, @runtime_tick_ms)
+  end
+end

--- a/elixir/lib/symphony_elixir_web/live/worker_detail_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/worker_detail_live.ex
@@ -35,6 +35,7 @@ defmodule SymphonyElixirWeb.WorkerDetailLive do
   alias SymphonyElixirWeb.{CodexTailServer, Endpoint, ObservabilityPubSub, Presenter}
 
   @runtime_tick_ms 1_000
+  @transcript_limit 300
 
   @impl true
   def mount(%{"issue_identifier" => issue_identifier} = params, _session, socket) do
@@ -87,10 +88,12 @@ defmodule SymphonyElixirWeb.WorkerDetailLive do
 
   def handle_info({:rollout_item, rid, item}, socket) do
     if current_rollout_id(socket) == rid do
+      row = conversation_item_to_row(item, socket.assigns.transcript_count)
+
       {:noreply,
        socket
-       |> stream_insert(:transcript, conversation_item_to_row(item, socket.assigns.transcript_count))
-       |> update(:transcript_count, &(&1 + 1))}
+       |> stream_insert(:transcript, row, limit: -@transcript_limit)
+       |> update(:transcript_count, &min(&1 + 1, @transcript_limit))}
     else
       {:noreply, socket}
     end
@@ -445,6 +448,7 @@ defmodule SymphonyElixirWeb.WorkerDetailLive do
     end
 
     items = load_initial_items(rollout)
+    start_offset = file_size(rollout.path)
 
     rows =
       items
@@ -452,12 +456,12 @@ defmodule SymphonyElixirWeb.WorkerDetailLive do
       |> Enum.map(fn {item, idx} -> conversation_item_to_row(item, idx) end)
 
     if connected?(socket) do
-      _ = CodexTailServer.subscribe(rollout_id: rid, path: rollout.path)
+      _ = CodexTailServer.subscribe(rollout_id: rid, path: rollout.path, start_offset: start_offset)
     end
 
     socket
     |> assign(:current_rollout, rollout)
-    |> stream(:transcript, rows, reset: true)
+    |> stream(:transcript, rows, reset: true, limit: -@transcript_limit)
     |> assign(:transcript_count, length(rows))
   end
 
@@ -469,14 +473,17 @@ defmodule SymphonyElixirWeb.WorkerDetailLive do
   end
 
   defp load_initial_items(rollout) do
-    rollout.path
-    |> RolloutReader.stream()
-    |> Stream.map(&RolloutReader.to_conversation_item/1)
-    |> Stream.reject(&is_nil/1)
-    |> Enum.to_list()
-  rescue
-    _ -> []
+    RolloutReader.conversation_items(rollout.path, limit: @transcript_limit)
   end
+
+  defp file_size(path) when is_binary(path) do
+    case File.stat(path) do
+      {:ok, %File.Stat{size: size}} -> size
+      _ -> 0
+    end
+  end
+
+  defp file_size(_), do: 0
 
   defp conversation_item_to_row(item, idx) do
     Map.put(item, :id, "tr-#{idx}-#{System.unique_integer([:positive])}")

--- a/elixir/lib/symphony_elixir_web/live/worker_detail_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/worker_detail_live.ex
@@ -240,12 +240,12 @@ defmodule SymphonyElixirWeb.WorkerDetailLive do
 
   # ---- panels ------------------------------------------------------------
 
-  attr :detail, :map, required: true
-  attr :current_rollout, :map, default: nil
-  attr :transcript_count, :integer, default: 0
-  attr :steer_auth_required, :boolean, required: true
-  attr :steer_token_configured, :boolean, required: true
-  attr :streams, :map, required: true
+  attr(:detail, :map, required: true)
+  attr(:current_rollout, :map, default: nil)
+  attr(:transcript_count, :integer, default: 0)
+  attr(:steer_auth_required, :boolean, required: true)
+  attr(:steer_token_configured, :boolean, required: true)
+  attr(:streams, :map, required: true)
 
   defp transcript_panel(assigns) do
     ~H"""
@@ -333,7 +333,7 @@ defmodule SymphonyElixirWeb.WorkerDetailLive do
     """
   end
 
-  attr :detail, :map, required: true
+  attr(:detail, :map, required: true)
 
   defp logs_panel(assigns) do
     ~H"""
@@ -353,7 +353,7 @@ defmodule SymphonyElixirWeb.WorkerDetailLive do
     """
   end
 
-  attr :detail, :map, required: true
+  attr(:detail, :map, required: true)
 
   defp workspace_panel(assigns) do
     ~H"""
@@ -368,7 +368,7 @@ defmodule SymphonyElixirWeb.WorkerDetailLive do
     """
   end
 
-  attr :detail, :map, required: true
+  attr(:detail, :map, required: true)
 
   defp pr_panel(assigns) do
     ~H"""

--- a/elixir/lib/symphony_elixir_web/live/worker_detail_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/worker_detail_live.ex
@@ -299,31 +299,35 @@ defmodule SymphonyElixirWeb.WorkerDetailLive do
         </ol>
       </div>
 
-      <%= if @detail.running do %>
-        <.form for={%{}} as={:steer} phx-submit="steer" class="composer-form">
-          <input type="hidden" name="steer[session_id]" value={session_id_or_empty(@detail)} />
-          <%= if @steer_auth_required and @steer_token_configured do %>
-            <input
-              type="password"
-              name="steer[operator_token]"
-              class="steer-token"
-              placeholder="Operator token"
-              autocomplete="off"
-            />
-          <% end %>
-          <div class="composer-row">
-            <textarea
-              name="steer[message]"
-              class="composer-input"
-              rows="2"
-              placeholder="Steer the agent…"
-              disabled={steer_locked?(@steer_auth_required, @steer_token_configured)}
-            ></textarea>
-            <button type="submit" disabled={steer_locked?(@steer_auth_required, @steer_token_configured)}>Send</button>
-          </div>
-        </.form>
-      <% else %>
-        <p class="composer-disabled">Worker is not running — steering is disabled.</p>
+      <%= cond do %>
+        <% @steer_auth_required and not @steer_token_configured -> %>
+          <p class="composer-disabled">Steering is locked — this dashboard is exposed without an operator token.</p>
+
+        <% @detail.running -> %>
+          <.form for={%{}} as={:steer} phx-submit="steer" class="composer-form">
+            <input type="hidden" name="steer[session_id]" value={session_id_or_empty(@detail)} />
+            <%= if @steer_auth_required and @steer_token_configured do %>
+              <input
+                type="password"
+                name="steer[operator_token]"
+                class="steer-token"
+                placeholder="Operator token"
+                autocomplete="off"
+              />
+            <% end %>
+            <div class="composer-row">
+              <textarea
+                name="steer[message]"
+                class="composer-input"
+                rows="2"
+                placeholder="Steer the agent…"
+              ></textarea>
+              <button type="submit">Send</button>
+            </div>
+          </.form>
+
+        <% true -> %>
+          <p class="composer-disabled">Worker is not running — steering is disabled.</p>
       <% end %>
     </div>
     """
@@ -686,9 +690,6 @@ defmodule SymphonyElixirWeb.WorkerDetailLive do
 
   defp non_blank_binary?(value) when is_binary(value), do: String.trim(value) != ""
   defp non_blank_binary?(_), do: false
-
-  defp steer_locked?(true, false), do: true
-  defp steer_locked?(_required, _configured), do: false
 
   defp steer_error_message(:blank_message), do: "Steer message cannot be blank."
   defp steer_error_message(:worker_not_running), do: "Worker is no longer running."

--- a/elixir/lib/symphony_elixir_web/presenter.ex
+++ b/elixir/lib/symphony_elixir_web/presenter.ex
@@ -192,13 +192,11 @@ defmodule SymphonyElixirWeb.Presenter do
   end
 
   defp lookup_rollouts(issue_identifier) do
-    try do
-      RolloutIndex.lookup(issue_identifier)
-    rescue
-      _ -> []
-    catch
-      _, _ -> []
-    end
+    RolloutIndex.lookup(issue_identifier)
+  rescue
+    _ -> []
+  catch
+    _, _ -> []
   end
 
   defp attach_rollouts(payload, rollouts) do

--- a/elixir/lib/symphony_elixir_web/presenter.ex
+++ b/elixir/lib/symphony_elixir_web/presenter.ex
@@ -3,7 +3,7 @@ defmodule SymphonyElixirWeb.Presenter do
   Shared projections for the observability API and dashboard.
   """
 
-  alias SymphonyElixir.{Deployment.Reload, Orchestrator, Redactor, RuntimeInfo, StatusDashboard}
+  alias SymphonyElixir.{Codex.RolloutIndex, Deployment.Reload, Orchestrator, Redactor, RuntimeInfo, StatusDashboard}
   alias SymphonyElixirWeb.WorkerApi
 
   @conversation_display_limit 120
@@ -49,19 +49,33 @@ defmodule SymphonyElixirWeb.Presenter do
 
   @spec issue_payload(String.t(), GenServer.name(), timeout()) :: {:ok, map()} | {:error, :issue_not_found}
   def issue_payload(issue_identifier, orchestrator, snapshot_timeout_ms) when is_binary(issue_identifier) do
+    rollouts = lookup_rollouts(issue_identifier)
+
     case Orchestrator.snapshot(orchestrator, snapshot_timeout_ms) do
       %{} = snapshot ->
         running = Enum.find(snapshot.running, &(&1.identifier == issue_identifier))
         retry = Enum.find(snapshot.retrying, &(&1.identifier == issue_identifier))
 
-        if is_nil(running) and is_nil(retry) do
-          {:error, :issue_not_found}
-        else
-          {:ok, issue_payload_body(issue_identifier, running, retry)}
+        cond do
+          not is_nil(running) or not is_nil(retry) ->
+            payload =
+              issue_identifier
+              |> issue_payload_body(running, retry)
+              |> attach_rollouts(rollouts)
+
+            {:ok, payload}
+
+          rollouts != [] ->
+            {:ok, historical_issue_payload(issue_identifier, rollouts)}
+
+          true ->
+            {:error, :issue_not_found}
         end
 
       _ ->
-        {:error, :issue_not_found}
+        if rollouts == [],
+          do: {:error, :issue_not_found},
+          else: {:ok, historical_issue_payload(issue_identifier, rollouts)}
     end
   end
 
@@ -176,6 +190,78 @@ defmodule SymphonyElixirWeb.Presenter do
       tracked: %{}
     }
   end
+
+  defp lookup_rollouts(issue_identifier) do
+    try do
+      RolloutIndex.lookup(issue_identifier)
+    rescue
+      _ -> []
+    catch
+      _, _ -> []
+    end
+  end
+
+  defp attach_rollouts(payload, rollouts) do
+    rollout_summaries = Enum.map(rollouts, &rollout_summary/1)
+
+    payload
+    |> Map.put(:rollouts, rollout_summaries)
+    |> Map.put(:current_rollout, List.first(rollout_summaries))
+    |> Map.update(:logs, %{codex_session_logs: rollout_log_paths(rollouts)}, fn logs ->
+      Map.put(logs, :codex_session_logs, rollout_log_paths(rollouts))
+    end)
+  end
+
+  defp historical_issue_payload(issue_identifier, [latest | _] = rollouts) do
+    rollout_summaries = Enum.map(rollouts, &rollout_summary/1)
+
+    %{
+      issue_identifier: issue_identifier,
+      issue_id: nil,
+      title: nil,
+      url: nil,
+      status: "ended",
+      workspace: %{path: latest.cwd, host: nil, branch: nil},
+      pull_request: nil,
+      checks: nil,
+      attempts: %{restart_count: nil, current_retry_attempt: nil},
+      running: nil,
+      retry: nil,
+      logs: %{codex_session_logs: rollout_log_paths(rollouts)},
+      recent_events: [],
+      timeline: [],
+      conversation: [],
+      debug: nil,
+      last_error: nil,
+      tracked: %{},
+      rollouts: rollout_summaries,
+      current_rollout: List.first(rollout_summaries)
+    }
+  end
+
+  defp rollout_summary(entry) do
+    %{
+      session_id: entry.session_id,
+      path: entry.path,
+      cwd: entry.cwd,
+      started_at: format_iso(entry.started_at),
+      model: entry.model
+    }
+  end
+
+  defp rollout_log_paths(rollouts) do
+    rollouts
+    |> Enum.map(fn entry ->
+      %{
+        label: entry.session_id || Path.basename(entry.path),
+        path: entry.path,
+        url: nil
+      }
+    end)
+  end
+
+  defp format_iso(nil), do: nil
+  defp format_iso(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
 
   defp issue_id_from_entries(running, retry),
     do: (running && running.issue_id) || (retry && retry.issue_id)

--- a/elixir/lib/symphony_elixir_web/router.ex
+++ b/elixir/lib/symphony_elixir_web/router.ex
@@ -25,7 +25,7 @@ defmodule SymphonyElixirWeb.Router do
     pipe_through(:browser)
 
     live("/", DashboardLive, :index)
-    live("/workers/:issue_identifier", DashboardLive, :worker_detail)
+    live("/workers/:issue_identifier", WorkerDetailLive)
   end
 
   scope "/", SymphonyElixirWeb do

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -30,6 +30,7 @@ defmodule SymphonyElixir.MixProject do
           SymphonyElixir.LogFile,
           SymphonyElixir.Workspace,
           SymphonyElixir.WindowsPreflight,
+          SymphonyElixirWeb.CodexTailServer,
           SymphonyElixirWeb.DashboardLive,
           SymphonyElixirWeb.Endpoint,
           SymphonyElixirWeb.ErrorHTML,
@@ -39,6 +40,7 @@ defmodule SymphonyElixir.MixProject do
           SymphonyElixirWeb.Presenter,
           SymphonyElixirWeb.StaticAssetController,
           SymphonyElixirWeb.StaticAssets,
+          SymphonyElixirWeb.WorkerDetailLive,
           SymphonyElixirWeb.Router,
           SymphonyElixirWeb.Router.Helpers
         ]

--- a/elixir/priv/static/dashboard.css
+++ b/elixir/priv/static/dashboard.css
@@ -968,3 +968,438 @@ pre,
     grid-template-columns: 1fr;
   }
 }
+
+/* ----- worker detail (PR2) ------------------------------------------- */
+
+.worker-shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.4rem 1.6rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.worker-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.9rem;
+  padding: 0.6rem 0.2rem 0.9rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.worker-back {
+  font-size: 0.86rem;
+  color: var(--muted);
+  letter-spacing: 0.01em;
+}
+
+.worker-back:hover {
+  color: var(--accent);
+}
+
+.worker-id {
+  font-family: "SF Mono", "JetBrains Mono", ui-monospace, monospace;
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+}
+
+.worker-title {
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.worker-live {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+  color: var(--accent);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.worker-live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px rgba(16, 163, 127, 0.18);
+  animation: worker-pulse 1.6s infinite ease-in-out;
+}
+
+@keyframes worker-pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.18); opacity: 0.65; }
+}
+
+.worker-grid {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  gap: 1.4rem;
+  align-items: start;
+}
+
+.worker-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  position: sticky;
+  top: 1rem;
+}
+
+.worker-sidebar-section {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 0.95rem 1rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.worker-section-title {
+  margin: 0 0 0.6rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.worker-section-empty {
+  color: var(--muted);
+  font-size: 0.86rem;
+  margin: 0;
+}
+
+.rollout-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.rollout-row .rollout-link {
+  display: flex;
+  flex-direction: column;
+  padding: 0.45rem 0.55rem;
+  border-radius: 8px;
+  border-left: 2px solid transparent;
+}
+
+.rollout-row .rollout-link:hover {
+  background: var(--card-muted);
+  color: var(--ink);
+}
+
+.rollout-row-active .rollout-link {
+  border-left-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.rollout-row-title {
+  font-family: "SF Mono", "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.82rem;
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.rollout-row-meta {
+  font-size: 0.74rem;
+  color: var(--muted);
+  margin-top: 0.1rem;
+}
+
+.worker-kv {
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.4rem;
+}
+
+.worker-kv > div {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr;
+  gap: 0.6rem;
+  align-items: baseline;
+}
+
+.worker-kv-wide > div {
+  grid-template-columns: 7rem 1fr;
+}
+
+.worker-kv dt {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.worker-kv dd {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--ink);
+  word-break: break-word;
+}
+
+.worker-main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  min-height: 60vh;
+}
+
+.worker-tabs {
+  display: flex;
+  gap: 0.2rem;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 0.2rem;
+}
+
+.worker-tab {
+  padding: 0.5rem 0.95rem;
+  font-size: 0.86rem;
+  color: var(--muted);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.worker-tab:hover {
+  color: var(--ink);
+}
+
+.worker-tab-active {
+  color: var(--ink);
+  border-bottom-color: var(--accent);
+}
+
+.transcript-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.transcript-meta {
+  font-size: 0.78rem;
+  color: var(--muted);
+  padding-left: 0.2rem;
+}
+
+.transcript-scroll {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 0.6rem 0;
+  max-height: 64vh;
+  overflow-y: auto;
+  box-shadow: var(--shadow-sm);
+}
+
+.transcript {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.transcript-empty {
+  padding: 1.4rem 1.4rem;
+  color: var(--muted);
+  text-align: center;
+}
+
+.transcript-item {
+  display: grid;
+  grid-template-columns: 1.6rem 1fr;
+  gap: 0.55rem;
+  padding: 0.55rem 1.1rem;
+  border-bottom: 1px solid transparent;
+}
+
+.transcript-item:hover {
+  background: rgba(16, 163, 127, 0.025);
+}
+
+.transcript-marker {
+  font-family: "SF Mono", "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.95rem;
+  color: var(--muted);
+  text-align: center;
+  line-height: 1.45;
+}
+
+.transcript-body {
+  min-width: 0;
+}
+
+.transcript-meta-row {
+  display: flex;
+  gap: 0.55rem;
+  align-items: baseline;
+  margin-bottom: 0.15rem;
+}
+
+.transcript-kind {
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.transcript-time {
+  font-size: 0.74rem;
+  color: var(--muted);
+}
+
+.transcript-text {
+  margin: 0;
+  font-size: 0.92rem;
+  color: var(--ink);
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.55;
+}
+
+.tr-assistant_message .transcript-marker {
+  color: var(--accent);
+}
+
+.tr-assistant_message .transcript-text {
+  font-weight: 500;
+}
+
+.tr-user_message .transcript-marker {
+  color: var(--ink);
+}
+
+.tr-user_message .transcript-text {
+  color: var(--accent-ink);
+}
+
+.tr-tool_call .transcript-text,
+.tr-tool_call .transcript-summary {
+  font-family: "SF Mono", "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.84rem;
+  color: var(--ink);
+}
+
+.tr-reasoning .transcript-text,
+.tr-reasoning .transcript-summary {
+  font-style: italic;
+  color: var(--muted);
+}
+
+.tr-state {
+  border-top: 1px dashed var(--line);
+  padding-top: 0.7rem;
+}
+
+.tr-state .transcript-text {
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.tr-error {
+  border-left: 3px solid var(--danger);
+  background: var(--danger-soft);
+}
+
+.tr-error .transcript-marker,
+.tr-error .transcript-text {
+  color: var(--danger);
+}
+
+.transcript-details {
+  margin-top: 0.15rem;
+}
+
+.transcript-summary {
+  cursor: pointer;
+  list-style: none;
+  color: var(--ink);
+  font-size: 0.88rem;
+  display: inline-block;
+  padding: 0.05rem 0;
+}
+
+.transcript-summary::-webkit-details-marker {
+  display: none;
+}
+
+.transcript-pre {
+  margin: 0.4rem 0 0;
+  padding: 0.65rem 0.8rem;
+  background: var(--card-muted);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  font-family: "SF Mono", "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.78rem;
+  color: var(--ink);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 16rem;
+  overflow-y: auto;
+}
+
+.composer-disabled {
+  margin: 0;
+  padding: 0.7rem 0.9rem;
+  font-size: 0.84rem;
+  color: var(--muted);
+  background: var(--card);
+  border: 1px dashed var(--line-strong);
+  border-radius: 12px;
+  text-align: center;
+}
+
+.panel-shell {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 1rem 1.1rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.log-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.log-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-size: 0.86rem;
+}
+
+.worker-error {
+  background: var(--danger-soft);
+  border: 1px solid rgba(180, 35, 24, 0.2);
+  border-radius: 14px;
+  padding: 1rem 1.2rem;
+}
+
+@media (max-width: 880px) {
+  .worker-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .worker-sidebar {
+    position: static;
+  }
+}

--- a/elixir/test/symphony_elixir/codex/rollout_index_test.exs
+++ b/elixir/test/symphony_elixir/codex/rollout_index_test.exs
@@ -1,0 +1,151 @@
+defmodule SymphonyElixir.Codex.RolloutIndexTest do
+  use ExUnit.Case, async: false
+
+  alias SymphonyElixir.Codex.RolloutIndex
+
+  setup do
+    base = Path.join(System.tmp_dir!(), "rollout-index-#{System.unique_integer([:positive])}")
+    sessions_root = Path.join(base, "sessions")
+    workspace_root = Path.join(base, "workspaces")
+    File.mkdir_p!(sessions_root)
+    File.mkdir_p!(workspace_root)
+
+    on_exit(fn -> File.rm_rf!(base) end)
+
+    %{base: base, sessions_root: sessions_root, workspace_root: workspace_root}
+  end
+
+  defp write_rollout!(sessions_root, opts) do
+    opts = Enum.into(opts, %{})
+    cwd = Map.fetch!(opts, :cwd)
+    session_id = Map.fetch!(opts, :session_id)
+    started_at = Map.get(opts, :started_at, "2026-05-02T10:43:30.000Z")
+
+    date_dir = Path.join([sessions_root, "2026", "05", "02"])
+    File.mkdir_p!(date_dir)
+
+    path =
+      Path.join(date_dir, "rollout-2026-05-02T#{:os.system_time(:nanosecond)}-#{session_id}.jsonl")
+
+    line =
+      Jason.encode!(%{
+        "timestamp" => started_at,
+        "type" => "session_meta",
+        "payload" => %{
+          "id" => session_id,
+          "cwd" => cwd,
+          "originator" => "Codex",
+          "cli_version" => "0.128.0",
+          "model_provider" => "openai",
+          "timestamp" => started_at
+        }
+      })
+
+    File.write!(path, line <> "\n")
+    path
+  end
+
+  defp start_index!(opts) do
+    name = :"rollout_index_#{System.unique_integer([:positive])}"
+    {:ok, _pid} = RolloutIndex.start_link(Keyword.put(opts, :name, name))
+    name
+  end
+
+  describe "lookup/1" do
+    test "groups rollouts by issue identifier from cwd basename and sorts newest-first",
+         %{sessions_root: sessions_root, workspace_root: workspace_root} do
+      alb_workspace = Path.join(workspace_root, "ALB-39")
+      File.mkdir_p!(alb_workspace)
+
+      _old =
+        write_rollout!(sessions_root,
+          cwd: alb_workspace,
+          session_id: "old-session",
+          started_at: "2026-05-01T10:00:00Z"
+        )
+
+      _new =
+        write_rollout!(sessions_root,
+          cwd: alb_workspace,
+          session_id: "new-session",
+          started_at: "2026-05-02T10:00:00Z"
+        )
+
+      name = start_index!(sessions_root: sessions_root, workspace_root: workspace_root)
+
+      entries = RolloutIndex.lookup("ALB-39", name: name)
+      assert length(entries) == 2
+      assert [first, second] = entries
+      assert first.session_id == "new-session"
+      assert second.session_id == "old-session"
+      assert first.issue_identifier == "ALB-39"
+    end
+
+    test "filters out rollouts whose cwd is outside the configured workspace root",
+         %{sessions_root: sessions_root, workspace_root: workspace_root} do
+      # Inside workspace root
+      inside = Path.join(workspace_root, "ALB-1")
+      File.mkdir_p!(inside)
+      write_rollout!(sessions_root, cwd: inside, session_id: "in-1")
+
+      # Outside workspace root (e.g. user opened Codex Desktop on a personal repo)
+      outside = Path.join(System.tmp_dir!(), "unrelated-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(outside)
+      on_exit(fn -> File.rm_rf!(outside) end)
+      write_rollout!(sessions_root, cwd: outside, session_id: "out-1")
+
+      name = start_index!(sessions_root: sessions_root, workspace_root: workspace_root)
+
+      assert [%{session_id: "in-1"}] = RolloutIndex.lookup("ALB-1", name: name)
+      assert RolloutIndex.lookup(Path.basename(outside), name: name) == []
+    end
+
+    test "returns [] for unknown issue identifiers",
+         %{sessions_root: sessions_root, workspace_root: workspace_root} do
+      name = start_index!(sessions_root: sessions_root, workspace_root: workspace_root)
+      assert RolloutIndex.lookup("DOES-NOT-EXIST", name: name) == []
+    end
+
+    test "returns [] when the index process is not running" do
+      assert RolloutIndex.lookup("ALB-1", name: :rollout_index_unstarted_xyz) == []
+    end
+  end
+
+  describe "refresh/0" do
+    test "picks up rollouts created after init",
+         %{sessions_root: sessions_root, workspace_root: workspace_root} do
+      alb_workspace = Path.join(workspace_root, "ALB-7")
+      File.mkdir_p!(alb_workspace)
+
+      name = start_index!(sessions_root: sessions_root, workspace_root: workspace_root)
+      assert RolloutIndex.lookup("ALB-7", name: name) == []
+
+      write_rollout!(sessions_root, cwd: alb_workspace, session_id: "fresh-session")
+
+      assert :ok = RolloutIndex.refresh(name: name)
+      assert [%{session_id: "fresh-session"}] = RolloutIndex.lookup("ALB-7", name: name)
+    end
+  end
+
+  describe "derive_issue_identifier/2" do
+    test "returns nil for nil cwd" do
+      assert RolloutIndex.derive_issue_identifier(nil, "/tmp") == nil
+    end
+
+    test "returns the basename when cwd is under the workspace root (case-insensitive)" do
+      assert RolloutIndex.derive_issue_identifier("D:/Workspaces/ALB-3", "d:/workspaces") == "ALB-3"
+    end
+
+    test "returns nil when cwd is outside the workspace root" do
+      assert RolloutIndex.derive_issue_identifier("/elsewhere/ALB-3", "/tmp/workspaces") == nil
+    end
+
+    test "sanitizes characters outside [A-Za-z0-9._-]" do
+      assert RolloutIndex.derive_issue_identifier("/ws/foo bar", "/ws") == "foo_bar"
+    end
+
+    test "passes through when no workspace root configured" do
+      assert RolloutIndex.derive_issue_identifier("/anywhere/ALB-9", nil) == "ALB-9"
+    end
+  end
+end

--- a/elixir/test/symphony_elixir/codex/rollout_index_test.exs
+++ b/elixir/test/symphony_elixir/codex/rollout_index_test.exs
@@ -81,6 +81,21 @@ defmodule SymphonyElixir.Codex.RolloutIndexTest do
       assert first.issue_identifier == "ALB-39"
     end
 
+    test "looks up rollouts by path",
+         %{sessions_root: sessions_root, workspace_root: workspace_root} do
+      alb_workspace = Path.join(workspace_root, "ALB-GET")
+      File.mkdir_p!(alb_workspace)
+      path = write_rollout!(sessions_root, cwd: alb_workspace, session_id: "get-session")
+
+      name = start_index!(sessions_root: sessions_root, workspace_root: workspace_root)
+
+      assert %{session_id: "get-session", path: entry_path, mtime: mtime} = RolloutIndex.get(path, name: name)
+      assert normalize_for_assertion(entry_path) == normalize_for_assertion(path)
+      assert is_integer(mtime)
+      assert RolloutIndex.get(Path.join(sessions_root, "missing.jsonl"), name: name) == nil
+      assert RolloutIndex.get(path, name: :rollout_index_unstarted_get) == nil
+    end
+
     test "filters out rollouts whose cwd is outside the configured workspace root",
          %{sessions_root: sessions_root, workspace_root: workspace_root} do
       # Inside workspace root
@@ -109,6 +124,32 @@ defmodule SymphonyElixir.Codex.RolloutIndexTest do
     test "returns [] when the index process is not running" do
       assert RolloutIndex.lookup("ALB-1", name: :rollout_index_unstarted_xyz) == []
     end
+
+    test "ignores malformed rollouts and missing session roots",
+         %{sessions_root: sessions_root, workspace_root: workspace_root, base: base} do
+      bad_dir = Path.join([sessions_root, "2026", "05", "03"])
+      File.mkdir_p!(bad_dir)
+      File.write!(Path.join(bad_dir, "rollout-bad.jsonl"), "not-json\n")
+
+      bad_name = start_index!(sessions_root: sessions_root, workspace_root: workspace_root)
+      assert RolloutIndex.lookup("ALB-BAD", name: bad_name) == []
+
+      missing_root = Path.join(base, "missing-sessions")
+      name = start_index!(sessions_root: missing_root, workspace_root: workspace_root)
+
+      assert RolloutIndex.lookup("ALB-BAD", name: name) == []
+      assert RolloutIndex.refresh(name: name) == :ok
+      assert RolloutIndex.lookup("ALB-BAD", name: name) == []
+    end
+
+    test "handles nil sessions root without crashing",
+         %{workspace_root: workspace_root} do
+      name = start_index!(sessions_root: nil, workspace_root: workspace_root)
+
+      assert RolloutIndex.lookup("ALB-NIL", name: name) == []
+      assert RolloutIndex.refresh(name: name) == :ok
+      assert RolloutIndex.lookup("ALB-NIL", name: name) == []
+    end
   end
 
   describe "refresh/0" do
@@ -124,6 +165,32 @@ defmodule SymphonyElixir.Codex.RolloutIndexTest do
 
       assert :ok = RolloutIndex.refresh(name: name)
       assert [%{session_id: "fresh-session"}] = RolloutIndex.lookup("ALB-7", name: name)
+    end
+
+    test "returns :ok when the index process is not running" do
+      assert :ok = RolloutIndex.refresh(name: :rollout_index_unstarted_refresh)
+    end
+
+    test "periodic refresh picks up new rollouts",
+         %{sessions_root: sessions_root, workspace_root: workspace_root} do
+      alb_workspace = Path.join(workspace_root, "ALB-TICK")
+      File.mkdir_p!(alb_workspace)
+
+      name = start_index!(sessions_root: sessions_root, workspace_root: workspace_root)
+      write_rollout!(sessions_root, cwd: alb_workspace, session_id: "tick-session")
+
+      pid = Process.whereis(name)
+      send(pid, :refresh)
+
+      assert eventually(fn ->
+               case RolloutIndex.lookup("ALB-TICK", name: name) do
+                 [%{session_id: "tick-session"}] -> true
+                 _ -> false
+               end
+             end)
+
+      send(pid, :unexpected)
+      assert Process.alive?(pid)
     end
   end
 
@@ -147,5 +214,60 @@ defmodule SymphonyElixir.Codex.RolloutIndexTest do
     test "passes through when no workspace root configured" do
       assert RolloutIndex.derive_issue_identifier("/anywhere/ALB-9", nil) == "ALB-9"
     end
+
+    test "returns nil for empty basenames" do
+      assert RolloutIndex.derive_issue_identifier("/", nil) == nil
+    end
+  end
+
+  describe "default_sessions_root/0" do
+    test "uses application override" do
+      previous = Application.get_env(:symphony_elixir, :codex_sessions_root)
+      override = Path.join(System.tmp_dir!(), "codex-sessions-override")
+      Application.put_env(:symphony_elixir, :codex_sessions_root, override)
+
+      on_exit(fn ->
+        if previous do
+          Application.put_env(:symphony_elixir, :codex_sessions_root, previous)
+        else
+          Application.delete_env(:symphony_elixir, :codex_sessions_root)
+        end
+      end)
+
+      assert RolloutIndex.default_sessions_root() == override
+    end
+
+    test "falls back to the user codex sessions directory" do
+      previous = Application.get_env(:symphony_elixir, :codex_sessions_root)
+      Application.delete_env(:symphony_elixir, :codex_sessions_root)
+
+      on_exit(fn ->
+        if previous do
+          Application.put_env(:symphony_elixir, :codex_sessions_root, previous)
+        end
+      end)
+
+      assert RolloutIndex.default_sessions_root() =~ ".codex"
+      assert RolloutIndex.default_sessions_root() =~ "sessions"
+    end
+  end
+
+  defp eventually(fun, attempts \\ 20)
+  defp eventually(_fun, 0), do: false
+
+  defp eventually(fun, attempts) do
+    if fun.() do
+      true
+    else
+      Process.sleep(10)
+      eventually(fun, attempts - 1)
+    end
+  end
+
+  defp normalize_for_assertion(path) do
+    path
+    |> Path.expand()
+    |> String.replace("\\", "/")
+    |> String.downcase()
   end
 end

--- a/elixir/test/symphony_elixir/codex/rollout_reader_test.exs
+++ b/elixir/test/symphony_elixir/codex/rollout_reader_test.exs
@@ -222,6 +222,30 @@ defmodule SymphonyElixir.Codex.RolloutReaderTest do
                Enum.map(parsed, &RolloutReader.to_conversation_item/1)
     end
 
+    test "conversation_items caps initial transcript to the latest items" do
+      path = Path.join(@tmp_dir, "rollout-limited-#{System.unique_integer([:positive])}.jsonl")
+
+      lines =
+        1..5
+        |> Enum.map(fn index ->
+          Jason.encode!(%{
+            "timestamp" => "2026-05-02T10:00:0#{index}Z",
+            "type" => "response_item",
+            "payload" => %{
+              "type" => "message",
+              "role" => "assistant",
+              "content" => "message #{index}"
+            }
+          })
+        end)
+
+      File.write!(path, Enum.join(lines, "\n"))
+      on_exit_cleanup(path)
+
+      assert [%{text: "message 3"}, %{text: "message 4"}, %{text: "message 5"}] =
+               RolloutReader.conversation_items(path, limit: 3)
+    end
+
     test "extracts function_call name and reasoning text" do
       assert %{kind: :tool_call, text: "rg"} =
                RolloutReader.to_conversation_item(

--- a/elixir/test/symphony_elixir/codex/rollout_reader_test.exs
+++ b/elixir/test/symphony_elixir/codex/rollout_reader_test.exs
@@ -44,6 +44,40 @@ defmodule SymphonyElixir.Codex.RolloutReaderTest do
       assert %DateTime{} = meta.started_at
     end
 
+    test "prefers explicit model and tolerates invalid timestamps" do
+      path =
+        write_jsonl!([
+          %{
+            "timestamp" => "not-a-timestamp",
+            "type" => "session_meta",
+            "payload" => %{
+              "id" => "session-model",
+              "cwd" => "/tmp/workspaces/ALB-4",
+              "model" => "gpt-test",
+              "model_provider" => "fallback-provider",
+              "timestamp" => "also-not-a-timestamp"
+            }
+          }
+        ])
+
+      assert {:ok, meta} = RolloutReader.read_meta(path)
+      assert meta.model == "gpt-test"
+      assert meta.started_at == nil
+    end
+
+    test "returns nil model when rollout metadata has no model fields" do
+      path =
+        write_jsonl!([
+          %{
+            "timestamp" => "2026-05-02T10:43:37.948Z",
+            "type" => "session_meta",
+            "payload" => %{"id" => "session-no-model", "cwd" => "/tmp/workspaces/ALB-5"}
+          }
+        ])
+
+      assert {:ok, %{model: nil}} = RolloutReader.read_meta(path)
+    end
+
     test "returns :empty_file when the file is empty" do
       path = Path.join(@tmp_dir, "rollout-empty-#{System.unique_integer([:positive])}.jsonl")
       File.write!(path, "")
@@ -130,6 +164,7 @@ defmodule SymphonyElixir.Codex.RolloutReaderTest do
 
     test "skips malformed JSON lines without crashing" do
       path = Path.join(@tmp_dir, "rollout-bad-#{System.unique_integer([:positive])}.jsonl")
+
       File.write!(
         path,
         Enum.join(
@@ -161,6 +196,32 @@ defmodule SymphonyElixir.Codex.RolloutReaderTest do
       assert [%{kind: :assistant_message, text: "ok"}] = items
     end
 
+    test "skips blank and unknown JSON lines" do
+      path = Path.join(@tmp_dir, "rollout-unknown-#{System.unique_integer([:positive])}.jsonl")
+
+      File.write!(
+        path,
+        [
+          "",
+          Jason.encode!(%{"timestamp" => "x", "type" => "unknown_type", "payload" => %{}}),
+          Jason.encode!(%{
+            "timestamp" => "2026-05-02T10:00:00Z",
+            "type" => "response_item",
+            "payload" => %{"type" => "message", "role" => "assistant", "content" => "ok"}
+          })
+        ]
+        |> Enum.join("\n")
+      )
+
+      on_exit_cleanup(path)
+
+      parsed = Enum.to_list(RolloutReader.stream(path))
+      assert [:unknown, {:response, _}] = parsed
+
+      assert [nil, %{kind: :assistant_message, text: "ok"}] =
+               Enum.map(parsed, &RolloutReader.to_conversation_item/1)
+    end
+
     test "extracts function_call name and reasoning text" do
       assert %{kind: :tool_call, text: "rg"} =
                RolloutReader.to_conversation_item(
@@ -179,6 +240,132 @@ defmodule SymphonyElixir.Codex.RolloutReaderTest do
                     "payload" => %{"type" => "reasoning", "text" => "thinking"}
                   }}
                )
+    end
+
+    test "projects reasoning content before text fallback and drops empty reasoning" do
+      assert %{kind: :reasoning, text: "content thinking"} =
+               RolloutReader.to_conversation_item(
+                 {:response,
+                  %{
+                    "timestamp" => "2026-05-02T10:00:01Z",
+                    "payload" => %{
+                      "type" => "reasoning",
+                      "content" => [%{"type" => "output_text", "text" => "content thinking"}],
+                      "text" => "fallback thinking"
+                    }
+                  }}
+               )
+
+      assert nil ==
+               RolloutReader.to_conversation_item(
+                 {:response,
+                  %{
+                    "timestamp" => "2026-05-02T10:00:02Z",
+                    "payload" => %{"type" => "reasoning", "content" => [], "text" => ""}
+                  }}
+               )
+    end
+
+    test "projects function output variants" do
+      assert %{kind: :tool_call, text: "line one\nline two", meta: %{is_output: true, call_id: "call-1"}} =
+               RolloutReader.to_conversation_item(
+                 {:response,
+                  %{
+                    "timestamp" => "2026-05-02T10:00:00Z",
+                    "payload" => %{
+                      "type" => "function_call_output",
+                      "call_id" => "call-1",
+                      "output" => %{
+                        "content" => [
+                          %{"type" => "input_text", "text" => "line one"},
+                          %{"type" => "output_text", "text" => "line two"}
+                        ]
+                      }
+                    }
+                  }}
+               )
+
+      assert %{kind: :tool_call, text: "plain output"} =
+               RolloutReader.to_conversation_item(
+                 {:response,
+                  %{
+                    "timestamp" => "2026-05-02T10:00:01Z",
+                    "payload" => %{"type" => "function_call_output", "output" => "plain output"}
+                  }}
+               )
+
+      assert %{kind: :tool_call, text: ""} =
+               RolloutReader.to_conversation_item(
+                 {:response,
+                  %{
+                    "timestamp" => "2026-05-02T10:00:02Z",
+                    "payload" => %{"type" => "function_call_output", "output" => %{}}
+                  }}
+               )
+    end
+
+    test "drops low-signal response and event variants" do
+      assert nil == RolloutReader.to_conversation_item(:unknown)
+      assert nil == RolloutReader.to_conversation_item({:meta, %{}})
+      assert nil == RolloutReader.to_conversation_item({:response, %{"timestamp" => "x", "payload" => %{"type" => "file_search"}}})
+      assert nil == RolloutReader.to_conversation_item({:event, %{"timestamp" => "x", "payload" => %{"type" => "heartbeat"}}})
+      assert nil == RolloutReader.to_conversation_item(%{})
+    end
+
+    test "drops empty or unsupported message roles" do
+      assert nil ==
+               RolloutReader.to_conversation_item(
+                 {:response,
+                  %{
+                    "timestamp" => "2026-05-02T10:00:00Z",
+                    "payload" => %{"type" => "message", "role" => "assistant", "content" => []}
+                  }}
+               )
+
+      assert nil ==
+               RolloutReader.to_conversation_item(
+                 {:response,
+                  %{
+                    "timestamp" => "2026-05-02T10:00:00Z",
+                    "payload" => %{"type" => "message", "role" => "critic", "content" => "note"}
+                  }}
+               )
+    end
+
+    test "projects state changes without timestamps and default tool-call labels" do
+      assert %{kind: :state_change, at: nil, text: "thread_started", meta: %{"thread_id" => "thread-1"}} =
+               RolloutReader.to_conversation_item(
+                 {:event,
+                  %{
+                    "timestamp" => nil,
+                    "payload" => %{"type" => "thread_started", "thread_id" => "thread-1"}
+                  }}
+               )
+
+      assert %{kind: :tool_call, text: "tool_call", meta: %{name: nil}} =
+               RolloutReader.to_conversation_item(
+                 {:response,
+                  %{
+                    "timestamp" => "2026-05-02T10:00:00Z",
+                    "payload" => %{"type" => "function_call", "name" => 123}
+                  }}
+               )
+    end
+
+    test "truncates very large transcript text" do
+      long_text = String.duplicate("a", 8_050)
+
+      assert %{text: text} =
+               RolloutReader.to_conversation_item(
+                 {:response,
+                  %{
+                    "timestamp" => "2026-05-02T10:00:00Z",
+                    "payload" => %{"type" => "message", "role" => "assistant", "content" => long_text}
+                  }}
+               )
+
+      assert byte_size(text) > 8_000
+      assert String.ends_with?(text, " …[truncated]")
     end
   end
 end

--- a/elixir/test/symphony_elixir/codex/rollout_reader_test.exs
+++ b/elixir/test/symphony_elixir/codex/rollout_reader_test.exs
@@ -1,0 +1,184 @@
+defmodule SymphonyElixir.Codex.RolloutReaderTest do
+  use ExUnit.Case, async: true
+
+  alias SymphonyElixir.Codex.RolloutReader
+
+  @tmp_dir System.tmp_dir!()
+
+  defp write_jsonl!(lines) do
+    name = "rollout-test-#{System.unique_integer([:positive])}.jsonl"
+    path = Path.join(@tmp_dir, name)
+    File.write!(path, Enum.map_join(lines, "\n", &Jason.encode!/1) <> "\n")
+
+    on_exit_cleanup(path)
+    path
+  end
+
+  defp on_exit_cleanup(path) do
+    ExUnit.Callbacks.on_exit(fn -> File.rm(path) end)
+  end
+
+  describe "read_meta/1" do
+    test "parses session_meta from the first line" do
+      path =
+        write_jsonl!([
+          %{
+            "timestamp" => "2026-05-02T10:43:37.948Z",
+            "type" => "session_meta",
+            "payload" => %{
+              "id" => "session-abc",
+              "cwd" => "d:\\desktop\\symphony-runtime\\workspaces\\ALB-39",
+              "originator" => "Codex Desktop",
+              "cli_version" => "0.128.0",
+              "model_provider" => "openai",
+              "timestamp" => "2026-05-02T10:43:30.579Z"
+            }
+          },
+          %{"timestamp" => "2026-05-02T10:43:38Z", "type" => "event_msg", "payload" => %{"type" => "task_started"}}
+        ])
+
+      assert {:ok, meta} = RolloutReader.read_meta(path)
+      assert meta.session_id == "session-abc"
+      assert meta.cwd == "d:\\desktop\\symphony-runtime\\workspaces\\ALB-39"
+      assert meta.originator == "Codex Desktop"
+      assert %DateTime{} = meta.started_at
+    end
+
+    test "returns :empty_file when the file is empty" do
+      path = Path.join(@tmp_dir, "rollout-empty-#{System.unique_integer([:positive])}.jsonl")
+      File.write!(path, "")
+      on_exit_cleanup(path)
+
+      assert {:error, :empty_file} = RolloutReader.read_meta(path)
+    end
+
+    test "returns :no_session_meta when the first line is not a session_meta record" do
+      path =
+        write_jsonl!([
+          %{"timestamp" => "2026-05-02T10:43:38Z", "type" => "event_msg", "payload" => %{"type" => "task_started"}}
+        ])
+
+      assert {:error, :no_session_meta} = RolloutReader.read_meta(path)
+    end
+
+    test "returns :open_failed when the file does not exist" do
+      assert {:error, {:open_failed, _}} = RolloutReader.read_meta(Path.join(@tmp_dir, "does-not-exist.jsonl"))
+    end
+  end
+
+  describe "stream/1 + to_conversation_item/1" do
+    test "projects assistant messages, hides developer/system roles, drops meta" do
+      path =
+        write_jsonl!([
+          %{
+            "timestamp" => "2026-05-02T10:00:00Z",
+            "type" => "session_meta",
+            "payload" => %{"id" => "s1", "cwd" => "/tmp/workspaces/ALB-1"}
+          },
+          %{
+            "timestamp" => "2026-05-02T10:00:01Z",
+            "type" => "response_item",
+            "payload" => %{
+              "type" => "message",
+              "role" => "developer",
+              "content" => [%{"type" => "input_text", "text" => "permissions instructions"}]
+            }
+          },
+          %{
+            "timestamp" => "2026-05-02T10:00:02Z",
+            "type" => "response_item",
+            "payload" => %{
+              "type" => "message",
+              "role" => "user",
+              "content" => [%{"type" => "input_text", "text" => "Hello"}]
+            }
+          },
+          %{
+            "timestamp" => "2026-05-02T10:00:03Z",
+            "type" => "response_item",
+            "payload" => %{
+              "type" => "message",
+              "role" => "assistant",
+              "content" => [%{"type" => "output_text", "text" => "Hi"}]
+            }
+          },
+          %{
+            "timestamp" => "2026-05-02T10:00:04Z",
+            "type" => "event_msg",
+            "payload" => %{"type" => "task_completed"}
+          },
+          %{
+            "timestamp" => "2026-05-02T10:00:05Z",
+            "type" => "event_msg",
+            "payload" => %{"type" => "error", "message" => "boom"}
+          }
+        ])
+
+      items =
+        path
+        |> RolloutReader.stream()
+        |> Stream.map(&RolloutReader.to_conversation_item/1)
+        |> Enum.reject(&is_nil/1)
+
+      kinds = Enum.map(items, & &1.kind)
+      assert kinds == [:user_message, :assistant_message, :state_change, :error]
+
+      [_, assistant, _, error] = items
+      assert assistant.text == "Hi"
+      assert error.text == "boom"
+    end
+
+    test "skips malformed JSON lines without crashing" do
+      path = Path.join(@tmp_dir, "rollout-bad-#{System.unique_integer([:positive])}.jsonl")
+      File.write!(
+        path,
+        Enum.join(
+          [
+            Jason.encode!(%{"timestamp" => "x", "type" => "session_meta", "payload" => %{"id" => "s1"}}),
+            "{not json",
+            Jason.encode!(%{
+              "timestamp" => "y",
+              "type" => "response_item",
+              "payload" => %{
+                "type" => "message",
+                "role" => "assistant",
+                "content" => [%{"type" => "output_text", "text" => "ok"}]
+              }
+            })
+          ],
+          "\n"
+        ) <> "\n"
+      )
+
+      on_exit_cleanup(path)
+
+      items =
+        path
+        |> RolloutReader.stream()
+        |> Stream.map(&RolloutReader.to_conversation_item/1)
+        |> Enum.reject(&is_nil/1)
+
+      assert [%{kind: :assistant_message, text: "ok"}] = items
+    end
+
+    test "extracts function_call name and reasoning text" do
+      assert %{kind: :tool_call, text: "rg"} =
+               RolloutReader.to_conversation_item(
+                 {:response,
+                  %{
+                    "timestamp" => "2026-05-02T10:00:00Z",
+                    "payload" => %{"type" => "function_call", "name" => "rg", "arguments" => %{"q" => "x"}, "call_id" => "c1"}
+                  }}
+               )
+
+      assert %{kind: :reasoning, text: "thinking"} =
+               RolloutReader.to_conversation_item(
+                 {:response,
+                  %{
+                    "timestamp" => "2026-05-02T10:00:01Z",
+                    "payload" => %{"type" => "reasoning", "text" => "thinking"}
+                  }}
+               )
+    end
+  end
+end

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -1222,7 +1222,9 @@ defmodule SymphonyElixir.ExtensionsTest do
                "payload_truncated?" => issue_payload["debug"]["payload_truncated?"]
              },
              "last_error" => nil,
-             "tracked" => %{}
+             "tracked" => %{},
+             "rollouts" => [],
+             "current_rollout" => nil
            }
 
     conn = get(build_conn(), "/api/v1/MT-RETRY")
@@ -1494,7 +1496,8 @@ defmodule SymphonyElixir.ExtensionsTest do
     {:ok, _view, html} = live(build_conn(), "/workers/MT-API")
     assert html =~ "codex/ALB-63-rate-limit-card"
     assert html =~ "https://github.com/albert-zen/symphony-windows-native/pull/110"
-    assert html =~ "pending"
+    # Check summary ("pending") only appears in the API projection above —
+    # the new LiveView shell surfaces the PR URL but not the rollup status.
   end
 
   test "agent worker status discovers branch and PR checks from workspace git and authenticated lookup" do
@@ -2333,7 +2336,7 @@ defmodule SymphonyElixir.ExtensionsTest do
         {:ok, _detail_view, detail_html} = live(build_conn(), "/workers/MT-HTTP")
 
         assert index_html =~ "Operations Dashboard"
-        assert detail_html =~ "Worker Detail"
+        assert detail_html =~ ~s|class="worker-id">MT-HTTP|
       end)
 
     assert log =~ "Replied in 409µs"
@@ -2457,15 +2460,13 @@ defmodule SymphonyElixir.ExtensionsTest do
     start_test_endpoint(orchestrator: orchestrator_name, snapshot_timeout_ms: 50)
 
     {:ok, view, html} = live(build_conn(), "/workers/MT-HTTP")
-    assert html =~ "Worker Detail"
-    assert html =~ "Agent Messages"
+    # New rollout-backed shell: identifier, sidebar/status block, and the steer composer.
+    assert html =~ ~s|class="worker-id">MT-HTTP|
     assert html =~ "thread-http"
-    assert html =~ "Agent update complete."
-    assert html =~ "Worker debug payload"
+    assert html =~ "Transcript"
+    assert html =~ "Steer the agent"
     refute html =~ "Keep the PR focused."
     refute html =~ "Debug JSON"
-    refute html =~ "Steer worker"
-    refute html =~ "Timeline"
     refute html =~ "Raw worker payload"
 
     render_submit(view, "steer", %{
@@ -2509,9 +2510,12 @@ defmodule SymphonyElixir.ExtensionsTest do
     rendered_payload = inspect(issue_payload, limit: :infinity)
     refute rendered_payload =~ hidden_marker
 
+    # The LiveView no longer renders orchestrator-buffered conversation —
+    # transcript is sourced from the on-disk Codex JSONL via RolloutReader.
+    # We still verify the API projection above; the LiveView shell renders
+    # the worker identifier and the empty-rollouts state in this fixture.
     {:ok, _view, html} = live(build_conn(), "/workers/MT-HTTP")
-    assert html =~ "Hello manager."
-    refute html =~ "mix test"
+    assert html =~ ~s|class="worker-id">MT-HTTP|
     refute html =~ hidden_marker
   end
 
@@ -2542,8 +2546,11 @@ defmodule SymphonyElixir.ExtensionsTest do
     issue_payload = json_response(get(build_conn(), "/api/v1/MT-HTTP"), 200)
     assert [%{"type" => "assistant", "excerpt" => "Durable message survives noise."}] = issue_payload["conversation"]
 
+    # LiveView transcript is sourced from on-disk Codex JSONL, not the
+    # orchestrator's in-memory completed_agent_messages — verified at the
+    # API layer above. The shell still renders for an active worker.
     {:ok, _view, html} = live(build_conn(), "/workers/MT-HTTP")
-    assert html =~ "Durable message survives noise."
+    assert html =~ ~s|class="worker-id">MT-HTTP|
     refute html =~ "noise 80"
   end
 
@@ -3019,12 +3026,15 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     {:ok, _view, html} = live(build_conn(), "/workers/MT-SECRET")
 
+    # Negative assertions still matter — confirm none of the orchestrator
+    # buffers leak into the new shell. The "[REDACTED]" marker only
+    # appears in the API/Presenter projection, not the LiveView shell,
+    # because the new transcript reads from on-disk Codex JSONL.
     refute html =~ "sk-live-secret"
     refute html =~ "p4ss"
     refute html =~ "live-token"
     refute html =~ "user:pass"
     refute html =~ "token=abc123"
-    assert html =~ "[REDACTED]"
   end
 
   test "worker detail liveview requires operator token when steer auth is enabled" do

--- a/elixir/test/symphony_elixir_web/codex_tail_server_test.exs
+++ b/elixir/test/symphony_elixir_web/codex_tail_server_test.exs
@@ -1,0 +1,80 @@
+defmodule SymphonyElixirWeb.CodexTailServerTest do
+  use SymphonyElixir.TestSupport
+
+  alias Phoenix.PubSub
+  alias SymphonyElixirWeb.CodexTailServer
+
+  test "start offset prevents replaying already loaded rollout lines" do
+    path = rollout_path()
+    write_message!(path, "old message")
+    {:ok, stat} = File.stat(path)
+
+    rollout_id = "tail-offset-#{System.unique_integer([:positive])}"
+    topic = CodexTailServer.topic(rollout_id)
+    assert :ok = PubSub.subscribe(SymphonyElixir.PubSub, topic)
+
+    assert {:ok, _pid} =
+             CodexTailServer.start(
+               rollout_id: rollout_id,
+               path: path,
+               start_offset: stat.size,
+               poll_interval_ms: 10
+             )
+
+    refute_receive {:rollout_item, ^rollout_id, %{text: "old message"}}, 80
+
+    write_message!(path, "new message", append: true)
+
+    assert_receive {:rollout_item, ^rollout_id, %{text: "new message"}}, 250
+    refute_receive {:rollout_item, ^rollout_id, %{text: "old message"}}, 80
+  end
+
+  test "tail server stops after idle timeout when there are no subscribers" do
+    path = rollout_path()
+    write_message!(path, "hello")
+    rollout_id = "tail-idle-#{System.unique_integer([:positive])}"
+
+    assert {:ok, pid} =
+             CodexTailServer.start(
+               rollout_id: rollout_id,
+               path: path,
+               poll_interval_ms: 10,
+               idle_timeout_ms: 20
+             )
+
+    ref = Process.monitor(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 250
+  end
+
+  defp rollout_path do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-tail-server-#{System.unique_integer([:positive])}.jsonl"
+      )
+
+    on_exit(fn -> File.rm(path) end)
+    path
+  end
+
+  defp write_message!(path, text, opts \\ []) do
+    payload =
+      %{
+        "timestamp" => DateTime.utc_now() |> DateTime.to_iso8601(),
+        "type" => "response_item",
+        "payload" => %{
+          "type" => "message",
+          "role" => "assistant",
+          "content" => text
+        }
+      }
+      |> Jason.encode!()
+      |> Kernel.<>("\n")
+
+    if Keyword.get(opts, :append, false) do
+      File.write!(path, payload, [:append])
+    else
+      File.write!(path, payload)
+    end
+  end
+end


### PR DESCRIPTION
#### Context

Fixes #62. The worker detail page should feel like an agent chat view, not a raw debug dump.

#### TL;DR

*Redesign worker detail around rollout-backed agent transcript tabs and steering.*

#### Summary

- Add a Codex rollout reader and index for historical worker transcripts.
- Route `/workers/:issue` to a dedicated LiveView detail page.
- Render transcript, logs, workspace, and PR/check context in focused tabs.
- Tail active rollout files with bounded LiveView updates.
- Let terminated workers resolve from rollout history instead of 404ing.
- Normalize rollout paths on Windows and keep pure rollout modules covered.

#### Alternatives

- Keeping the view inside DashboardLive kept detail rendering tangled with the dashboard.
- Rendering raw timeline events first would reintroduce noisy system/debug rows.
- Excluding pure rollout modules from coverage was avoided; only UI shell modules follow policy.

#### Test Plan

- [ ] `make -C elixir all` not run locally because this PR touches worker-detail UI, rollout parsing, and tests; narrower validation plus coverage, format, diff, and Dialyzer were run.
- [x] `mise exec -- mix test test/symphony_elixir/codex/rollout_reader_test.exs test/symphony_elixir/codex/rollout_index_test.exs` passed: 34 tests, 0 failures.
- [x] `mise exec -- mix test test/symphony_elixir/extensions_test.exs` passed: 74 tests, 0 failures.
- [x] `mise exec -- mix test test/symphony_elixir_web/codex_tail_server_test.exs test/symphony_elixir/codex/rollout_reader_test.exs test/symphony_elixir/codex/rollout_index_test.exs test/symphony_elixir/extensions_test.exs` passed after review fixes: 111 tests, 0 failures.
- [x] `mise exec -- mix test --cover` passed via redirected log capture after review fixes: 537 tests, 0 failures, 7 skipped, total coverage 95.15%.
- [x] `mise exec -- mix dialyzer --format short` passed: 0 errors.
- [x] `mise exec -- mix specs.check` passed after the CI lint finding: all public functions have specs.
- [x] `mise exec -- mix lint` passed after review fixes: no issues.
- [x] `mise exec -- mix format.check_normalized ...` passed for all touched files.
- [x] `mise exec -- mix format.check_normalized lib/symphony_elixir_web/live/codex_tail_server.ex` passed after the spec fix.
- [x] `git diff --check 7d13b1b..HEAD` passed.
