### PR TITLE
Set up the worker reviewer agent flywheel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,9 @@ policy or recurring pitfalls change.
   [`elixir/docs/manager-agent-runbook.md`](elixir/docs/manager-agent-runbook.md)
   for review, blocker triage, issue release, waiting, and deployment
   verification.
+- **Workflow policy:** read [`elixir/docs/agents/issue-tracker.md`](elixir/docs/agents/issue-tracker.md)
+  and [`elixir/docs/agents/worker-model.md`](elixir/docs/agents/worker-model.md)
+  when changing Linear states, agent routing, or review/rework behavior.
 
 ## Windows Paths And Commands
 
@@ -73,15 +76,21 @@ mise exec -- mix symphony.preflight.windows .\WORKFLOW.optimization.windows.md
 
 ## Linear And GitHub Flow
 
-- If a Linear issue starts in `Todo`, move it to `In Progress` before editing.
-- Use exactly one Linear comment whose first line is `## Codex Workpad`; update
-  it instead of creating progress spam.
+- Worker agents should accept `Ready for Agent` and `Rework` issues, then move
+  them to `In Progress` before editing. `Todo` is not the agent release queue.
+- Use exactly one human-facing Linear comment whose first line is
+  `## Codex Workpad`; update it instead of creating progress spam. Symphony may
+  also maintain transient `## Symphony Control` system comments for durable
+  claim coordination; do not use those control comments for human progress notes.
 - Use the linked GitHub issue as the public implementation spec.
 - Do not accept or continue work labeled `manager-owned`, or whose Workpad says
   `Manager classification: manager-owned`, unless the manager has decomposed a
   narrow worker-safe subtask for you.
 - Open the PR against `main`, link it in the Workpad, and wait for required
-  GitHub checks before moving Linear to `In Review`.
+  GitHub checks before moving Linear to `Agent Review`.
+- If the issue lacks enough spec, acceptance criteria, dependency state, or
+  decision authority, move it to `Needs Human Context` with the missing context
+  spelled out.
 - If checks are pending, failing, or unverifiable, record the exact reason in the
   Workpad or PR and keep the issue active.
 
@@ -92,7 +101,7 @@ runtime orchestration, worker startup, Linear state transitions, Codex
 app-server protocol, CI, merge/review policy, more than one subsystem, or docs
 that encode operating decisions. Record the request and findings in the PR or
 Workpad. Blocking findings keep the issue in `In Progress` or return it to
-`Todo` until fixed and checks pass.
+`Rework` until fixed and checks pass.
 
 ## Blockers Protocol
 
@@ -124,6 +133,10 @@ Workpad. Blocking findings keep the issue in `In Progress` or return it to
 
 - PowerShell wrappers can corrupt `codex app-server` JSON-RPC stdio; start Codex
   directly unless the wrapper is proven quiet.
+- `codex app-server` with `model_reasoning_effort=minimal` can fail before the
+  first agent message when the default tool set includes tools such as
+  `image_gen` or `web_search`. Use `low` or higher for Linear automation
+  workflows.
 - Windows CRLF and snapshot rendering can differ from Unix expectations.
 - Fake `ssh`, `gh`, and Codex fixtures may assume Unix shebang/chmod behavior.
 - Stale `main` or a checkout where `origin` still points at the upstream

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you are trying to run Symphony directly on Windows, start here:
 - [Windows native setup guide](elixir/docs/windows-native.md)
 - [Windows workflow example](elixir/WORKFLOW.windows.example.md)
 - [Windows optimization workflow example](elixir/WORKFLOW.optimization.windows.example.md)
-- [Small-team agentic build flywheel playbook](elixir/docs/small-team-agentic-flywheel.md)
+- [Agentic flywheel setup and operations](elixir/docs/agentic-flywheel-setup.md)
 - [PowerShell launcher](elixir/scripts/start-windows-native.ps1)
 
 The Windows path is experimental, but the local Linear -> Symphony -> Codex -> Linear loop has been

--- a/elixir/AGENTS.md
+++ b/elixir/AGENTS.md
@@ -30,8 +30,24 @@ forcing every worker to read every project document.
 
 Use [`../SPEC.md`](../SPEC.md) when changing public behavior or contracts. Use
 [`docs/windows-native.md`](docs/windows-native.md) for Windows setup/runtime
-details, and [`docs/agent-quality-flywheel.md`](docs/agent-quality-flywheel.md)
+details, and [`docs/agentic-flywheel-quality.md`](docs/agentic-flywheel-quality.md)
 for PR quality policy.
+
+## Agent Workflow
+
+This repo uses a two-instance agent workflow:
+
+- Worker Symphony polls `Ready for Agent` and `Rework`, then starts implementer
+  Codex sessions.
+- Reviewer Symphony polls `Agent Review`, then starts review-only Codex
+  sessions.
+- State machine and issue readiness rules: [`docs/agents/issue-tracker.md`](docs/agents/issue-tracker.md).
+- Worker/reviewer responsibilities: [`docs/agents/worker-model.md`](docs/agents/worker-model.md).
+- Review policy: [`docs/agents/review-policy.md`](docs/agents/review-policy.md).
+- Quality gates: [`docs/agents/quality-gates.md`](docs/agents/quality-gates.md).
+- Durable Linear claim coordination uses runtime-owned `## Symphony Control`
+  comments. These are separate from the human-facing `## Codex Workpad` single
+  comment rule.
 
 ## Environment
 
@@ -43,13 +59,15 @@ for PR quality policy.
 ## Codebase-Specific Conventions
 
 - Runtime config is loaded from `WORKFLOW.md` front matter via `SymphonyElixir.Workflow` and `SymphonyElixir.Config`.
-- Agent PRs must follow the quality policy in [`docs/agent-quality-flywheel.md`](docs/agent-quality-flywheel.md).
+- Agent PRs must follow the quality policy in [`docs/agentic-flywheel-quality.md`](docs/agentic-flywheel-quality.md).
 - Keep the implementation aligned with [`../SPEC.md`](../SPEC.md) where practical.
   - The implementation may be a superset of the spec.
   - The implementation must not conflict with the spec.
   - If implementation changes meaningfully alter the intended behavior, update the spec in the same
     change where practical so the spec stays current.
 - Prefer adding config access through `SymphonyElixir.Config` instead of ad-hoc env reads.
+- Do not run Codex app-server automation with `model_reasoning_effort=minimal`;
+  use `low` or higher so app-server's default tool set is accepted by the API.
 - Workspace safety is critical:
   - Never run Codex turn cwd in source repo.
   - Workspaces must stay under configured workspace root.

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -15,7 +15,9 @@ clean.
 
 For a full walkthrough, read [docs/windows-native.md](docs/windows-native.md).
 For the small-team operating model behind the optimization loop, read
-[docs/small-team-agentic-flywheel.md](docs/small-team-agentic-flywheel.md).
+[docs/agentic-flywheel-setup.md](docs/agentic-flywheel-setup.md). The current
+two-instance worker/reviewer state machine is defined in
+[docs/agents/issue-tracker.md](docs/agents/issue-tracker.md).
 
 Quick setup:
 
@@ -41,13 +43,16 @@ Useful lifecycle commands:
 
 ```powershell
 .\scripts\start-windows-native.ps1 -WorkflowPath .\WORKFLOW.windows.md -Port 4011 -Background
+.\scripts\start-agent-flywheel.ps1 -WorkerWorkflowPath .\WORKFLOW.optimization.windows.md -ReviewerWorkflowPath .\WORKFLOW.optimization.reviewer.windows.md
 .\scripts\stop-windows-native.ps1 -Force
 .\scripts\install-windows-native-service.ps1 -WorkflowPath .\WORKFLOW.windows.md -Port 4011
 .\scripts\cleanup-windows-native.ps1 -WorkflowPath .\WORKFLOW.windows.md -IssueIdentifier ALB-11
 ```
 
-The install helper creates a Task Scheduler entry for the current Windows user. The cleanup helper
-requires explicit targets and refuses source-checkout-like workspace roots.
+The flywheel helper starts separate worker and reviewer background instances
+with separate ports, logs, and PID files. The install helper creates a Task
+Scheduler entry for the current Windows user. The cleanup helper requires
+explicit targets and refuses source-checkout-like workspace roots.
 
 Do not commit `WORKFLOW.windows.md` if it contains private repository URLs, project slugs, or other
 local details. Use `WORKFLOW.windows.safe.example.md` for first runs and
@@ -78,7 +83,7 @@ Symphony stops the active agent for that issue and cleans up matching workspaces
 1. Make sure your codebase is set up to work well with agents: see
    [Harness engineering](https://openai.com/index/harness-engineering/).
    For Symphony-managed PRs in this repo, also follow the
-   [agent quality flywheel policy](docs/agent-quality-flywheel.md).
+   [agentic flywheel quality policy](docs/agentic-flywheel-quality.md).
 2. Get a new personal token in Linear via Settings → Security & access → Personal API keys, and
    set it as the `LINEAR_API_KEY` environment variable.
 3. Copy this directory's `WORKFLOW.md` to your repo.
@@ -92,8 +97,8 @@ Symphony stops the active agent for that issue and cleans up matching workspaces
      least one matching label. Prefer a fixed Linear project first; use labels when that project
      must contain unrelated work.
    - When creating a workflow based on this repo, note that it depends on non-standard Linear
-     issue statuses: "Rework", "Human Review", and "Merging". You can customize them in
-     Team Settings → Workflow in Linear.
+     issue statuses: "Ready for Agent", "Needs Human Context", "Agent Review", "Rework", and
+     "Human Review". You can customize them in Team Settings → Workflow in Linear.
 6. Follow the instructions below to install the required runtime dependencies and start the service.
 
 ## Prerequisites

--- a/elixir/WORKFLOW.optimization.reviewer.windows.example.md
+++ b/elixir/WORKFLOW.optimization.reviewer.windows.example.md
@@ -1,0 +1,130 @@
+---
+prompt_context:
+  linear_project_name: YOUR_LINEAR_PROJECT_NAME
+  github_issue_label: symphony-optimization
+tracker:
+  kind: linear
+  api_key: $LINEAR_API_KEY
+  project_slug: "YOUR_LINEAR_PROJECT_SLUG"
+  # Optional: uncomment only if this project is shared with unrelated work.
+  # labels:
+  #   - symphony-optimization
+  dispatch_states:
+    - Agent Review
+  active_states:
+    - Agent Review
+  terminal_states:
+    - Human Review
+    - Rework
+    - Needs Human Context
+    - Blocked
+    - Done
+    - Canceled
+    - Cancelled
+    - Duplicate
+polling:
+  interval_ms: 5000
+workspace:
+  root: "D:/code/symphony-reviewer-workspaces"
+hooks:
+  timeout_ms: 300000
+  after_create: |
+    $ErrorActionPreference = "Stop"
+    git clone --depth 1 https://github.com/YOUR_GITHUB_OWNER/YOUR_REPO.git .
+    git remote set-url origin https://github.com/YOUR_GITHUB_OWNER/YOUR_REPO.git
+    git fetch origin main
+    git config user.email "codex-symphony@example.invalid"
+    git config user.name "Codex Symphony"
+    Set-Location elixir
+    mise trust
+    mise install
+    mise exec -- mix deps.get
+  before_remove: |
+    $ErrorActionPreference = "Stop"
+    git status --short
+agent:
+  max_concurrent_agents: 1
+  max_turns: 10
+codex:
+  command: codex --config shell_environment_policy.inherit=all --config model=gpt-5.5 --config model_reasoning_effort=medium app-server
+  approval_policy: never
+  read_timeout_ms: 30000
+  thread_sandbox: danger-full-access
+  review_readiness_repository: YOUR_GITHUB_OWNER/YOUR_REPO
+  review_readiness_required_checks:
+    - make-all
+    - validate-pr-description
+    - windows-native-test
+  review_readiness_guarded_states:
+    - Agent Review
+  turn_sandbox_policy:
+    type: dangerFullAccess
+---
+
+You are running the Symphony reviewer flywheel on Windows.
+
+Issue:
+- Identifier: {{ issue.identifier }}
+- Title: {{ issue.title }}
+- State: {{ issue.state }}
+- URL: {{ issue.url }}
+- Labels: {{ issue.labels }}
+
+Description:
+{% if issue.description %}
+{{ issue.description }}
+{% else %}
+No description provided.
+{% endif %}
+
+Reviewer operating model:
+
+1. You may run commands and make temporary verification edits inside the reviewer workspace when
+   that helps inspect behavior. Do not push reviewer edits, open a new implementation PR, or turn
+   exploratory changes into implementation work.
+2. Read the Linear issue, the `## Codex Workpad`, linked GitHub issue or `## Agent Brief`,
+   linked PR, CI/check status, and PR diff.
+3. Review on two separate axes:
+   - Standards Review: repo conventions, ADRs, architecture/TDD standards, quality gates,
+     stale-base overlap, coverage policy, and evidence quality.
+   - Spec Review: the implementation satisfies the Agent Brief, PRD, acceptance criteria,
+     required tests, required evidence, dependencies, and explicit out-of-scope boundaries.
+4. Write the review result to the Workpad and, when useful, the PR conversation:
+
+   ```md
+   ## Standards Review
+
+   ### Blocking
+
+   ### Non-Blocking
+
+   ### Missing Evidence
+
+   ## Spec Review
+
+   ### Blocking
+
+   ### Non-Blocking
+
+   ### Missing Evidence
+   ```
+
+5. Move the Linear issue based on the review result:
+   - `Human Review` when both axes have no blocking findings and required evidence is present.
+   - `Rework` when the spec is clear and bounded worker fixes are needed.
+   - `Needs Human Context` when the spec, acceptance criteria, dependency state, or decision
+     authority is insufficient.
+   - `Blocked` when GitHub, Linear, Codex, CI, environment, dependency, or deployment failure
+     prevents review.
+6. If you move to `Rework`, make the blocking findings concrete enough for a worker to fix without
+   another review discussion.
+7. If you move to `Needs Human Context`, state the exact human answer needed.
+8. If you move to `Blocked`, include failed command/API, evidence, recovery attempted, and the next
+   operator action.
+
+Quality bar:
+
+- Passing checks are necessary evidence, not proof of intent.
+- Do not approve scope creep merely because tests pass.
+- Do not ask a worker to resolve unclear product or architecture decisions by guessing.
+- Do not broaden the issue; file or link follow-up defects when review discovers adjacent work.

--- a/elixir/WORKFLOW.optimization.windows.example.md
+++ b/elixir/WORKFLOW.optimization.windows.example.md
@@ -12,14 +12,20 @@ tracker:
   # Optional: uncomment only if this project is shared with unrelated work.
   # labels:
   #   - symphony-optimization
-  # Poll only release-ready work. Keep Backlog and In Progress out of dispatch_states.
+  # Poll only worker-ready work. Keep Backlog and In Progress out of dispatch_states.
   dispatch_states:
-    - Todo
-  # Keep In Progress active so workers are not stopped after they claim a Todo issue.
+    - Ready for Agent
+    - Rework
+  # Keep In Progress active so workers are not stopped after they claim an issue.
   active_states:
-    - Todo
+    - Ready for Agent
     - In Progress
+    - Rework
   terminal_states:
+    - Agent Review
+    - Human Review
+    - Needs Human Context
+    - Blocked
     - Done
     - Canceled
     - Cancelled
@@ -52,6 +58,7 @@ agent:
 codex:
   command: codex --config shell_environment_policy.inherit=all --config model=gpt-5.5 --config model_reasoning_effort=medium app-server
   approval_policy: never
+  read_timeout_ms: 30000
   thread_sandbox: danger-full-access
   # Used when GitHub branch protection required-check metadata is private or unavailable.
   review_readiness_repository: YOUR_GITHUB_OWNER/YOUR_REPO
@@ -64,6 +71,8 @@ codex:
     - make-all
     - validate-pr-description
     - windows-native-test
+  review_readiness_guarded_states:
+    - Agent Review
   turn_sandbox_policy:
     type: dangerFullAccess
 ---
@@ -87,9 +96,11 @@ No description provided.
 Operating model:
 
 1. Work only in the current workspace.
-2. If the Linear issue is Todo, move it to In Progress before implementation.
+2. If the Linear issue is `Ready for Agent` or `Rework`, move it to `In Progress` before implementation.
 3. Use exactly one Linear comment whose first line is `## Codex Workpad`; update it instead of creating progress spam.
-4. Use the linked GitHub issue as the durable public implementation spec.
+4. Use the linked GitHub issue or embedded `## Agent Brief` as the durable implementation spec.
+   If the issue lacks enough context, acceptance criteria, dependency state, testing intent, or
+   decision authority, write the missing context into the Workpad and move it to `Needs Human Context`.
 5. Keep changes focused on the current Linear/GitHub issue.
 6. Create a branch named `codex/<linear-identifier>-<short-topic>`.
 7. Run focused validation before committing.
@@ -99,9 +110,9 @@ Operating model:
 9. Open a GitHub pull request against `main` and link it in the Linear workpad.
    If the Linear issue has one unambiguous origin GitHub issue, include a supported closing keyword
    in the PR body, for example `Fixes #NN`.
-10. Wait for required GitHub checks to complete before moving the Linear issue to `In Review`.
+10. Wait for required GitHub checks to complete before moving the Linear issue to `Agent Review`.
     If checks cannot be verified, record the exact reason in the workpad and PR, then keep the
-    issue in `In Progress` or return it to `Todo`; only a manager may explicitly override this.
+    issue in `In Progress` or return it to `Rework`; only a manager may explicitly override this.
     When checks are verified through GitHub CLI, connector, or another non-REST path, record this
     exact machine-readable evidence in the `## Codex Workpad`:
     `PR: https://github.com/{{ workflow.codex.review_readiness_repository }}/pull/<number>`
@@ -109,7 +120,7 @@ Operating model:
     `- make-all run <run-id>: success.`
     `- validate-pr-description run <run-id>: success.`
     `- windows-native-test run <run-id>: success.`
-11. Do not move unrelated Backlog issues to Todo.
+11. Do not move unrelated Backlog issues to `Ready for Agent`.
 12. If you discover an automation/system defect:
     - Search existing open and recently closed GitHub issues plus Linear mirrors for the same root
       cause before creating anything new.
@@ -147,17 +158,17 @@ Quality bar:
   GitHub base ref for manager-side stale-base checks unless the workflow
   explicitly configures another trusted remote.
 - Run `mix format` for touched Elixir files.
-- Follow `docs/agent-quality-flywheel.md` for PR quality gates, review loop rules, and defect
+- Follow `docs/agentic-flywheel-quality.md` for PR quality gates, review loop rules, and defect
   protocol.
 - Run focused Windows shell and workspace/config tests when touching Windows runtime or workflow
   behavior:
   `make windows-native-test`.
-- Do not move the issue to `In Review` while required checks are pending or failing.
-- For non-trivial changes, request manager/subagent review before handoff and record the review
-  request plus findings in the PR and/or Workpad.
-- If review finds blocking issues, keep the issue in `In Progress` or return it to `Todo` until
-  the findings are addressed and required checks pass.
+- Do not move the issue to `Agent Review` while required checks are pending or failing.
+- `Agent Review` is the reviewer-agent queue. Do not move directly to `Human Review` unless a
+  manager explicitly instructs you to do so.
+- If review finds blocking issues, move through `Rework`, address only those findings, and return
+  to `Agent Review` after required checks pass.
 - Write CI/runtime failures back to the Linear Workpad or linked GitHub issue before ending.
 - Do not broaden scope to multiple optimization issues in one PR.
 - If blocked by credentials or permissions, record the exact blocker in the Workpad and keep the
-  issue out of `In Review` unless a manager explicitly moves it there.
+  issue out of `Agent Review` unless a manager explicitly moves it there.

--- a/elixir/docs/agentic-flywheel-quality.md
+++ b/elixir/docs/agentic-flywheel-quality.md
@@ -1,8 +1,16 @@
-# Agent quality flywheel
+# Agentic flywheel quality discipline
 
-This policy defines the minimum review and validation loop for Symphony-managed agent PRs. It is
-intended to be copied into workflow prompts and used by humans when deciding whether an issue can
-leave active work.
+This policy defines the minimum validation, Workpad, blocker, review, and state
+discipline for Symphony-managed agent PRs. It is the companion to
+[agentic-flywheel-setup.md](agentic-flywheel-setup.md), which covers
+project setup and operating rhythm.
+
+The canonical Linear state machine lives in
+[`agents/issue-tracker.md`](agents/issue-tracker.md). In the current target
+workflow, `Agent Review` is the machine review queue and `Human Review` is the
+human acceptance queue. Older workflow files may still use `In Review`; the
+protected review destination is configured through
+`codex.review_readiness_guarded_states`.
 
 ## Required gates
 
@@ -20,12 +28,12 @@ Every agent PR must record these checks in the PR body and the Linear `## Codex 
 
 Agents should run focused validation before committing. `make all` should run before handoff when
 the local environment can support the full gate. If a gate cannot be run locally, the PR and workpad
-must say why, and the issue must stay out of `In Review` until required GitHub checks pass or a
+must say why, and the issue must stay out of `Agent Review` until required GitHub checks pass or a
 manager explicitly moves it.
 
 Agents must not weaken, skip, disable, or relax CI, lint, formatter, or test gates to land agent
 work. If a gate is wrong or flaky, file or link a follow-up defect and keep the current issue out of
-`In Review` until the required checks pass or a manager explicitly overrides the state transition.
+`Agent Review` until the required checks pass or a manager explicitly overrides the state transition.
 
 Coverage is a quality signal, not a mechanical target. The repository keeps a high total coverage
 threshold, but it is intentionally below 100% so workers are not forced to add filler tests for
@@ -35,13 +43,35 @@ made through an explicit issue and review, not as a drive-by workaround in an un
 
 Coverage ignore changes are gate changes. A PR must not add a production module to
 `test_coverage.ignore_modules` when that same module is changed in the PR. The review-readiness
-gate rejects that overlap before an agent can move the Linear issue to review. If a manager believes
-an exception is justified, the manager must audit it outside the agent session and leave an explicit
-approval note; the agent cannot self-approve the transition.
+gate rejects that overlap before an agent can move the Linear issue to `Agent Review`. If a manager
+believes an exception is justified, the manager must audit it outside the agent session and leave an
+explicit approval note; the agent cannot self-approve the transition.
 
 Stale-base overlap is also not review-ready. When the PR's recorded base SHA is behind the current
 base branch and files changed on current base overlap files changed in the PR, the agent must merge
 current base, resolve the overlap, and rerun validation before handoff.
+
+## Local validation fallback
+
+Focused local checks are preferred while iterating. Broad or coverage-heavy
+gates should run locally when the environment supports them, but workers should
+not burn repeated turns on ambiguous local tooling failures.
+
+In Codex App sessions, run broad gates such as `make all`, `make.cmd
+windows-native-test`, or `mix test --cover` with stdout/stderr redirected to a
+log file. If the tool call times out or is interrupted:
+
+1. Inspect the log tail and search for final result markers such as `Coverage`,
+   `Threshold`, `failures`, and `Generated HTML coverage results`.
+2. Check for residual `mix`, `beam`, `erl`, `elixir`, or `mise` processes.
+3. If the log contains a final result, use that result instead of rerunning.
+4. If the log is incomplete and no matching process remains, rerun at most once
+   with a fresh log path only when a local result is required before pushing.
+5. Otherwise push and use formal GitHub CI as the verification source, recording
+   the command, log path, process check, and CI handoff reason.
+
+This is not permission to skip quality gates. It is a token-control policy for
+unreliable local broad-gate execution.
 
 ## Review loop
 
@@ -72,14 +102,52 @@ changing or encoding operating policy, workflow expectations, state transitions,
 review rules, and all required documentation checks pass.
 
 Record the review request and outcome in the PR conversation or Linear workpad. If the review finds
-blocking issues, keep the Linear issue in `In Progress` or return it to `Todo` until the findings are
-addressed and required checks are green.
+blocking issues, move the Linear issue to `Rework` when the fix is bounded, or `Needs Human Context`
+when the spec is incomplete. Keep it out of `Human Review` until findings are addressed and required
+checks are green.
+
+## Workpad and blocker discipline
+
+Use exactly one Linear comment whose first line is:
+
+```md
+## Codex Workpad
+```
+
+Update that comment instead of adding progress spam. Runtime-owned
+`## Symphony Control` comments are the exception to the single-comment rule:
+they are reserved for durable claim coordination and must not be used for human
+progress notes. A useful Workpad records:
+
+- Status: current phase and whether the issue is blocked.
+- Scope: GitHub issue, branch, PR, and linked acceptance criteria.
+- Plan: the next concrete steps.
+- Validation: commands run, outcomes, log paths, and CI handoff reason when
+  local broad gates are ambiguous.
+- Review: reviewer requested, findings, and resolution.
+- Checks: required GitHub check status.
+- Blockers: exact missing credential, permission, environment, dependency, or
+  system condition.
+
+Routine retries and recovered failures belong in the Workpad. Create a separate
+problem comment only when the failure changes the plan, requires a workaround,
+consumes operator attention, or blocks completion.
+
+Environment and pipeline blockers need capability evidence, not repeated blind
+retries. Before handoff, run or cite
+`mix symphony.preflight.windows --capabilities-only --json <WORKFLOW>` when the
+failure may involve OS, shell, PowerShell, `tasklist`, GitHub CLI, Linear auth,
+coverage policy, or line endings. The Workpad entry must state the failed
+command, capability result, local recovery attempted, and manager action needed.
+If the blocker matches an existing canonical system issue, comment there with
+the new evidence instead of creating a duplicate.
 
 ## Linear and GitHub state rules
 
-Agents must not move a Linear issue to `In Review` solely because a branch was pushed. `In Review`
-means a PR exists, required checks have completed and passed, and required manager/subagent review
-findings have been addressed, unless a manager explicitly moves the issue there.
+Agents must not move a Linear issue to `Agent Review` solely because a branch was pushed. `Agent
+Review` means a PR exists, required checks have completed and passed, and the Workpad contains
+enough validation evidence for a reviewer agent to inspect the work. `Human Review` means the
+reviewer agent found no blocking standards or spec findings and human acceptance remains.
 
 When a Linear issue has one unambiguous origin GitHub issue in the trusted repository, the linked PR
 must close that GitHub issue through the PR body before review handoff. Use a supported closing
@@ -89,17 +157,11 @@ unrelated or still-active GitHub issue.
 
 Pending, failing, or unverifiable required checks are not review-ready. The agent must write the
 failure or blocker to the workpad and/or linked GitHub issue or PR, then keep the issue in
-`In Progress` or return it to `Todo`. If a true blocker prevents completion, the agent should move
-the issue to `Blocked` when that state exists. If Linear returns `:state_not_found` or the workflow
-has no `Blocked` state, the agent must record `Blocked state missing` and keep the issue active for
-manager triage.
-
-Environment and pipeline blockers need capability evidence, not repeated blind retries. Before
-handoff, run or cite `mix symphony.preflight.windows --capabilities-only --json <WORKFLOW>` when the
-failure may involve OS, shell, PowerShell, `tasklist`, GitHub CLI, Linear auth, coverage policy, or
-line endings. The Workpad entry must state the failed command, capability result, local recovery
-attempted, and manager action needed. If the blocker matches an existing canonical system issue,
-comment there with the new evidence instead of creating a duplicate.
+`In Progress` or return it to `Rework` when it was already in a repair loop. If the issue brief is
+insufficient, move it to `Needs Human Context`. If a true blocker prevents completion, the agent
+should move the issue to `Blocked` when that state exists. If Linear returns `:state_not_found` or
+the workflow has no `Blocked` state, the agent must record `Blocked state missing` and keep the issue
+active for manager triage.
 
 Human triage for agent-written blocker comments:
 
@@ -112,7 +174,7 @@ Human triage for agent-written blocker comments:
   consolidate future notes into the workpad.
 
 If a required gate fails, the agent must summarize the failure in the workpad or linked GitHub issue
-and keep the Linear issue in `In Progress` or return it to `Todo` for repair. Failures discovered by
+and keep the Linear issue in `In Progress` or move it to `Rework` for repair. Failures discovered by
 automation should create a GitHub issue with the `symphony-optimization` label when they describe a
 system defect outside the current PR.
 
@@ -129,13 +191,6 @@ Use this manager-run path only for already completed work:
 
 This reconciliation is intentionally explicit. Agents should prevent new stale issues with PR closing
 keywords; they should not bulk-close GitHub issues for active or ambiguous Linear work.
-
-## Problem comment scope
-
-Agents should not create issue comments for every failed command. Use the persistent workpad for
-ordinary retries, dependency installs that recover, and validation failures fixed within the same
-plan. Create a separate problem comment only when the failure changes the plan, requires a
-workaround, consumes operator attention, or blocks completion.
 
 ## Commit and PR conventions
 

--- a/elixir/docs/agentic-flywheel-setup.md
+++ b/elixir/docs/agentic-flywheel-setup.md
@@ -1,22 +1,29 @@
-# Small-team agentic build flywheel
+# Agentic flywheel setup and operations
 
-This playbook describes a lightweight agentic build loop for small teams using
-Linear, GitHub, Symphony, and Codex. It is intentionally smaller than an
-enterprise harness: the durable system is a queue, a thin orchestrator, clear
-quality gates, and a human manager who keeps the loop pointed at the right work.
+This playbook describes how to set up and operate an agentic build loop using
+Linear, GitHub, Symphony, and Codex. It covers project setup, the runtime loop,
+manager responsibilities, worker and reviewer handoff, pause and resume, and
+how to reuse the pattern on another repository.
 
 Use this pattern when a project has enough repeatable engineering work for
 automation, but still needs human product judgment, review, and prioritization.
+The canonical state machine and role boundaries live under
+[`docs/agents/`](agents/). For the quality discipline that makes the loop safe,
+read [agentic-flywheel-quality.md](agentic-flywheel-quality.md).
 
 ## Roles
 
 - Linear project: the private operating queue and state machine.
 - GitHub issues: the durable public implementation backlog and acceptance
   criteria.
-- Symphony: a thin dispatcher that polls eligible Linear work, creates isolated
-  workspaces, and starts Codex app-server sessions.
-- Codex agents: implementers that make scoped changes, validate them, open PRs,
-  and leave evidence.
+- Worker Symphony: a dispatcher that polls `Ready for Agent` and `Rework`,
+  creates isolated workspaces, and starts implementer Codex sessions.
+- Reviewer Symphony: a dispatcher that polls `Agent Review` and starts
+  reviewer Codex sessions.
+- Worker Codex agents: implementers that make scoped changes, validate them,
+  open PRs, and leave evidence.
+- Reviewer Codex agents: reviewers that do not edit code and instead report
+  standards/spec findings and move issues to the next review state.
 - Human manager: the upper-level product and quality owner who orders work,
   handles ambiguous tradeoffs, reviews results, and keeps production saturated.
 - Codex Workpad: one persistent Linear comment that records the current plan,
@@ -28,18 +35,20 @@ automation, but still needs human product judgment, review, and prioritization.
 2. The manager mirrors or routes one small piece of work into the Linear
    flywheel project.
 3. Backlog work stays parked in `Backlog`; Symphony does not poll it.
-4. The manager moves one issue at a time to `Todo` when it is eligible for
-   automation.
-5. Symphony claims eligible `Todo` or active work and starts a Codex session in
-   a fresh workspace.
+4. The manager moves ready DAG nodes to `Ready for Agent` when they are eligible
+   for automation.
+5. Worker Symphony claims eligible `Ready for Agent` or `Rework` issues and
+   starts a Codex session in a fresh workspace.
 6. The agent moves the issue to `In Progress`, creates or updates the single
    `## Codex Workpad`, and implements only the linked issue.
 7. The agent pushes a focused branch, opens a PR, records validation and review
    evidence, and waits for required checks.
-8. The issue moves to review only after the PR exists and required checks pass.
-   If review finds blocking issues, the work stays in or returns to an active
-   state until those findings are addressed.
-9. Defects discovered while running the loop become new GitHub issues and, when
+8. The issue moves to `Agent Review` only after the PR exists and required
+   checks pass. Reviewer Symphony then runs an independent standards/spec
+   review.
+9. Passing review moves the issue to `Human Review`; blocking findings move it
+   to `Rework`; missing spec context moves it to `Needs Human Context`.
+10. Defects discovered while running the loop become new GitHub issues and, when
    appropriate, Linear mirrors in the flywheel project.
 
 This makes the flywheel self-improving: the system uses normal engineering
@@ -52,37 +61,58 @@ Before starting unattended work, prepare the project:
 1. Create or choose a Linear project dedicated to the flywheel.
 2. Configure states so parked work is not eligible for polling:
    - `Backlog`: parked, not polled.
-   - `Todo`: eligible for Symphony.
-   - `In Progress`: active agent work.
+   - `Needs Human Context`: missing spec, acceptance criteria, dependency
+     state, or decision authority.
+   - `Ready for Agent`: eligible for worker Symphony.
+   - `In Progress`: active worker implementation.
    - `Blocked`: missing dependency, credentials, environment, or orchestration
      capability.
-   - `In Review`: PR exists, required checks passed, and review is requested or
-     underway. Work with unresolved blocking review findings stays in or returns
-     to an active work state.
+   - `Agent Review`: PR exists, required checks passed, and reviewer Symphony
+     should inspect the result.
+   - `Rework`: reviewer found bounded blocking findings for a worker to fix.
+   - `Human Review`: reviewer passed the work and human acceptance remains.
    - `Done`, `Canceled`, `Cancelled`, `Duplicate`: terminal states.
 3. Keep GitHub issues as the durable implementation specs. Linear descriptions
    can mirror GitHub, but implementation discussion should stay in GitHub when
    it needs to be public or reviewable later.
-4. Configure the workflow prompt to require a single `## Codex Workpad`, focused
-   branches, validation evidence, PR creation, and no review transition while
-   required checks are pending or failing.
-5. On Windows, copy the optimization workflow example, edit it for the project,
-   and run preflight from `elixir/`:
+4. Configure the worker workflow prompt to require a single `## Codex Workpad`,
+   focused branches, validation evidence, PR creation, and no `Agent Review`
+   transition while required checks are pending or failing.
+5. Configure a reviewer workflow prompt that performs review only and moves
+   issues to `Human Review`, `Rework`, `Needs Human Context`, or `Blocked`.
+6. On Windows, copy the worker and reviewer workflow examples, edit them for
+   the project, and run preflight from `elixir/`:
 
    ```powershell
    Copy-Item .\WORKFLOW.optimization.windows.example.md .\WORKFLOW.optimization.windows.md
+   Copy-Item .\WORKFLOW.optimization.reviewer.windows.example.md .\WORKFLOW.optimization.reviewer.windows.md
    notepad .\WORKFLOW.optimization.windows.md
+   notepad .\WORKFLOW.optimization.reviewer.windows.md
    mise exec -- mix symphony.preflight.windows .\WORKFLOW.optimization.windows.md
+   mise exec -- mix symphony.preflight.windows .\WORKFLOW.optimization.reviewer.windows.md
    ```
 
-6. Start with `agent.max_concurrent_agents: 1`. Increase concurrency only after
+7. Start with `agent.max_concurrent_agents: 1`. Increase concurrency only after
    claim behavior, review readiness, and CI reporting are reliable.
-7. Move the next issue from `Backlog` to `Todo`.
-8. Start Symphony and monitor the dashboard and Linear Workpad.
+8. Move the next issue from `Backlog` to `Ready for Agent`.
+9. Start the worker and reviewer Symphony instances and monitor the dashboards
+   and Linear Workpad.
 
 For the Windows-native optimization project, use
 [`WORKFLOW.optimization.windows.example.md`](../WORKFLOW.optimization.windows.example.md)
-as the baseline workflow.
+as the worker baseline and
+[`WORKFLOW.optimization.reviewer.windows.example.md`](../WORKFLOW.optimization.reviewer.windows.example.md)
+as the reviewer baseline. Start both local files together with
+`scripts/start-agent-flywheel.ps1` after editing the Linear project slug,
+repository URL, workspace roots, and required checks.
+
+The flywheel start script treats the two instances as one startup unit by
+default: both worker and reviewer must start, publish PID metadata, and listen
+on their configured ports. If reviewer startup fails after the worker is up, the
+script stops the worker and prints the failed phase, reason, worker/reviewer log
+roots, and cleanup status. Use `-AllowPartial` only for explicit debugging when
+you want to keep a successfully started worker while investigating reviewer
+startup; the script reports `Partial startup` in that mode.
 
 ## Keeping production saturated
 
@@ -94,98 +124,49 @@ Good saturation looks like:
 
 - A small number of active issues, each scoped to one PR.
 - A ready queue of `Backlog` issues that can be promoted one at a time.
-- Clear GitHub acceptance criteria before an issue reaches `Todo`.
+- Clear GitHub acceptance criteria before an issue reaches `Ready for Agent`.
 - Explicit dependency notes so prerequisite work lands or deploys before
-  dependent issues are released to `Todo`.
+  dependent issues are released to `Ready for Agent`.
 - Fast human responses to true blockers.
 - Follow-up issues for discovered defects instead of broadening the active PR.
 
-Avoid moving many speculative issues to `Todo` before the claim, lease, and
-quality gates are proven. A small team gets better throughput from predictable
-handoffs than from maximum parallelism.
+Avoid moving many speculative issues to `Ready for Agent` before the claim,
+lease, and quality gates are proven. A small team gets better throughput from
+predictable handoffs than from maximum parallelism.
 
 Dependent work is not independent capacity. If issue B depends on issue A,
 keep B parked in `Backlog` until A is merged and deployed when deployment is
-part of the unblock condition. Releasing both into `Todo` at the same time
-usually creates stale branches, repeated validation, and misleading `Blocked`
-states.
+part of the unblock condition. Releasing both into `Ready for Agent` at the
+same time usually creates stale branches, repeated validation, and misleading
+`Blocked` states.
 
-## Guardrails that stop quality debt from compounding
+## Quality discipline
 
 Generated work compounds quickly when low-quality PRs are allowed to become the
-base for later agents. These guardrails are the minimum bar:
+base for later agents. Keep this document focused on setup and operating rhythm;
+put quality rules, local validation fallback, blocker protocol, Workpad
+discipline, review readiness, and PR conventions in
+[agentic-flywheel-quality.md](agentic-flywheel-quality.md).
 
-- Workers should start from the repository-level
-  [agent entrypoint playbook](../../AGENTS.md) so recurring Windows and
-  flywheel facts are not rediscovered every run.
-- One issue, one branch, one PR.
-- Branches use `codex/<linear-identifier>-<short-topic>`.
-- Commits use lightweight Conventional Commits.
-- The Linear Workpad records the plan, validation, blockers, PR link, review
-  status, and any CI/runtime failures.
-- The PR body follows the repository template and includes concrete validation
-  evidence.
-- PRs for Linear issues with one unambiguous origin GitHub issue include a closing
-  keyword such as `Fixes #NN` in the PR body.
-- `make all` is the repository gate when the local environment supports it.
-- `windows-native-test` runs for Windows shell, workspace/config, workflow, or
-  path-handling changes.
-- CI, lint, formatter, and test gates must not be weakened, skipped, disabled,
-  or relaxed to land agent work.
-- Required GitHub checks must complete and pass before an agent moves Linear to
-  `In Review`.
-- Meaningful changes get an independent SubAgent review loop before handoff.
-  This includes docs that encode operating decisions, workflow policy, state
-  transitions, quality gates, or review rules. Manager review is still useful,
-  but manager-only approval does not satisfy this gate.
-- Blocking review findings keep the issue in `In Progress` or return it to
-  `Todo` until fixed.
-
-See [agent-quality-flywheel.md](agent-quality-flywheel.md) for the detailed PR
-quality policy used by this repository.
-
-See [manager-agent-runbook.md](manager-agent-runbook.md) for the manager
-orchestration loop used to review completed work, investigate blockers, release
-ready issues into `Todo`, keep workers saturated, and verify deployed system
-changes.
-
-## Workpad discipline
-
-Use exactly one Linear comment whose first line is:
-
-```md
-## Codex Workpad
-```
-
-Update that comment instead of adding progress spam. A useful Workpad has:
-
-- Status: current phase and whether the issue is blocked.
-- Scope: GitHub issue, branch, PR, and linked acceptance criteria.
-- Plan: the next few concrete steps.
-- Validation: commands run and outcomes.
-- Review: reviewer requested, findings, and resolution.
-- Checks: required GitHub check status.
-- Blockers: exact missing credential, permission, environment, dependency, or
-  system condition.
-
-Use a separate Linear problem comment only when a failure changes the plan,
-requires a workaround, consumes operator attention, or blocks completion. Routine
-retry noise belongs in the Workpad.
+Managers should use [manager-agent-runbook.md](manager-agent-runbook.md) for the
+operational loop: review completed work, investigate blockers, release ready
+issues into `Ready for Agent`, keep workers saturated, and verify deployed
+system changes.
 
 ## Pausing safely
 
 Pause the flywheel by stopping new dispatch first, then letting active work land
 or park cleanly:
 
-1. Stop moving new issues from `Backlog` to `Todo`.
-2. If immediate pause is needed, remove `Todo` from `tracker.dispatch_states` or
-   stop the Symphony process.
+1. Stop moving new issues from `Backlog` to `Ready for Agent`.
+2. If immediate pause is needed, remove `Ready for Agent` from the worker
+   `tracker.dispatch_states` or stop the worker Symphony process.
 3. Let active agents finish their current turn when possible.
 4. For unfinished active issues, update the Workpad with the current branch,
    last validation result, exact blocker or pause reason, and next resume step.
 5. Move truly blocked work to `Blocked` when that state exists. If it does not,
    record `Blocked state missing` and keep the issue active for manager triage.
-6. Do not move issues to `In Review` only because a branch or PR exists.
+6. Do not move issues to `Agent Review` only because a branch or PR exists.
 
 When resuming, inspect the Workpad first, then the PR or branch, then restart
 Symphony with the same workflow boundaries.
@@ -195,11 +176,13 @@ Symphony with the same workflow boundaries.
 To reuse this pattern outside Symphony:
 
 1. Create a dedicated Linear project or label route for agentic work.
-2. Decide which Linear states are active and terminal.
+2. Decide which Linear states are active and terminal, using
+   [`agents/issue-tracker.md`](agents/issue-tracker.md) as the default state
+   model.
 3. Add a workflow prompt that encodes the team's branch, commit, validation,
    Workpad, blocker, and review rules.
 4. Add a project-local quality document equivalent to
-   `agent-quality-flywheel.md`.
+   `agentic-flywheel-quality.md`.
 5. Start with one trusted repository and one agent at a time.
 6. Make every automation defect visible as a normal backlog issue.
 7. Expand concurrency only after the team trusts the claim behavior, CI signal,
@@ -207,12 +190,13 @@ To reuse this pattern outside Symphony:
 
 ### Project configuration checklist
 
-Before moving real work into `Todo`, make these project-specific settings
-explicit. Treat this as the minimum hard configuration for a new repo:
+Before moving real work into `Ready for Agent`, make these project-specific
+settings explicit. Treat this as the minimum hard configuration for a new repo:
 
 - **Linear routing:** project slug, team, eligible labels if any, and exact state
-  names. Keep `Backlog` out of `tracker.dispatch_states`; normally only `Todo`
-  should be dispatchable.
+  names. Keep `Backlog` out of `tracker.dispatch_states`; worker instances
+  normally dispatch only `Ready for Agent` and `Rework`; reviewer instances
+  normally dispatch only `Agent Review`.
 - **GitHub routing:** repository owner/name, trusted issue labels, branch base,
   PR template, and required checks. Required check names must match the checks
   GitHub actually reports.

--- a/elixir/docs/agents/artifact-paths.md
+++ b/elixir/docs/agents/artifact-paths.md
@@ -1,0 +1,20 @@
+# Agent Artifact Paths
+
+Use these paths as the default locations for durable agent workflow artifacts.
+
+- Architecture canvas: `elixir/docs/agents/canvas.md`
+- Visual architecture canvas: `elixir/docs/agents/canvas.html`
+- PRDs and specs: `elixir/docs/prd/`
+- Issue DAGs: `elixir/docs/implementation/`
+- Agent workflow rules: `elixir/docs/agents/`
+- Review evidence: Linear Workpad, GitHub PR conversation, and PR body
+  `Test Plan`
+- Runtime evidence: Symphony dashboard, worker detail pages, logs root, and
+  linked CI runs
+
+GitHub issues remain the durable public implementation specs when public
+traceability is needed. Linear descriptions may mirror the brief but should not
+be the only durable source for complex specs.
+
+Do not commit local workflow files that contain private project slugs, tokens,
+workspace roots, or repository URLs.

--- a/elixir/docs/agents/domain.md
+++ b/elixir/docs/agents/domain.md
@@ -1,0 +1,29 @@
+# Agent Workflow Domain
+
+Symphony is the Windows-native orchestration service that polls Linear, creates
+isolated workspaces, and starts Codex app-server sessions.
+
+## Core Concepts
+
+- Linear project: private operating queue and state machine.
+- GitHub issue: durable public spec and acceptance criteria when the work needs
+  traceability.
+- Linear blocker relation: DAG edge between issue nodes.
+- Worker Symphony: dispatcher for implementation work.
+- Reviewer Symphony: dispatcher for independent agent review.
+- Agent Brief: minimum context contract for autonomous work.
+- Codex Workpad: single Linear comment recording status, plan, evidence,
+  blockers, and review outcome.
+- Review readiness: guard that prevents premature movement into the machine
+  review queue.
+
+## Durable Workflow Docs
+
+- Issue tracker and state machine: `issue-tracker.md`
+- Worker and reviewer responsibilities: `worker-model.md`
+- Review policy: `review-policy.md`
+- Quality gates: `quality-gates.md`
+- Artifact paths: `artifact-paths.md`
+
+Older operational docs under `elixir/docs/` should defer to these files when
+state names or role boundaries differ.

--- a/elixir/docs/agents/issue-tracker.md
+++ b/elixir/docs/agents/issue-tracker.md
@@ -1,0 +1,153 @@
+# Agent Issue Tracker
+
+This repo uses Linear as the private operating queue for agentic work and
+GitHub issues as the durable public implementation spec when public review or
+long-term traceability is needed.
+
+## Linear States
+
+Use these states for the agent build workflow:
+
+- `Backlog`: parked work, design notes, or DAG nodes that are not ready for an
+  agent.
+- `Needs Human Context`: the issue lacks enough context, acceptance criteria,
+  dependency state, or decision authority for an agent to proceed safely.
+- `Ready for Agent`: the only normal state a worker Symphony instance should
+  poll for new implementation work.
+- `In Progress`: a worker has claimed the issue and is implementing or
+  validating it.
+- `Agent Review`: worker handoff queue. The PR, required checks, Workpad, and
+  evidence must be ready before a worker moves an issue here.
+- `Rework`: reviewer found blocking findings. The worker should address only
+  the recorded findings and return through `Agent Review`.
+- `Human Review`: reviewer passed the issue and human review, merge, or final
+  acceptance is needed.
+- `Blocked`: a tool, credential, environment, dependency, CI, deployment, or
+  system condition prevents progress. This is not for missing product context.
+- `Done`: terminal success.
+- `Canceled`, `Cancelled`, `Duplicate`: terminal non-success outcomes.
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+  Backlog --> NeedsHumanContext: spec incomplete
+  Backlog --> ReadyForAgent: spec ready and blockers clear
+  NeedsHumanContext --> ReadyForAgent: human fills context
+  ReadyForAgent --> InProgress: worker claims
+  Rework --> InProgress: worker claims fixes
+  InProgress --> AgentReview: PR and checks ready
+  InProgress --> NeedsHumanContext: important decision or unclear spec
+  InProgress --> Blocked: external/system blocker
+  AgentReview --> HumanReview: reviewer passes
+  AgentReview --> Rework: blocking review findings
+  AgentReview --> NeedsHumanContext: reviewer cannot verify spec
+  AgentReview --> Blocked: review blocked by tooling/system
+  HumanReview --> Done: human accepts or merge completes
+```
+
+## Symphony Routing
+
+Run separate Symphony instances for worker and reviewer roles.
+
+Worker workflow:
+
+```yaml
+tracker:
+  dispatch_states:
+    - Ready for Agent
+    - Rework
+  active_states:
+    - Ready for Agent
+    - In Progress
+    - Rework
+  terminal_states:
+    - Agent Review
+    - Human Review
+    - Needs Human Context
+    - Blocked
+    - Done
+    - Canceled
+    - Cancelled
+    - Duplicate
+```
+
+Reviewer workflow:
+
+```yaml
+tracker:
+  dispatch_states:
+    - Agent Review
+  active_states:
+    - Agent Review
+  terminal_states:
+    - Rework
+    - Human Review
+    - Needs Human Context
+    - Blocked
+    - Done
+    - Canceled
+    - Cancelled
+    - Duplicate
+```
+
+The worker should move `Ready for Agent` or `Rework` issues to `In Progress`
+before editing. The reviewer should not edit product code.
+
+## DAG Release
+
+Use Linear blocking relations as the execution DAG. A DAG node is releasable
+only when:
+
+- all non-terminal blockers are resolved,
+- the issue brief satisfies the readiness contract below,
+- the work is worker-safe rather than manager-owned,
+- dependencies that require deployment are merged and deployed, not merely
+  coded.
+
+Keep unreleased DAG nodes in `Backlog`. Move exactly the ready nodes to
+`Ready for Agent`. Do not use `Todo` as an automation queue.
+
+## Agent Brief Readiness
+
+An issue can enter `Ready for Agent` only when it has enough information for a
+worker and reviewer to judge success independently:
+
+```markdown
+## Agent Brief
+
+**Category:** bug / enhancement / docs / chore
+**Summary:** one-line description
+
+## Current Behavior
+
+## Desired Behavior
+
+## What To Build
+
+## Key Interfaces
+
+## Acceptance Criteria
+
+- [ ] Observable criterion
+
+## Required Tests
+
+## Required Evidence
+
+## Dependencies
+
+- Blocked by:
+- Blocks:
+
+## Decision Policy
+
+- Agent may decide:
+- Return to Needs Human Context when:
+
+## Out Of Scope
+```
+
+If the brief is missing clear scope, acceptance criteria, testing intent,
+dependency state, or decision policy, move the issue to `Needs Human Context`
+instead of guessing.

--- a/elixir/docs/agents/quality-gates.md
+++ b/elixir/docs/agents/quality-gates.md
@@ -1,0 +1,53 @@
+# Agent Quality Gates
+
+This file points agent workflow skills at the repo-specific gates. The detailed
+policy remains in `../agentic-flywheel-quality.md`.
+
+## Required Evidence
+
+Every worker handoff must record these in the PR body and Linear Workpad:
+
+- PR body follows `.github/pull_request_template.md`.
+- Local focused validation for the changed behavior.
+- `make all` from `elixir/` when the environment supports it, or the documented
+  CI handoff reason and log path.
+- `make.cmd windows-native-test` for Windows shell, workspace/config, workflow,
+  path-handling, or runtime orchestration changes.
+- `mix format` for touched Elixir files.
+- `mix specs.check` when public `lib/` functions are added or changed.
+- Required GitHub checks complete and pass before `Agent Review`.
+
+## Review Readiness
+
+The readiness gate should protect `Agent Review`, not `Todo` or `Human Review`.
+Set `codex.review_readiness_guarded_states` in the workflow config to the
+machine review queue states that require PR/check evidence. The default remains
+`In Review` for compatibility with older workflow files; the optimization
+flywheel config should set it to `Agent Review`.
+
+The readiness policy requires:
+
+- linked PR from Linear attachment metadata,
+- trusted repository configured in workflow,
+- PR branch containing the Linear issue identifier,
+- PR body validation evidence,
+- required checks from branch protection or workflow config,
+- no changed production module added to coverage ignores,
+- no stale-base overlap against the current base branch.
+
+## Skip Policy
+
+Agents must not weaken, disable, skip, or hide failures from tests, lint,
+formatting, coverage, review readiness, or PR-body checks to land unrelated
+work. A wrong or flaky gate is a separate manager-owned issue unless the current
+issue is explicitly about that gate.
+
+When broad local gates time out or are ambiguous, inspect the log and residual
+processes before retrying. Rerun at most once when a local result is required
+before pushing; otherwise hand off to CI with exact evidence.
+
+For Codex app-server automation, do not set `model_reasoning_effort` to
+`minimal`. Current app-server sessions can include default tools such as
+`image_gen` or `web_search`, and the API rejects that combination before the
+agent emits any useful message. Use `low` or higher for worker and reviewer
+instances.

--- a/elixir/docs/agents/review-policy.md
+++ b/elixir/docs/agents/review-policy.md
@@ -1,0 +1,78 @@
+# Agent Review Policy
+
+Review is split into two axes: standards review and spec review. Passing tests
+are required evidence, but they do not prove the issue satisfied the intended
+behavior.
+
+## Review States
+
+`Agent Review` is the machine review queue. A worker may move an issue there
+only after the linked PR, checks, Workpad, and evidence are review-ready.
+
+`Human Review` means the reviewer agent found no blocking findings and human
+acceptance, merge, or final product judgment remains.
+
+`Rework` means the reviewer found blocking findings that a worker can fix
+without new human context.
+
+`Needs Human Context` means the reviewer cannot verify success because the spec,
+acceptance criteria, dependency state, or decision authority is incomplete.
+
+## Review Axes
+
+Standards Review checks:
+
+- local coding conventions, ADRs, and architecture canvas,
+- TDD discipline and behavior-oriented tests,
+- deep modules, clear interfaces, locality, leverage, and deletion tests,
+- quality gates, coverage policy, stale-base overlap, and PR hygiene,
+- whether follow-up defects are filed instead of hidden in logs.
+
+Spec Review checks:
+
+- every acceptance criterion is implemented or explicitly deferred,
+- behavior matches the Agent Brief, PRD, and DAG node,
+- implementation does not exceed scope,
+- required tests and evidence prove the requested behavior,
+- unresolved ambiguity is escalated instead of guessed.
+
+## Reviewer Output
+
+Reviewer agents write a concise review result to the Workpad or PR:
+
+```markdown
+## Standards Review
+
+### Blocking
+
+### Non-Blocking
+
+### Missing Evidence
+
+## Spec Review
+
+### Blocking
+
+### Non-Blocking
+
+### Missing Evidence
+```
+
+Blocking findings must include the file, behavior, standard or requirement
+violated, and the required fix. Missing spec context must name the exact human
+answer needed.
+
+## Approval Rule
+
+Move to `Human Review` only when both review axes have no blocking findings and
+required evidence is present.
+
+Move to `Rework` when the spec is clear and the fix is bounded.
+
+Move to `Needs Human Context` when review exposes unclear intent or a
+hard-to-reverse decision.
+
+Move to `Blocked` when review cannot proceed because of GitHub, Linear, Codex,
+CI, environment, dependency, or deployment failure.
+
+Reviewer agents do not fix code, broaden scope, or spawn additional workers.

--- a/elixir/docs/agents/worker-model.md
+++ b/elixir/docs/agents/worker-model.md
@@ -1,0 +1,87 @@
+# Agent Worker Model
+
+This workflow separates shaping, implementation, review, and final acceptance.
+Each role owns a different decision surface.
+
+## Roles
+
+- Human manager: aligns on product and architecture intent, shapes specs,
+  releases ready DAG nodes, resolves hard decisions, owns final acceptance, and
+  handles system-level blockers.
+- Worker Symphony instance: polls `Ready for Agent` and `Rework`, starts
+  implementer Codex sessions, and enforces implementation handoff discipline.
+- Worker Codex agent: implements one scoped issue, validates it, opens a PR,
+  records evidence, and moves only to `Agent Review` after readiness passes.
+- Reviewer Symphony instance: polls `Agent Review` and starts reviewer Codex
+  sessions.
+- Reviewer Codex agent: performs review only. It reports findings and moves the
+  Linear issue to `Human Review`, `Rework`, `Needs Human Context`, or `Blocked`.
+- Codex Workpad: one persistent human-facing Linear comment whose first line is
+  `## Codex Workpad`. The runtime may also maintain transient
+  `## Symphony Control` system comments for durable claim coordination; those
+  control comments are not a Workpad and should not contain human progress
+  notes.
+
+## Worker Assignment Packet
+
+The worker prompt must include:
+
+- Linear identifier, title, state, URL, labels, and description.
+- Linked GitHub issue or embedded Agent Brief.
+- Blocker/dependency summary and current release reason.
+- Branch, commit, PR, and Workpad rules.
+- Required local and CI validation commands.
+- Review readiness destination, normally `Agent Review`.
+- Decision policy for safe choices versus human context escalation.
+
+## Worker Return Packet
+
+Before moving to `Agent Review`, the worker must leave:
+
+- branch name and PR URL,
+- final scope summary,
+- acceptance criteria status,
+- validation commands and outcomes, with log paths when relevant,
+- required check status or CI handoff reason,
+- reviewer notes and known residual risks,
+- blocker or context escalation details when not complete.
+
+## Reviewer Assignment Packet
+
+The reviewer prompt must include:
+
+- Linear issue, Workpad, PR URL, and diff scope,
+- Agent Brief, PRD, DAG node, and acceptance criteria,
+- architecture/quality standards and relevant ADRs,
+- required validation evidence,
+- explicit instruction that reviewer workspace edits are only for local
+  verification; reviewers must not push those edits, open implementation PRs, or
+  turn exploratory changes into implementation work.
+
+## Decision Policy
+
+Agents should make conservative decisions when the choice is safe, local,
+reversible, and does not change product meaning or architecture direction.
+Record the decision in the Workpad.
+
+Agents must move the issue to `Needs Human Context` when a decision affects:
+
+- product behavior or acceptance criteria,
+- architecture direction or public interfaces,
+- data shape, migration, or irreversible state,
+- security, privacy, credentials, or deployment policy,
+- quality gate, coverage, review, or merge policy,
+- ambiguous scope where multiple reasonable implementations would satisfy
+  different intents.
+
+Use `Blocked` only when the work is clear but cannot proceed because of an
+external or system condition.
+
+## Conflict Policy
+
+Keep one Linear issue, one branch, and one PR. Do not broaden an active worker
+issue to absorb adjacent work. Create or link follow-up issues for discovered
+defects outside the assigned scope.
+
+Do not change another worker's branch or workspace unless a manager explicitly
+assigns integration or recovery work.

--- a/elixir/docs/manager-agent-runbook.md
+++ b/elixir/docs/manager-agent-runbook.md
@@ -6,14 +6,18 @@ fresh machine where the operator needs to understand the expected rhythm before
 touching the queue.
 
 The manager agent is not primarily an implementer. Its job is to keep the
-flywheel honest: shape the next work, keep parallel workers fed, review finished
-work against the original intent, investigate blockers to root cause, and turn
-system defects into durable issues.
+flywheel honest: shape the next work, keep worker and reviewer queues fed,
+review finished work against the original intent, investigate blockers to root
+cause, and turn system defects into durable issues.
+
+The canonical state machine and role split live in
+[`agents/issue-tracker.md`](agents/issue-tracker.md) and
+[`agents/worker-model.md`](agents/worker-model.md).
 
 ## Operating posture
 
-- Treat `Backlog` as parked work. Symphony claims `Todo` and active work, not
-  Backlog.
+- Treat `Backlog` as parked work. Worker Symphony claims `Ready for Agent` and
+  `Rework`; reviewer Symphony claims `Agent Review`.
 - Move work forward only after the public GitHub issue has a clear spec,
   testing intent, and acceptance criteria.
 - Prefer orchestration over hand repair. If a worker can finish the issue after
@@ -23,8 +27,8 @@ system defects into durable issues.
   defects where waiting for a worker would increase risk.
 - Review is intent-based. Passing tests and green CI are required evidence, but
   they do not prove the human request was satisfied.
-- Worker completion is a manager handoff, not a done state. A PR that reaches
-  review still needs manager review, state cleanup, and sometimes deployment.
+- Worker completion is a reviewer handoff, not a done state. A PR that reaches
+  `Agent Review` still needs reviewer and often human review before completion.
 - Keep the system saturated, not chaotic. Raise concurrency only after claim
   behavior, review readiness, and CI signal are trustworthy.
 - Treat repeated pipeline friction as a product defect in the flywheel, not as a
@@ -41,15 +45,17 @@ planes:
    runtime commit, PID file, and workflow path.
 2. Check GitHub open PRs, required checks, and recently updated optimization
    issues.
-3. Check Linear states for the optimization project across `Backlog`, `Todo`,
-   `In Progress`, `In Review`, `Blocked`, and terminal states.
+3. Check Linear states for the optimization project across `Backlog`,
+   `Needs Human Context`, `Ready for Agent`, `In Progress`, `Agent Review`,
+   `Rework`, `Human Review`, `Blocked`, and terminal states.
 4. Confirm the running runtime commit matches `origin/main` after any recently
    merged system PR. If not, rebuild and restart before launching more work.
-5. Review completed or `In Review` work before releasing another issue.
+5. Review completed or `Human Review` work, and check `Agent Review` throughput,
+   before releasing another issue.
 6. Inspect `Blocked` work to root cause. Do not let new workers rediscover a
    shared blocker.
 7. Only then choose the next Backlog issue, complete its spec/testing/acceptance,
-   classify it as worker-safe or manager-owned, and move it to `Todo`.
+   classify it as worker-safe or manager-owned, and move it to `Ready for Agent`.
 
 The useful default rhythm is review, triage, release, wait, then repeat. Worker
 runs often take 10 to 20 minutes; the manager should use that time to review
@@ -68,7 +74,7 @@ Examples:
 - Choosing the canonical issue for a repeated system defect, marking duplicates,
   or defining defect intake policy.
 - Deciding whether a dependency chain is resolved enough to release downstream
-  work to `Todo`.
+  work to `Ready for Agent`.
 - Applying privacy-sensitive history cleanup or deployment/restart changes.
 - Root-causing why active work is `Blocked`, stale, duplicated, or running on
   old code.
@@ -89,7 +95,8 @@ Mark manager-owned work explicitly so it is not released accidentally:
   Workpad`.
 - Keep the issue in `Backlog` until a manager handles it or creates narrower
   worker-safe subtasks.
-- Do not move manager-owned issues to `Todo` merely to keep concurrency high.
+- Do not move manager-owned issues to `Ready for Agent` merely to keep
+  concurrency high.
 
 ## Worker blocker handoff
 
@@ -134,8 +141,9 @@ Run this loop until the operator deliberately pauses the flywheel.
    - Check the dashboard for active workers, queue depth, token pressure, retry
      noise, and rate-limit status.
    - Check GitHub PRs, checks, mergeability, and recently changed issues.
-   - Check Linear state across `Backlog`, `Todo`, `In Progress`, `In Review`,
-     `Blocked`, and terminal states.
+   - Check Linear state across `Backlog`, `Needs Human Context`,
+     `Ready for Agent`, `In Progress`, `Agent Review`, `Rework`,
+     `Human Review`, `Blocked`, and terminal states.
    - Check runtime logs, PID files, workflow config, and the deployed commit
      when the runtime may be stale.
    - For worker detail pages, use the processed conversation surface for normal
@@ -146,9 +154,11 @@ Run this loop until the operator deliberately pauses the flywheel.
 2. Review completed work first.
    - Read the original human request, the GitHub issue, the Linear Workpad, the
      PR diff, CI results, and review evidence.
-   - Request independent SubAgent review for meaningful changes before handoff.
-   - Merge only when the implementation satisfies intent and required checks are
-     green, or return the issue to active work with concrete findings.
+   - Inspect `Agent Review` items through reviewer Symphony. Do not substitute
+     green CI for reviewer judgment.
+   - Accept `Human Review` items only when the implementation satisfies intent
+     and required checks are green, or move the issue to `Rework` or
+     `Needs Human Context` with concrete findings.
 3. Investigate blockers immediately.
    - A blocked issue needs a root cause, not just a label.
    - Classify the blocker as worker implementation, stale base, failing CI,
@@ -166,8 +176,8 @@ Run this loop until the operator deliberately pauses the flywheel.
      it. Do not release manager-owned work merely to fill a concurrency slot.
    - Complete the GitHub issue spec, testing intent, and acceptance criteria.
    - Add links between GitHub and Linear.
-   - Move it to `Todo` only when there is available capacity and the task is
-     ready for an isolated worker.
+   - Move it to `Ready for Agent` only when there is available capacity and the
+     task is ready for an isolated worker.
 5. Wait deliberately.
    - Worker runs commonly take 10 to 20 minutes.
    - During long waits, use a heartbeat automation or a local sleep interval,
@@ -186,7 +196,7 @@ Use this checklist before accepting a PR:
 - The PR body preserves the repository template headings and records concrete
   validation.
 - Required checks passed; pending, failing, or missing checks are explained and
-  resolved before review state.
+  resolved before `Agent Review` or `Human Review`.
 - Windows-specific behavior was validated when paths, shells, workflow config,
   workspace cleanup, or runtime orchestration changed.
 - Coverage, lint, formatter, CI, review-readiness, and PR-body gates were not
@@ -197,8 +207,9 @@ Use this checklist before accepting a PR:
   describe system behavior beyond the active PR.
 
 When a PR fails this checklist, leave a specific GitHub PR review comment and
-update the Linear Workpad with the review outcome before moving the issue back
-to active work. Do not leave it in `In Review` just because a branch exists.
+update the Linear Workpad with the review outcome before moving the issue to
+`Rework` or `Needs Human Context`. Do not leave it in `Agent Review` just
+because a branch exists.
 
 ## Blocker investigation
 
@@ -241,10 +252,11 @@ Before creating a new system issue:
 This keeps the flywheel from manufacturing review debt while it is trying to fix
 itself.
 
-## Releasing work to Todo
+## Releasing work to Ready for Agent
 
-Backlog issues are not ready by default. Before moving an issue to `Todo`, the
-manager should ensure the public GitHub issue includes:
+Backlog issues are not ready by default. Before moving an issue to
+`Ready for Agent`, the manager should ensure the public GitHub issue or Linear
+description includes:
 
 - Problem statement and user-facing intent.
 - Scope boundaries and explicit non-goals.
@@ -254,12 +266,15 @@ manager should ensure the public GitHub issue includes:
 - Testing intent: focused local checks, broad gates, and Windows-specific checks
   when relevant.
 - Acceptance criteria that a reviewer can verify from the final behavior.
+- Decision policy that names safe agent choices and decisions that require
+  human context.
 - Links to related issues, PRs, prior failures, and Linear mirror.
 
 Use a `## Dependencies` section or an explicit `Depends on:` line in the GitHub
 issue when the work must wait for another issue, PR, deployment, credential, or
-system capability. Do not move that issue to `Todo` while the dependency is
-active, unmerged, blocked, or merged-but-not-deployed when deployment matters.
+system capability. Do not move that issue to `Ready for Agent` while the
+dependency is active, unmerged, blocked, or merged-but-not-deployed when
+deployment matters.
 After the dependency is resolved, mark it with `[x]`, `resolved by`, `merged in`,
 or `deployed in`, then record the dependency resolution in the Workpad when
 releasing the issue.
@@ -279,7 +294,8 @@ were independent work.
 
 After the worker claims the issue, avoid changing the task underneath it. If the
 intent changes, update the GitHub issue and Workpad, then decide whether to let
-the current worker continue or return the issue to `Todo`.
+the current worker continue, move the issue to `Needs Human Context`, or return
+it to `Ready for Agent`.
 
 ## Saturation and waiting
 
@@ -289,8 +305,8 @@ concurrency, while preserving review quality.
 - Start with low concurrency on a new deployment.
 - Increase concurrency after the runtime proves it can claim, run, report, and
   hand off reliably.
-- Keep a small prepared Backlog so the next issue can move to `Todo` quickly
-  after a review or merge.
+- Keep a small prepared Backlog so the next issue can move to
+  `Ready for Agent` quickly after a review or merge.
 - Prefer reviewing finished work over launching new work.
 - During quiet periods, wait 5 to 10 minutes and inspect again.
 
@@ -333,11 +349,11 @@ On a new machine or fresh deployment, confirm:
 - Runtime directory and workflow file paths match the local machine.
 - GitHub CLI is installed and authenticated.
 - Linear access works through the connector or `LINEAR_API_KEY`.
-- The Linear project has the expected active, review, blocked, duplicate, and
-  terminal states.
+- The Linear project has the expected active, review, context, blocked,
+  duplicate, and terminal states.
 - The workflow config sets the intended concurrency and worker reasoning effort.
 - Dashboard URL, PID files, logs, and workspace root are known.
-- `Backlog` remains parked and `Todo` is the release valve.
+- `Backlog` remains parked and `Ready for Agent` is the worker release valve.
 - The manager has a plan for review, blockers, deployment, and waiting before
   launching many workers.
 

--- a/elixir/docs/windows-native.md
+++ b/elixir/docs/windows-native.md
@@ -235,7 +235,8 @@ explicit review target.
 The optimization example is a fixed-project routing template. Replace
 `YOUR_LINEAR_PROJECT_SLUG` with the slug for the Linear project you want
 Symphony to poll. Keep `Backlog` out of `tracker.dispatch_states`; parked issues
-remain invisible to Symphony until a human moves one issue at a time to `Todo`.
+remain invisible to Symphony until a human moves ready nodes to
+`Ready for Agent`.
 
 Keep the public example generic. Operator-specific project names, workspace
 paths, and repository owners should live in a local workflow file such as
@@ -251,16 +252,18 @@ tracker:
   labels:
     - symphony-optimization
   dispatch_states:
-    - Todo
+    - Ready for Agent
+    - Rework
   active_states:
-    - Todo
+    - Ready for Agent
     - In Progress
+    - Rework
 ```
 
 The label match and `dispatch_states` apply only to candidate dispatch.
 Already-running issues are still reconciled by `active_states` so Symphony keeps
-valid workers alive after they move from `Todo` to `In Progress`, and stops them
-cleanly when they move to a terminal state.
+valid workers alive after they move from `Ready for Agent` to `In Progress`,
+and stops them cleanly when they move to a terminal state.
 
 To find the right Linear values, use the Linear UI for the project slug when
 possible, or query Linear GraphQL with your own API key. Do not commit API keys,
@@ -288,6 +291,40 @@ Use `-Background` when you want the launcher to return after starting a hidden P
 .\scripts\start-windows-native.ps1 -WorkflowPath .\WORKFLOW.windows.md -Port 4011 -Background
 ```
 
+For the two-instance worker/reviewer flywheel, create local workflow files from
+the optimization examples and start both instances with distinct ports and log
+roots:
+
+```powershell
+Copy-Item .\WORKFLOW.optimization.windows.example.md .\WORKFLOW.optimization.windows.md
+Copy-Item .\WORKFLOW.optimization.reviewer.windows.example.md .\WORKFLOW.optimization.reviewer.windows.md
+notepad .\WORKFLOW.optimization.windows.md
+notepad .\WORKFLOW.optimization.reviewer.windows.md
+.\scripts\start-agent-flywheel.ps1 `
+  -WorkerWorkflowPath .\WORKFLOW.optimization.windows.md `
+  -ReviewerWorkflowPath .\WORKFLOW.optimization.reviewer.windows.md `
+  -WorkerPort 4011 `
+  -ReviewerPort 4012
+```
+
+`start-agent-flywheel.ps1` is all-or-nothing by default. It preflights the
+workflow files, `LINEAR_API_KEY`, `mise`, live PID metadata, and listening ports,
+then waits for both background instances to publish PID metadata and listen on
+their ports. If the worker starts but the reviewer fails, the script stops the
+worker, reports the failure phase and reason, and prints both log roots plus the
+worker/reviewer cleanup status.
+
+For debugging a reviewer-only startup failure, pass `-AllowPartial` to keep the
+worker running. The script still reports `Partial startup` and the reviewer
+failure details:
+
+```powershell
+.\scripts\start-agent-flywheel.ps1 `
+  -WorkerWorkflowPath .\WORKFLOW.optimization.windows.md `
+  -ReviewerWorkflowPath .\WORKFLOW.optimization.reviewer.windows.md `
+  -AllowPartial
+```
+
 Or run the escript directly:
 
 ```powershell
@@ -295,10 +332,12 @@ $env:LINEAR_API_KEY = [Environment]::GetEnvironmentVariable("LINEAR_API_KEY", "U
 mise exec -- escript .\bin\symphony .\WORKFLOW.windows.md --port 4011 --logs-root "$env:LOCALAPPDATA\Symphony\logs" --i-understand-that-this-will-be-running-without-the-usual-guardrails
 ```
 
-Open the dashboard:
+Open the dashboard. The second URL is used only when the reviewer instance is
+running:
 
 ```text
 http://127.0.0.1:4011/
+http://127.0.0.1:4012/
 ```
 
 ## Stop Symphony
@@ -309,6 +348,13 @@ Stop a launcher started by `start-windows-native.ps1`:
 .\scripts\stop-windows-native.ps1 -Force
 ```
 
+Stop the two flywheel instances by pointing at their separate PID files:
+
+```powershell
+.\scripts\stop-windows-native.ps1 -PidFile "$env:LOCALAPPDATA\Symphony\agent-flywheel\symphony.worker.pid.json" -Force
+.\scripts\stop-windows-native.ps1 -PidFile "$env:LOCALAPPDATA\Symphony\agent-flywheel\symphony.reviewer.pid.json" -Force
+```
+
 The stop script reads the PID metadata and verifies that the target command line is a
 `start-windows-native.ps1` process before terminating that process tree. If the PID file is missing,
 pass `-WorkflowPath` to locate a matching launcher process:
@@ -317,14 +363,17 @@ pass `-WorkflowPath` to locate a matching launcher process:
 .\scripts\stop-windows-native.ps1 -WorkflowPath .\WORKFLOW.windows.md -Force
 ```
 
-Linear claim leases are also cleaned up as workers stop. If the host or runtime
-exits before a release comment is written, the next runtime startup checks active
-Linear claim comments before dispatch. A claim owned by the same Windows host is
-released only when its recorded OS process ID is no longer alive; claims from
-other hosts, malformed owners, or still-running local processes remain protected.
-While another active lease is preserved, the issue appears in the dashboard
-backoff queue with an `external_claim` reason instead of being shown as a local
-running worker.
+Linear claim leases are also cleaned up as workers stop. Symphony stores active
+claim state in runtime-owned `## Symphony Control` Linear comments and removes
+the active control comment on normal release, falling back to a release update if
+delete fails. This avoids appending separate human-facing claim and release
+comments for normal dispatch. If the host or runtime exits before a release is
+written, the next runtime startup checks active Linear claim state before
+dispatch. A claim owned by the same Windows host is released only when its
+recorded OS process ID is no longer alive; claims from other hosts, malformed
+owners, or still-running local processes remain protected. While another active
+lease is preserved, the issue appears in the dashboard backoff queue with an
+`external_claim` reason instead of being shown as a local running worker.
 
 ## Apply merged runtime updates
 
@@ -401,17 +450,20 @@ agent how to use Linear.
 A practical flow is:
 
 - `Backlog`: not picked up by Symphony.
-- `Todo`: Symphony can pick this up. The agent should move it to `In Progress`.
-- `In Progress`: the agent implements and validates.
+- `Needs Human Context`: the issue lacks enough spec, acceptance criteria,
+  dependency state, or decision authority for autonomous work.
+- `Ready for Agent`: worker Symphony can pick this up. The agent should move it
+  to `In Progress`.
+- `In Progress`: the worker implements and validates.
 - `Blocked`: the agent cannot complete because a required tool, auth grant,
   dependency, environment, or orchestration condition is missing. Add this state
   to the Linear team before enabling blocked-state transitions; if it is absent,
   agents must record `Blocked state missing` and leave the issue in its active
   state for a manager to triage.
-- `Human Review`: the agent has created or updated a PR, required checks are passing, and review is
-  requested or underway.
-- `Rework`: the agent should handle reviewer feedback.
-- `Merging`: the agent should run the repository's merge/land process.
+- `Agent Review`: the worker has created or updated a PR, required checks are
+  passing, and reviewer Symphony should inspect the work.
+- `Rework`: reviewer found bounded blocking findings for a worker to fix.
+- `Human Review`: reviewer passed the work and human acceptance remains.
 - `Done`: terminal. Symphony stops the active agent.
 - `Canceled`, `Cancelled`, `Duplicate`: terminal.
 
@@ -477,7 +529,11 @@ steer submission; read-only dashboard and JSON views remain available.
 
 ### Review readiness
 
-Agent-initiated moves to `In Review` are guarded by review readiness checks.
+Agent-initiated moves to the machine review queue are guarded by review
+readiness checks. Configure the protected destination states with
+`codex.review_readiness_guarded_states`; older workflow files default to
+`In Review`, while the two-instance optimization flywheel should set this to
+`Agent Review`.
 The tool only allows that transition when the issue has a linked GitHub PR and
 the required checks on the PR head are complete and successful. If GitHub branch
 protection metadata is private or unavailable to the Windows runtime, configure
@@ -533,7 +589,7 @@ returns from init, so dashboard and app readiness are not blocked by old
 workspace removal or `hooks.before_remove`.
 
 Startup cleanup is retention-aware. It queries terminal states plus configured
-active states and the protected `In Review` and `Blocked` states, preserves any
+active states and protected review/blocker states, preserves any
 non-terminal issue workspace, and removes only terminal issue workspaces whose
 `updated_at` timestamp is older than `workspace.startup_cleanup_ttl_ms`. The
 default TTL is seven days. Set the TTL to `0` only when an operator needs
@@ -578,11 +634,11 @@ profile:
 make windows-native-test
 ```
 
-Agent PRs should also follow the [agent quality flywheel](agent-quality-flywheel.md): keep one
+Agent PRs should also follow the [agentic flywheel quality discipline](agentic-flywheel-quality.md): keep one
 Linear workpad, use Conventional Commits, record validation in the PR body, and wait for required
 GitHub checks before moving the Linear issue to review.
 For the small-team manager and agent operating model, see the
-[small-team agentic build flywheel playbook](small-team-agentic-flywheel.md).
+[agentic flywheel setup and operations playbook](agentic-flywheel-setup.md).
 
 ## Troubleshooting
 

--- a/elixir/lib/symphony_elixir/codex/app_server.ex
+++ b/elixir/lib/symphony_elixir/codex/app_server.ex
@@ -4,7 +4,7 @@ defmodule SymphonyElixir.Codex.AppServer do
   """
 
   require Logger
-  alias SymphonyElixir.{Codex.DynamicTool, Config, LocalShell, PathSafety, SSH}
+  alias SymphonyElixir.{Codex.DynamicTool, Config, LocalShell, PathSafety, Redactor, SSH}
 
   @initialize_id 1
   @thread_start_id 2
@@ -450,7 +450,14 @@ defmodule SymphonyElixir.Codex.AppServer do
          _turn_context
        ) do
     emit_turn_event(on_message, :turn_completed, payload, payload_string, port, payload)
-    {:ok, :turn_completed}
+
+    case failed_completed_turn_reason(payload) do
+      nil ->
+        {:ok, :turn_completed}
+
+      reason ->
+        {:error, {:turn_failed, reason}}
+    end
   end
 
   defp handle_decoded_payload(
@@ -613,10 +620,35 @@ defmodule SymphonyElixir.Codex.AppServer do
             metadata
           )
 
-          Logger.debug("Codex notification: #{inspect(method)}")
+          log_notification(method, payload)
           continue_receive_loop(port, on_message, loop_options, turn_context)
         end
     end
+  end
+
+  defp failed_completed_turn_reason(%{"params" => %{"turn" => %{"status" => "failed"} = turn}}) do
+    Map.take(turn, ["id", "status", "error"])
+  end
+
+  defp failed_completed_turn_reason(%{"params" => %{"turn" => %{"error" => error} = turn}})
+       when not is_nil(error) do
+    Map.take(turn, ["id", "status", "error"])
+  end
+
+  defp failed_completed_turn_reason(_payload), do: nil
+
+  defp log_notification("error", payload) do
+    details =
+      payload
+      |> Map.get("params", payload)
+      |> Redactor.redact()
+      |> inspect(limit: 50, printable_limit: @max_stream_log_bytes)
+
+    Logger.warning("Codex error notification: #{details}")
+  end
+
+  defp log_notification(method, _payload) do
+    Logger.debug("Codex notification: #{inspect(method)}")
   end
 
   defp handle_steer_message(

--- a/elixir/lib/symphony_elixir/codex/review_readiness.ex
+++ b/elixir/lib/symphony_elixir/codex/review_readiness.ex
@@ -1,6 +1,6 @@
 defmodule SymphonyElixir.Codex.ReviewReadiness do
   @moduledoc """
-  Guards agent-initiated Linear `In Review` transitions.
+  Guards agent-initiated Linear transitions into configured review states.
   """
 
   @github_api "https://api.github.com"
@@ -131,7 +131,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
 
   defp authorize_destination(issue, destination_state, variables, linear_client, github_client) do
     cond do
-      not in_review_state?(destination_state) ->
+      not review_readiness_guarded_state?(destination_state) ->
         :ok
 
       manager_override?(variables) ->
@@ -381,9 +381,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     end
   end
 
-  defp in_review_state?(state_name) when is_binary(state_name) do
-    normalize(state_name) == "in review"
-  end
+  defp review_readiness_guarded_state?(state_name), do: Config.review_readiness_guarded_state?(state_name)
 
   defp manager_override?(variables) do
     truthy?(Map.get(variables, "symphonyManagerOverride") || Map.get(variables, :symphonyManagerOverride)) and
@@ -1411,7 +1409,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
     message = rejection_message(reason)
 
     if is_binary(issue["id"]) do
-      _ = upsert_workpad(issue, readiness_note(issue, "In Review transition rejected", message), linear_client)
+      _ = upsert_workpad(issue, readiness_note(issue, "Review readiness transition rejected", message), linear_client)
     end
 
     {:error,
@@ -1419,7 +1417,7 @@ defmodule SymphonyElixir.Codex.ReviewReadiness do
       %{
         "error" => %{
           "code" => "review_readiness_rejected",
-          "message" => "Linear In Review transition rejected: #{message}",
+          "message" => "Linear review readiness transition rejected: #{message}",
           "reason" => inspect(reason)
         }
       }}}

--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -61,6 +61,17 @@ defmodule SymphonyElixir.Config do
 
   def max_concurrent_agents_for_state(_state_name), do: settings!().agent.max_concurrent_agents
 
+  @spec review_readiness_guarded_state?(term()) :: boolean()
+  def review_readiness_guarded_state?(state_name) when is_binary(state_name) do
+    normalized_state_name = Schema.normalize_issue_state(state_name)
+
+    settings!().codex.review_readiness_guarded_states
+    |> Enum.map(&Schema.normalize_issue_state/1)
+    |> Enum.member?(normalized_state_name)
+  end
+
+  def review_readiness_guarded_state?(_state_name), do: false
+
   @spec codex_turn_sandbox_policy(Path.t() | nil) :: map()
   def codex_turn_sandbox_policy(workspace \\ nil) do
     case Schema.resolve_runtime_turn_sandbox_policy(settings!(), workspace) do

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -195,6 +195,7 @@ defmodule SymphonyElixir.Config.Schema do
       field(:command_watchdog_block_on_stall, :boolean, default: false)
       field(:review_readiness_repository, :string)
       field(:review_readiness_required_checks, {:array, :string}, default: [])
+      field(:review_readiness_guarded_states, {:array, :string}, default: ["In Review"])
     end
 
     @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
@@ -216,7 +217,8 @@ defmodule SymphonyElixir.Config.Schema do
           :command_watchdog_repeated_output_limit,
           :command_watchdog_block_on_stall,
           :review_readiness_repository,
-          :review_readiness_required_checks
+          :review_readiness_required_checks,
+          :review_readiness_guarded_states
         ],
         empty_values: []
       )
@@ -352,7 +354,9 @@ defmodule SymphonyElixir.Config.Schema do
 
   @spec normalize_issue_state(String.t()) :: String.t()
   def normalize_issue_state(state_name) when is_binary(state_name) do
-    String.downcase(state_name)
+    state_name
+    |> String.trim()
+    |> String.downcase()
   end
 
   @doc false
@@ -419,7 +423,8 @@ defmodule SymphonyElixir.Config.Schema do
       | approval_policy: normalize_keys(settings.codex.approval_policy),
         turn_sandbox_policy: normalize_optional_map(settings.codex.turn_sandbox_policy),
         review_readiness_repository: normalize_repository(settings.codex.review_readiness_repository),
-        review_readiness_required_checks: normalize_required_checks(settings.codex.review_readiness_required_checks)
+        review_readiness_required_checks: normalize_required_checks(settings.codex.review_readiness_required_checks),
+        review_readiness_guarded_states: normalize_issue_states(settings.codex.review_readiness_guarded_states)
     }
 
     observability = %{

--- a/elixir/lib/symphony_elixir/linear/adapter.ex
+++ b/elixir/lib/symphony_elixir/linear/adapter.ex
@@ -9,6 +9,7 @@ defmodule SymphonyElixir.Linear.Adapter do
 
   @claim_ttl_seconds 4 * 60 * 60
   @claim_settle_ms 250
+  @control_marker "## Symphony Control"
   @claim_marker "## Symphony Claim Lease"
   @claim_release_marker "## Symphony Claim Release"
   @claim_signature_version "v1"
@@ -21,6 +22,22 @@ defmodule SymphonyElixir.Linear.Adapter do
         id
         createdAt
       }
+    }
+  }
+  """
+
+  @update_comment_mutation """
+  mutation SymphonyUpdateComment($commentId: String!, $body: String!) {
+    commentUpdate(id: $commentId, input: {body: $body}) {
+      success
+    }
+  }
+  """
+
+  @delete_comment_mutation """
+  mutation SymphonyDeleteComment($commentId: String!) {
+    commentDelete(id: $commentId) {
+      success
     }
   }
   """
@@ -80,10 +97,11 @@ defmodule SymphonyElixir.Linear.Adapter do
     expires_at = DateTime.add(now, @claim_ttl_seconds, :second)
     owner = claim_owner()
     token = claim_token()
-    body = claim_body(identifier, owner, token, now, expires_at)
+    body = control_claim_body(identifier, owner, token, now, expires_at)
 
-    with :ok <- preflight_issue_claim(issue_id),
-         {:ok, claim} <- create_claim_comment(issue_id, body, owner, token, now, expires_at) do
+    with {:ok, claim_state} <- fetch_claim_state(issue_id),
+         :ok <- preflight_issue_claim(claim_state.records),
+         {:ok, claim} <- create_claim_control(issue_id, body, owner, token, now, expires_at) do
       verify_issue_claim(issue_id, claim)
     end
   end
@@ -102,16 +120,9 @@ defmodule SymphonyElixir.Linear.Adapter do
     token = claim_value(claim, :token)
 
     if is_binary(id) and is_binary(owner) and is_binary(token) do
-      body = release_body(id, owner, token, DateTime.utc_now())
+      body = control_release_body(id, owner, token, DateTime.utc_now())
 
-      with {:ok, response} <- client_module().graphql(@create_comment_mutation, %{issueId: issue_id, body: body}),
-           true <- get_in(response, ["data", "commentCreate", "success"]) == true do
-        :ok
-      else
-        false -> {:error, :claim_release_failed}
-        {:error, reason} -> {:error, reason}
-        _ -> {:error, :claim_release_failed}
-      end
+      release_visible_claim(issue_id, claim, body)
     else
       :ok
     end
@@ -164,37 +175,138 @@ defmodule SymphonyElixir.Linear.Adapter do
     Application.get_env(:symphony_elixir, :linear_client_module, Client)
   end
 
-  defp preflight_issue_claim(issue_id) do
-    case fetch_claim_comments(issue_id) do
-      {:ok, claims} ->
-        case winning_claim(claims, DateTime.utc_now()) do
-          {:ok, winner} -> {:error, {:issue_claimed, winner}}
-          {:error, :claim_not_visible} -> :ok
-        end
-
-      {:error, reason} ->
-        {:error, reason}
+  defp preflight_issue_claim(claims) do
+    case winning_claim(claims, DateTime.utc_now()) do
+      {:ok, winner} -> {:error, {:issue_claimed, winner}}
+      {:error, :claim_not_visible} -> :ok
     end
   end
 
-  defp create_claim_comment(issue_id, body, owner, token, now, expires_at) do
+  defp create_claim_control(issue_id, body, owner, token, now, expires_at) do
+    with {:ok, comment} <- create_control_comment(issue_id, body) do
+      id = Map.get(comment, "id")
+
+      if is_binary(id) and String.trim(id) != "" do
+        {:ok,
+         %{
+           id: id,
+           owner: owner,
+           token: token,
+           claimed_at: now,
+           expires_at: clamp_expires_at(expires_at, now)
+         }}
+      else
+        {:error, :claim_create_failed}
+      end
+    end
+  end
+
+  defp create_control_comment(issue_id, body) do
     with {:ok, response} <- client_module().graphql(@create_comment_mutation, %{issueId: issue_id, body: body}),
          true <- get_in(response, ["data", "commentCreate", "success"]) == true do
       comment = get_in(response, ["data", "commentCreate", "comment"]) || %{}
-      claimed_at = parse_datetime(comment["createdAt"]) || now
-
-      {:ok,
-       %{
-         id: comment["id"],
-         owner: owner,
-         token: token,
-         claimed_at: claimed_at,
-         expires_at: clamp_expires_at(expires_at, claimed_at)
-       }}
+      {:ok, comment}
     else
       false -> {:error, :claim_create_failed}
       {:error, reason} -> {:error, reason}
       _ -> {:error, :claim_create_failed}
+    end
+  end
+
+  defp delete_control_comment(comment_id) do
+    with {:ok, response} <- client_module().graphql(@delete_comment_mutation, %{commentId: comment_id}),
+         true <- get_in(response, ["data", "commentDelete", "success"]) == true do
+      :ok
+    else
+      false -> {:error, :claim_delete_failed}
+      {:error, reason} -> {:error, reason}
+      _ -> {:error, :claim_delete_failed}
+    end
+  end
+
+  defp update_control_comment(comment_id, body) do
+    with {:ok, response} <- client_module().graphql(@update_comment_mutation, %{commentId: comment_id, body: body}),
+         true <- get_in(response, ["data", "commentUpdate", "success"]) == true do
+      :ok
+    else
+      false -> {:error, :claim_update_failed}
+      {:error, reason} -> {:error, reason}
+      _ -> {:error, :claim_update_failed}
+    end
+  end
+
+  defp choose_control_comment(control_comments) when is_list(control_comments) do
+    control_comments
+    |> Enum.sort_by(fn comment ->
+      {
+        comment |> Map.get("createdAt") |> parse_datetime() |> datetime_sort_key(),
+        Map.get(comment, "id") || ""
+      }
+    end)
+    |> List.first()
+  end
+
+  defp release_visible_claim(issue_id, claim, body) do
+    with {:ok, claim_state} <- fetch_claim_state(issue_id) do
+      now = DateTime.utc_now()
+
+      claim_state.records
+      |> active_claims(now)
+      |> Enum.any?(&same_claim_identity?(&1, claim))
+      |> case do
+        true -> write_release_control(issue_id, claim_state.control_comments, claim, body)
+        false -> :ok
+      end
+    end
+  end
+
+  defp write_release_control(issue_id, control_comments, claim, body) do
+    claim_id = claim_value(claim, :id)
+    control_comment = find_control_comment(control_comments, claim_id)
+
+    if control_comment do
+      release_control_comment(control_comment, body)
+    else
+      write_legacy_release_control(issue_id, control_comments, body)
+    end
+  end
+
+  defp find_control_comment(control_comments, claim_id) do
+    Enum.find(control_comments, fn comment ->
+      Map.get(comment, "id") == claim_id
+    end)
+  end
+
+  defp release_control_comment(%{"id" => comment_id}, body) when is_binary(comment_id) do
+    case delete_control_comment(comment_id) do
+      :ok -> :ok
+      {:error, _reason} -> update_release_control(comment_id, body)
+    end
+  end
+
+  defp write_legacy_release_control(issue_id, control_comments, body) do
+    case choose_control_comment(control_comments) do
+      %{"id" => comment_id} when is_binary(comment_id) ->
+        update_release_control(comment_id, body)
+
+      _ ->
+        create_release_control(issue_id, body)
+    end
+  end
+
+  defp create_release_control(issue_id, body) do
+    case create_control_comment(issue_id, body) do
+      {:ok, _comment} -> :ok
+      {:error, :claim_create_failed} -> {:error, :claim_release_failed}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp update_release_control(comment_id, body) do
+    case update_control_comment(comment_id, body) do
+      :ok -> :ok
+      {:error, :claim_update_failed} -> {:error, :claim_release_failed}
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -226,19 +338,31 @@ defmodule SymphonyElixir.Linear.Adapter do
   end
 
   defp fetch_claim_comments(issue_id) do
-    fetch_claim_comments_page(issue_id, nil, [])
+    with {:ok, claim_state} <- fetch_claim_state(issue_id) do
+      {:ok, claim_state.records}
+    end
+  end
+
+  defp fetch_claim_state(issue_id) do
+    fetch_claim_comments_page(issue_id, nil, %{records: [], control_comments: []})
   end
 
   defp fetch_claim_comments_page(issue_id, after_cursor, acc) do
     with {:ok, response} <- client_module().graphql(@claim_comments_query, %{issueId: issue_id, after: after_cursor}),
          comments when is_list(comments) <- get_in(response, ["data", "issue", "comments", "nodes"]) do
       parsed = parse_claim_comments(comments)
+      control_comments = Enum.filter(comments, &control_comment?/1)
       page_info = get_in(response, ["data", "issue", "comments", "pageInfo"]) || %{}
 
+      next_acc = %{
+        records: parsed ++ acc.records,
+        control_comments: control_comments ++ acc.control_comments
+      }
+
       if page_info["hasNextPage"] == true and is_binary(page_info["endCursor"]) do
-        fetch_claim_comments_page(issue_id, page_info["endCursor"], parsed ++ acc)
+        fetch_claim_comments_page(issue_id, page_info["endCursor"], next_acc)
       else
-        {:ok, parsed ++ acc}
+        {:ok, next_acc}
       end
     else
       {:error, reason} -> {:error, reason}
@@ -253,15 +377,29 @@ defmodule SymphonyElixir.Linear.Adapter do
       |> Enum.group_by(& &1.owner)
 
     claims
+    |> active_claims(releases, now)
+    |> case do
+      [claim | _] -> {:ok, claim}
+      [] -> {:error, :claim_not_visible}
+    end
+  end
+
+  defp active_claims(claims, now) when is_list(claims) do
+    releases =
+      claims
+      |> Enum.filter(&(&1.type == :release))
+      |> Enum.group_by(& &1.owner)
+
+    active_claims(claims, releases, now)
+  end
+
+  defp active_claims(claims, releases, now) do
+    claims
     |> Enum.filter(&(&1.type == :claim))
     |> Enum.reject(&(claim_expired?(&1, now) or claim_released?(&1, releases)))
     |> Enum.sort_by(fn claim ->
       {DateTime.to_unix(claim.claimed_at, :microsecond), claim.id || "", claim.token || ""}
     end)
-    |> case do
-      [claim | _] -> {:ok, claim}
-      [] -> {:error, :claim_not_visible}
-    end
   end
 
   defp parse_claim_comments(comments) do
@@ -275,39 +413,16 @@ defmodule SymphonyElixir.Linear.Adapter do
     comment_created_at = parse_datetime(created_at)
 
     cond do
+      String.starts_with?(body, @control_marker) ->
+        parse_control_comment(id, body, fields, comment_created_at)
+
       String.starts_with?(body, @claim_marker) ->
         claimed_at = trusted_claimed_at(Map.get(fields, "claimed_at"), comment_created_at)
-
-        claim = %{
-          type: :claim,
-          id: id,
-          owner: Map.get(fields, "owner"),
-          token: Map.get(fields, "token"),
-          claimed_at: claimed_at,
-          expires_at:
-            fields
-            |> Map.get("expires_at")
-            |> parse_datetime()
-            |> clamp_expires_at(claimed_at),
-          signature: Map.get(fields, "signature")
-        }
-
-        if valid_claim?(claim) and valid_signature?(:claim, fields), do: [claim], else: []
+        parse_claim_record(id, fields, claimed_at)
 
       String.starts_with?(body, @claim_release_marker) ->
         released_at = comment_created_at || parse_datetime(Map.get(fields, "released_at"))
-
-        release = %{
-          type: :release,
-          id: id,
-          claim_id: Map.get(fields, "claim_id"),
-          owner: Map.get(fields, "owner"),
-          token: Map.get(fields, "token"),
-          released_at: released_at,
-          signature: Map.get(fields, "signature")
-        }
-
-        if valid_release?(release) and valid_signature?(:release, fields), do: [release], else: []
+        parse_release_record(id, fields, released_at)
 
       true ->
         []
@@ -315,6 +430,53 @@ defmodule SymphonyElixir.Linear.Adapter do
   end
 
   defp parse_claim_comment(_comment), do: []
+
+  defp parse_control_comment(id, _body, fields, comment_created_at) do
+    case Map.get(fields, "state") do
+      "claimed" ->
+        claimed_at = trusted_claimed_at(Map.get(fields, "claimed_at"), comment_created_at)
+        parse_claim_record(id, fields, claimed_at)
+
+      "released" ->
+        released_at = parse_datetime(Map.get(fields, "released_at"))
+        parse_release_record(id, fields, released_at)
+
+      _ ->
+        []
+    end
+  end
+
+  defp parse_claim_record(id, fields, claimed_at) do
+    claim = %{
+      type: :claim,
+      id: id,
+      owner: Map.get(fields, "owner"),
+      token: Map.get(fields, "token"),
+      claimed_at: claimed_at,
+      expires_at:
+        fields
+        |> Map.get("expires_at")
+        |> parse_datetime()
+        |> clamp_expires_at(claimed_at),
+      signature: Map.get(fields, "signature")
+    }
+
+    if valid_claim?(claim) and valid_signature?(:claim, fields), do: [claim], else: []
+  end
+
+  defp parse_release_record(id, fields, released_at) do
+    release = %{
+      type: :release,
+      id: id,
+      claim_id: Map.get(fields, "claim_id"),
+      owner: Map.get(fields, "owner"),
+      token: Map.get(fields, "token"),
+      released_at: released_at,
+      signature: Map.get(fields, "signature")
+    }
+
+    if valid_release?(release) and valid_signature?(:release, fields), do: [release], else: []
+  end
 
   defp claim_fields(body) when is_binary(body) do
     body
@@ -360,10 +522,22 @@ defmodule SymphonyElixir.Linear.Adapter do
       claim_value(claim, :token) == claim_value(expected_claim, :token)
   end
 
+  defp same_claim_identity?(claim, expected_claim) do
+    same_claim?(claim, expected_claim) and claim_value(claim, :id) == claim_value(expected_claim, :id)
+  end
+
   defp claim_value(claim, key) when is_map(claim), do: Map.get(claim, key) || Map.get(claim, Atom.to_string(key))
   defp claim_value(_claim, _key), do: nil
 
+  defp control_claim_body(identifier, owner, token, claimed_at, expires_at) do
+    claim_body(identifier, owner, token, claimed_at, expires_at, @control_marker, "state: claimed")
+  end
+
   defp claim_body(identifier, owner, token, claimed_at, expires_at) do
+    claim_body(identifier, owner, token, claimed_at, expires_at, @claim_marker, nil)
+  end
+
+  defp claim_body(identifier, owner, token, claimed_at, expires_at, marker, state_line) do
     fields = %{
       "owner" => owner,
       "token" => token,
@@ -373,8 +547,9 @@ defmodule SymphonyElixir.Linear.Adapter do
     }
 
     [
-      @claim_marker,
+      marker,
       "",
+      state_line,
       "version: #{@claim_signature_version}",
       "owner: #{fields["owner"]}",
       "token: #{fields["token"]}",
@@ -385,10 +560,19 @@ defmodule SymphonyElixir.Linear.Adapter do
       "",
       "Symphony dispatch lease. A newer worker must not dispatch this issue while this lease is unexpired unless this owner has released it."
     ]
+    |> Enum.reject(&is_nil/1)
     |> Enum.join("\n")
   end
 
+  defp control_release_body(claim_id, owner, token, released_at) do
+    release_body(claim_id, owner, token, released_at, @control_marker, "state: released")
+  end
+
   defp release_body(claim_id, owner, token, released_at) do
+    release_body(claim_id, owner, token, released_at, @claim_release_marker, nil)
+  end
+
+  defp release_body(claim_id, owner, token, released_at, marker, state_line) do
     fields = %{
       "claim_id" => claim_id,
       "owner" => owner,
@@ -397,8 +581,9 @@ defmodule SymphonyElixir.Linear.Adapter do
     }
 
     [
-      @claim_release_marker,
+      marker,
       "",
+      state_line,
       "version: #{@claim_signature_version}",
       "claim_id: #{fields["claim_id"]}",
       "owner: #{fields["owner"]}",
@@ -406,8 +591,15 @@ defmodule SymphonyElixir.Linear.Adapter do
       "released_at: #{fields["released_at"]}",
       "signature: #{signature_for(:release, fields)}"
     ]
+    |> Enum.reject(&is_nil/1)
     |> Enum.join("\n")
   end
+
+  defp control_comment?(%{"body" => body}) when is_binary(body), do: String.starts_with?(body, @control_marker)
+  defp control_comment?(_comment), do: false
+
+  defp datetime_sort_key(%DateTime{} = datetime), do: DateTime.to_unix(datetime, :microsecond)
+  defp datetime_sort_key(_datetime), do: 0
 
   defp trusted_claimed_at(_raw_claimed_at, %DateTime{} = comment_created_at), do: comment_created_at
 
@@ -552,9 +744,21 @@ defmodule SymphonyElixir.Linear.Adapter do
   end
 
   @doc false
+  @spec control_claim_body_for_test(String.t() | nil, String.t(), String.t(), DateTime.t(), DateTime.t()) :: String.t()
+  def control_claim_body_for_test(identifier, owner, token, claimed_at, expires_at) do
+    control_claim_body(identifier, owner, token, claimed_at, expires_at)
+  end
+
+  @doc false
   @spec release_body_for_test(String.t(), String.t(), String.t(), DateTime.t()) :: String.t()
   def release_body_for_test(claim_id, owner, token, released_at) do
     release_body(claim_id, owner, token, released_at)
+  end
+
+  @doc false
+  @spec control_release_body_for_test(String.t(), String.t(), String.t(), DateTime.t()) :: String.t()
+  def control_release_body_for_test(claim_id, owner, token, released_at) do
+    control_release_body(claim_id, owner, token, released_at)
   end
 
   defp claim_owner do

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -18,7 +18,7 @@ defmodule SymphonyElixir.Orchestrator do
   @max_recent_codex_events 80
   @max_completed_agent_messages 120
   @steer_request_timeout_ms 3_000
-  @startup_cleanup_preserved_states ["In Review", "Blocked"]
+  @startup_cleanup_preserved_states ["Blocked"]
   @workspace_cleanup_progress_notify_every 10
   @empty_codex_totals %{
     input_tokens: 0,
@@ -1127,7 +1127,10 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp cleanup_candidate_states(settings) do
-    (settings.tracker.terminal_states ++ settings.tracker.active_states ++ @startup_cleanup_preserved_states)
+    (settings.tracker.terminal_states ++
+       settings.tracker.active_states ++
+       settings.codex.review_readiness_guarded_states ++
+       @startup_cleanup_preserved_states)
     |> Enum.map(&String.trim/1)
     |> Enum.reject(&(&1 == ""))
     |> Enum.uniq()

--- a/elixir/lib/symphony_elixir_web/live/config_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/config_live.ex
@@ -232,6 +232,7 @@ defmodule SymphonyElixirWeb.ConfigLive do
                 <div><dt>Stall timeout</dt><dd><%= duration_label(@projection.config.codex.stall_timeout_ms) %></dd></div>
                 <div><dt>Watchdog</dt><dd><%= watchdog_summary(@projection.config.codex) %></dd></div>
                 <div><dt>Review repo</dt><dd><%= @projection.config.codex.review_readiness_repository || "n/a" %></dd></div>
+                <div><dt>Guarded states</dt><dd><%= list_label(@projection.config.codex.review_readiness_guarded_states) %></dd></div>
                 <div><dt>Checks</dt><dd><%= list_label(@projection.config.codex.review_readiness_required_checks) %></dd></div>
               </dl>
             </section>

--- a/elixir/lib/symphony_elixir_web/workflow_config_projection.ex
+++ b/elixir/lib/symphony_elixir_web/workflow_config_projection.ex
@@ -126,7 +126,8 @@ defmodule SymphonyElixirWeb.WorkflowConfigProjection do
         command_watchdog_repeated_output_limit: settings.codex.command_watchdog_repeated_output_limit,
         command_watchdog_block_on_stall: settings.codex.command_watchdog_block_on_stall,
         review_readiness_repository: settings.codex.review_readiness_repository,
-        review_readiness_required_checks: settings.codex.review_readiness_required_checks
+        review_readiness_required_checks: settings.codex.review_readiness_required_checks,
+        review_readiness_guarded_states: settings.codex.review_readiness_guarded_states
       },
       workspace: %{
         root: settings.workspace.root,

--- a/elixir/make.cmd
+++ b/elixir/make.cmd
@@ -3,7 +3,9 @@ setlocal
 
 set "MIX_CMD=%MIX%"
 if "%MIX_CMD%"=="" for %%I in (mix.bat) do set "MIX_CMD=%%~$PATH:I"
-if "%MIX_CMD%"=="" set "MIX_CMD=mix.bat"
+if "%MIX_CMD%"=="" for %%I in (mix.exe) do set "MIX_CMD=%%~$PATH:I"
+if "%MIX_CMD%"=="" for %%I in (mix) do set "MIX_CMD=%%~$PATH:I"
+if "%MIX_CMD%"=="" set "MIX_CMD=mix"
 
 if "%~1"=="" goto help
 

--- a/elixir/scripts/start-agent-flywheel.ps1
+++ b/elixir/scripts/start-agent-flywheel.ps1
@@ -1,0 +1,521 @@
+param(
+  [string]$WorkerWorkflowPath = ".\WORKFLOW.optimization.windows.md",
+  [string]$ReviewerWorkflowPath = ".\WORKFLOW.optimization.reviewer.windows.md",
+  [int]$WorkerPort = 4011,
+  [int]$ReviewerPort = 4012,
+  [string]$LogsRoot = "$env:LOCALAPPDATA\Symphony\agent-flywheel",
+  [string]$Mise = "",
+  [switch]$TerminalDashboard,
+  [switch]$AllowPartial,
+  [int]$StartupTimeoutSeconds = 60
+)
+
+$ErrorActionPreference = "Stop"
+$utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+$OutputEncoding = $utf8NoBom
+
+try {
+  [Console]::InputEncoding = $utf8NoBom
+  [Console]::OutputEncoding = $utf8NoBom
+} catch {
+  Write-Warning "Unable to force console UTF-8 encoding: $($_.Exception.Message)"
+}
+
+function Resolve-AgentFlywheelPath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    [Parameter(Mandatory = $true)]
+    [string]$BasePath
+  )
+
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+  }
+
+  $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath((Join-Path $BasePath $Path))
+}
+
+function Assert-AgentFlywheelFile {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Message
+  )
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    throw "$Message`: $Path"
+  }
+}
+
+function Get-AgentFlywheelProcessId {
+  param([string]$PidFile)
+
+  if (-not (Test-Path -LiteralPath $PidFile -PathType Leaf)) {
+    return $null
+  }
+
+  try {
+    $metadata = Get-Content -Raw -LiteralPath $PidFile | ConvertFrom-Json
+    if ($metadata.ProcessId) {
+      return [int]$metadata.ProcessId
+    }
+  } catch {
+    return $null
+  }
+
+  return $null
+}
+
+function Test-AgentFlywheelProcessAlive {
+  param([string]$PidFile)
+
+  $processId = Get-AgentFlywheelProcessId $PidFile
+  if (-not $processId) {
+    return $false
+  }
+
+  return [bool](Get-Process -Id $processId -ErrorAction SilentlyContinue)
+}
+
+function Get-AgentFlywheelPortOwnerProcessId {
+  param([int]$Port)
+
+  if (-not (Get-Command Get-NetTCPConnection -ErrorAction SilentlyContinue)) {
+    return $null
+  }
+
+  $owners =
+    @(Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue |
+      Select-Object -ExpandProperty OwningProcess -Unique)
+
+  if ($owners.Count -gt 1) {
+    throw "Multiple processes are listening on port ${Port}: $($owners -join ', ')"
+  }
+
+  if ($owners.Count -eq 1) {
+    return [int]$owners[0]
+  }
+
+  return $null
+}
+
+function Test-AgentFlywheelPortAvailable {
+  param([int]$Port)
+
+  -not (Get-AgentFlywheelPortOwnerProcessId $Port)
+}
+
+function Test-AgentFlywheelCanInspectPorts {
+  [bool](Get-Command Get-NetTCPConnection -ErrorAction SilentlyContinue)
+}
+
+function Get-AgentFlywheelLastLogLine {
+  param([string]$Path)
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    return ""
+  }
+
+  try {
+    $line =
+      Get-Content -LiteralPath $Path -Tail 40 -ErrorAction Stop |
+      Where-Object { $_ -and $_.Trim() } |
+      Select-Object -Last 1
+
+    return [string]$line
+  } catch {
+    return ""
+  }
+}
+
+function Get-AgentFlywheelFailureReason {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+
+    [Parameter(Mandatory = $true)]
+    [string]$InstanceLogsRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Fallback
+  )
+
+  $stderrPath = Join-Path $InstanceLogsRoot "symphony.stderr.log"
+  $stdoutPath = Join-Path $InstanceLogsRoot "symphony.stdout.log"
+  $stderrLine = Get-AgentFlywheelLastLogLine $stderrPath
+
+  if ($stderrLine) {
+    return "$Name stderr: $stderrLine"
+  }
+
+  $stdoutLine = Get-AgentFlywheelLastLogLine $stdoutPath
+  if ($stdoutLine) {
+    return "$Name stdout: $stdoutLine"
+  }
+
+  return $Fallback
+}
+
+function Wait-AgentFlywheelInstance {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+
+    [Parameter(Mandatory = $true)]
+    [string]$InstanceLogsRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$PidFile,
+
+    [Parameter(Mandatory = $true)]
+    [int]$Port,
+
+    [Parameter(Mandatory = $true)]
+    [int]$TimeoutSeconds
+  )
+
+  $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+  $sawPidFile = $false
+
+  do {
+    if (Test-Path -LiteralPath $PidFile -PathType Leaf) {
+      $sawPidFile = $true
+      $processId = Get-AgentFlywheelProcessId $PidFile
+      $process = $null
+
+      if ($processId) {
+        $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
+      }
+
+      if (-not $process) {
+        $reason = Get-AgentFlywheelFailureReason $Name $InstanceLogsRoot "launcher process exited before port $Port became ready"
+        throw $reason
+      }
+
+      if (Test-AgentFlywheelCanInspectPorts) {
+        $portOwner = Get-AgentFlywheelPortOwnerProcessId $Port
+        if ($portOwner) {
+          return
+        }
+      } else {
+        Write-Warning "Get-NetTCPConnection is unavailable; treating live $Name launcher PID $processId as started."
+        return
+      }
+    }
+
+    Start-Sleep -Milliseconds 500
+  } while ((Get-Date) -lt $deadline)
+
+  $fallback =
+    if ($sawPidFile) {
+      "timed out after ${TimeoutSeconds}s waiting for $Name port $Port to listen"
+    } else {
+      "timed out after ${TimeoutSeconds}s waiting for $Name PID metadata: $PidFile"
+    }
+
+  throw (Get-AgentFlywheelFailureReason $Name $InstanceLogsRoot $fallback)
+}
+
+function Start-AgentFlywheelInstance {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+
+    [Parameter(Mandatory = $true)]
+    [string]$WorkflowPath,
+
+    [Parameter(Mandatory = $true)]
+    [int]$Port,
+
+    [Parameter(Mandatory = $true)]
+    [string]$InstanceLogsRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$PidFile,
+
+    [Parameter(Mandatory = $true)]
+    [string]$StartScript,
+
+    [Parameter(Mandatory = $true)]
+    [int]$StartupTimeoutSeconds,
+
+    [string]$Mise,
+
+    [switch]$TerminalDashboard
+  )
+
+  $arguments = @{
+    WorkflowPath = $WorkflowPath
+    Port = $Port
+    LogsRoot = $InstanceLogsRoot
+    PidFile = $PidFile
+    Background = $true
+  }
+
+  if ($Mise) {
+    $arguments.Mise = $Mise
+  }
+
+  if ($TerminalDashboard) {
+    $arguments.TerminalDashboard = $true
+  }
+
+  Write-Host "Starting $Name Symphony instance..."
+  & $StartScript @arguments
+  Wait-AgentFlywheelInstance `
+    -Name $Name `
+    -InstanceLogsRoot $InstanceLogsRoot `
+    -PidFile $PidFile `
+    -Port $Port `
+    -TimeoutSeconds $StartupTimeoutSeconds
+
+  Write-Host "$Name dashboard: http://127.0.0.1:$Port/"
+  Write-Host "$Name logs: $InstanceLogsRoot"
+  Write-Host "$Name PID metadata: $PidFile"
+}
+
+function Invoke-AgentFlywheelStop {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+
+    [Parameter(Mandatory = $true)]
+    [string]$PidFile,
+
+    [Parameter(Mandatory = $true)]
+    [string]$StopScript
+  )
+
+  try {
+    Write-Host "Stopping $Name Symphony instance..."
+    & $StopScript -PidFile $PidFile -Force
+    return $true
+  } catch {
+    Write-Warning "Unable to stop $Name instance: $($_.Exception.Message)"
+    return $false
+  }
+}
+
+function Write-AgentFlywheelStartupFailure {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Phase,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Reason,
+
+    [Parameter(Mandatory = $true)]
+    [string]$WorkerLogsRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ReviewerLogsRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$WorkerCleanupStatus,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ReviewerCleanupStatus
+  )
+
+  Write-Host "Agent flywheel startup failed."
+  Write-Host "Failure phase: $Phase"
+  Write-Host "Failure reason: $Reason"
+  Write-Host "Worker logs: $WorkerLogsRoot"
+  Write-Host "Reviewer logs: $ReviewerLogsRoot"
+  Write-Host "Worker cleanup: $WorkerCleanupStatus"
+  Write-Host "Reviewer cleanup: $ReviewerCleanupStatus"
+}
+
+function Assert-AgentFlywheelPreflight {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$StartScript,
+
+    [Parameter(Mandatory = $true)]
+    [string]$StopScript,
+
+    [Parameter(Mandatory = $true)]
+    [string]$WorkerWorkflowPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ReviewerWorkflowPath,
+
+    [Parameter(Mandatory = $true)]
+    [int]$WorkerPort,
+
+    [Parameter(Mandatory = $true)]
+    [int]$ReviewerPort,
+
+    [Parameter(Mandatory = $true)]
+    [string]$WorkerPidFile,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ReviewerPidFile,
+
+    [string]$Mise
+  )
+
+  if ($WorkerPort -eq $ReviewerPort) {
+    throw "WorkerPort and ReviewerPort must be different."
+  }
+
+  if ($WorkerPort -le 0 -or $ReviewerPort -le 0) {
+    throw "WorkerPort and ReviewerPort must be positive TCP ports."
+  }
+
+  Assert-AgentFlywheelFile $StartScript "Windows-native start script not found"
+  Assert-AgentFlywheelFile $StopScript "Windows-native stop script not found"
+  Assert-AgentFlywheelFile $WorkerWorkflowPath "Worker workflow file not found. Copy WORKFLOW.optimization.windows.example.md first"
+  Assert-AgentFlywheelFile $ReviewerWorkflowPath "Reviewer workflow file not found. Copy WORKFLOW.optimization.reviewer.windows.example.md first"
+
+  if (-not $env:LINEAR_API_KEY) {
+    $env:LINEAR_API_KEY = [Environment]::GetEnvironmentVariable("LINEAR_API_KEY", "User")
+  }
+
+  if (-not $env:LINEAR_API_KEY) {
+    throw "LINEAR_API_KEY is not set. Store it in the user environment or set it for this PowerShell session."
+  }
+
+  if ($Mise) {
+    if ([System.IO.Path]::IsPathRooted($Mise) -or $Mise.Contains("\") -or $Mise.Contains("/")) {
+      Assert-AgentFlywheelFile $Mise "mise executable not found"
+    } elseif (-not (Get-Command $Mise -ErrorAction SilentlyContinue)) {
+      throw "mise executable not found on PATH: $Mise"
+    }
+  } elseif (-not (Get-Command mise -ErrorAction SilentlyContinue)) {
+    throw "mise was not found on PATH. Install it with: winget install --id jdx.mise -e"
+  }
+
+  if (Test-AgentFlywheelProcessAlive $WorkerPidFile) {
+    throw "Worker PID file points at a running process: $WorkerPidFile"
+  }
+
+  if (Test-AgentFlywheelProcessAlive $ReviewerPidFile) {
+    throw "Reviewer PID file points at a running process: $ReviewerPidFile"
+  }
+
+  if (-not (Test-AgentFlywheelPortAvailable $WorkerPort)) {
+    $owner = Get-AgentFlywheelPortOwnerProcessId $WorkerPort
+    throw "Worker port $WorkerPort is already in use by PID $owner."
+  }
+
+  if (-not (Test-AgentFlywheelPortAvailable $ReviewerPort)) {
+    $owner = Get-AgentFlywheelPortOwnerProcessId $ReviewerPort
+    throw "Reviewer port $ReviewerPort is already in use by PID $owner."
+  }
+}
+
+# Entry point.
+if ($WorkerPort -eq $ReviewerPort) {
+  throw "WorkerPort and ReviewerPort must be different."
+}
+
+$scriptDir = Split-Path -Parent $PSCommandPath
+$elixirRoot = Split-Path -Parent $scriptDir
+$startScript = Join-Path $scriptDir "start-windows-native.ps1"
+$stopScript = Join-Path $scriptDir "stop-windows-native.ps1"
+$resolvedLogsRoot = Resolve-AgentFlywheelPath $LogsRoot $elixirRoot
+$resolvedWorkerWorkflowPath = Resolve-AgentFlywheelPath $WorkerWorkflowPath $elixirRoot
+$resolvedReviewerWorkflowPath = Resolve-AgentFlywheelPath $ReviewerWorkflowPath $elixirRoot
+$workerLogsRoot = Join-Path $resolvedLogsRoot "worker"
+$reviewerLogsRoot = Join-Path $resolvedLogsRoot "reviewer"
+$workerPidFile = Join-Path $resolvedLogsRoot "symphony.worker.pid.json"
+$reviewerPidFile = Join-Path $resolvedLogsRoot "symphony.reviewer.pid.json"
+
+Assert-AgentFlywheelPreflight `
+  -StartScript $startScript `
+  -StopScript $stopScript `
+  -WorkerWorkflowPath $resolvedWorkerWorkflowPath `
+  -ReviewerWorkflowPath $resolvedReviewerWorkflowPath `
+  -WorkerPort $WorkerPort `
+  -ReviewerPort $ReviewerPort `
+  -WorkerPidFile $workerPidFile `
+  -ReviewerPidFile $reviewerPidFile `
+  -Mise $Mise
+
+New-Item -ItemType Directory -Force -Path $resolvedLogsRoot | Out-Null
+
+$workerStarted = $false
+$reviewerStarted = $false
+
+Push-Location $elixirRoot
+try {
+  $workerInstance = @{
+    Name = "worker"
+    WorkflowPath = $resolvedWorkerWorkflowPath
+    Port = $WorkerPort
+    InstanceLogsRoot = $workerLogsRoot
+    PidFile = $workerPidFile
+    StartScript = $startScript
+    StartupTimeoutSeconds = $StartupTimeoutSeconds
+    Mise = $Mise
+    TerminalDashboard = $TerminalDashboard
+  }
+
+  Start-AgentFlywheelInstance @workerInstance
+  $workerStarted = $true
+
+  $reviewerInstance = @{
+    Name = "reviewer"
+    WorkflowPath = $resolvedReviewerWorkflowPath
+    Port = $ReviewerPort
+    InstanceLogsRoot = $reviewerLogsRoot
+    PidFile = $reviewerPidFile
+    StartScript = $startScript
+    StartupTimeoutSeconds = $StartupTimeoutSeconds
+    Mise = $Mise
+    TerminalDashboard = $TerminalDashboard
+  }
+
+  Start-AgentFlywheelInstance @reviewerInstance
+  $reviewerStarted = $true
+} catch {
+  $phase = if ($workerStarted) { "reviewer startup" } else { "worker startup" }
+  $reason = $_.Exception.Message
+  $workerCleanupStatus = if ($workerStarted) { "not attempted" } else { "not needed" }
+  $reviewerCleanupStatus = if ($reviewerStarted) { "not attempted" } else { "not needed" }
+
+  if ($phase -eq "reviewer startup") {
+    $reviewerCleaned = Invoke-AgentFlywheelStop -Name "reviewer" -PidFile $reviewerPidFile -StopScript $stopScript
+    $reviewerCleanupStatus = if ($reviewerCleaned) { "completed" } else { "failed or not running" }
+
+    if ($AllowPartial) {
+      $workerCleanupStatus = "skipped by -AllowPartial"
+      Write-AgentFlywheelStartupFailure `
+        -Phase $phase `
+        -Reason $reason `
+        -WorkerLogsRoot $workerLogsRoot `
+        -ReviewerLogsRoot $reviewerLogsRoot `
+        -WorkerCleanupStatus $workerCleanupStatus `
+        -ReviewerCleanupStatus $reviewerCleanupStatus
+      Write-Warning "Partial startup: worker instance is still running; reviewer failed."
+      return
+    }
+
+    $workerCleaned = Invoke-AgentFlywheelStop -Name "worker" -PidFile $workerPidFile -StopScript $stopScript
+    $workerCleanupStatus = if ($workerCleaned) { "completed" } else { "failed or not running" }
+  } else {
+    $workerCleaned = Invoke-AgentFlywheelStop -Name "worker" -PidFile $workerPidFile -StopScript $stopScript
+    $workerCleanupStatus = if ($workerCleaned) { "completed" } else { "failed or not running" }
+  }
+
+  Write-AgentFlywheelStartupFailure `
+    -Phase $phase `
+    -Reason $reason `
+    -WorkerLogsRoot $workerLogsRoot `
+    -ReviewerLogsRoot $reviewerLogsRoot `
+    -WorkerCleanupStatus $workerCleanupStatus `
+    -ReviewerCleanupStatus $reviewerCleanupStatus
+
+  throw "Agent flywheel startup failed during $phase`: $reason"
+} finally {
+  Pop-Location
+}
+
+Write-Host "Agent flywheel started."
+Write-Host "Worker:   http://127.0.0.1:$WorkerPort/"
+Write-Host "Reviewer: http://127.0.0.1:$ReviewerPort/"

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -261,6 +261,9 @@ defmodule SymphonyElixir.TestSupport do
 
       const rl = readline.createInterface({ input: process.stdin, terminal: false });
 
+      process.stdin.on("end", () => process.exit(0));
+      process.stdin.on("close", () => process.exit(0));
+
       rl.on("line", line => {
         count += 1;
         writeTrace(line);
@@ -373,6 +376,7 @@ defmodule SymphonyElixir.TestSupport do
           codex_command_watchdog_block_on_stall: false,
           codex_review_readiness_repository: nil,
           codex_review_readiness_required_checks: [],
+          codex_review_readiness_guarded_states: ["In Review"],
           hook_after_create: nil,
           hook_before_run: nil,
           hook_after_run: nil,
@@ -421,6 +425,7 @@ defmodule SymphonyElixir.TestSupport do
     codex_command_watchdog_block_on_stall = Keyword.get(config, :codex_command_watchdog_block_on_stall)
     codex_review_readiness_repository = Keyword.get(config, :codex_review_readiness_repository)
     codex_review_readiness_required_checks = Keyword.get(config, :codex_review_readiness_required_checks)
+    codex_review_readiness_guarded_states = Keyword.get(config, :codex_review_readiness_guarded_states)
     hook_after_create = Keyword.get(config, :hook_after_create)
     hook_before_run = Keyword.get(config, :hook_before_run)
     hook_after_run = Keyword.get(config, :hook_after_run)
@@ -473,6 +478,7 @@ defmodule SymphonyElixir.TestSupport do
         "  command_watchdog_block_on_stall: #{yaml_value(codex_command_watchdog_block_on_stall)}",
         "  review_readiness_repository: #{yaml_value(codex_review_readiness_repository)}",
         "  review_readiness_required_checks: #{yaml_value(codex_review_readiness_required_checks)}",
+        "  review_readiness_guarded_states: #{yaml_value(codex_review_readiness_guarded_states)}",
         hooks_yaml(hook_after_create, hook_before_run, hook_after_run, hook_before_remove, hook_timeout_ms),
         observability_yaml(observability_enabled, observability_refresh_ms, observability_render_interval_ms),
         server_yaml(server_port, server_host),

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -276,6 +276,55 @@ defmodule SymphonyElixir.AppServerTest do
     end
   end
 
+  test "app server treats failed turn completion as a hard failure" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-app-server-failed-completion-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-90")
+      codex_binary = Path.join(test_root, "fake-codex")
+      File.mkdir_p!(workspace)
+
+      write_fake_codex!(codex_binary, [
+        ~s({"id":1,"result":{}}),
+        ~s({"id":2,"result":{"thread":{"id":"thread-90"}}}),
+        ~s({"id":3,"result":{"turn":{"id":"turn-90"}}}),
+        ~s({"method":"turn/completed","params":{"turn":{"id":"turn-90","status":"failed","error":{"message":"bad request"}}}})
+      ])
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        codex_command: "#{codex_binary} app-server"
+      )
+
+      issue = %Issue{
+        id: "issue-failed-completion",
+        identifier: "MT-90",
+        title: "Failed turn completion",
+        description: "Ensure app-server failed completion is not treated as success",
+        state: "In Progress",
+        url: "https://example.org/issues/MT-90",
+        labels: ["backend"]
+      }
+
+      test_pid = self()
+      on_message = fn message -> send(test_pid, {:app_server_message, message}) end
+
+      assert {:error, {:turn_failed, reason}} =
+               AppServer.run(workspace, "Fail this turn", issue, on_message: on_message)
+
+      assert reason["status"] == "failed"
+      assert get_in(reason, ["error", "message"]) == "bad request"
+      assert_received {:app_server_message, %{event: :turn_completed}}
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
   test "app server fails when command execution approval is required under safer defaults" do
     test_root =
       Path.join(

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -29,6 +29,7 @@ defmodule SymphonyElixir.CoreTest do
     assert config.agent.max_turns == 20
     assert config.codex.review_readiness_repository == nil
     assert config.codex.review_readiness_required_checks == []
+    assert config.codex.review_readiness_guarded_states == ["In Review"]
 
     write_workflow_file!(Workflow.workflow_file_path(), poll_interval_ms: "invalid")
 
@@ -92,6 +93,12 @@ defmodule SymphonyElixir.CoreTest do
 
     assert Config.settings!().codex.review_readiness_repository == "Albert-Zen/symphony-windows-native"
     assert Config.settings!().codex.review_readiness_required_checks == ["make-all", "windows-native-test"]
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      codex_review_readiness_guarded_states: [" Agent Review ", "", "Agent Review", "Human Review"]
+    )
+
+    assert Config.settings!().codex.review_readiness_guarded_states == ["Agent Review", "Human Review"]
 
     write_workflow_file!(Workflow.workflow_file_path(), codex_review_readiness_repository: "   ")
     assert Config.settings!().codex.review_readiness_repository == nil
@@ -408,8 +415,9 @@ defmodule SymphonyElixir.CoreTest do
         tracker_kind: "memory",
         workspace_root: test_root,
         workspace_startup_cleanup_ttl_ms: 60_000,
-        tracker_active_states: ["Todo", "In Progress", "In Review", "Blocked"],
+        tracker_active_states: ["Todo", "In Progress", "Blocked"],
         tracker_terminal_states: ["Done", "Canceled"],
+        codex_review_readiness_guarded_states: ["Agent Review"],
         poll_interval_ms: 30_000
       )
 
@@ -433,7 +441,7 @@ defmodule SymphonyElixir.CoreTest do
         %Issue{
           id: "issue-active",
           identifier: "MT-ACTIVE",
-          state: "In Review",
+          state: "Agent Review",
           updated_at: DateTime.add(now, -120_000, :millisecond)
         }
       ])
@@ -458,6 +466,7 @@ defmodule SymphonyElixir.CoreTest do
 
       snapshot = Orchestrator.snapshot(orchestrator_name, 1_000)
       assert snapshot.workspace_cleanup.status == :completed
+      assert snapshot.workspace_cleanup.checked == 3
       assert snapshot.workspace_cleanup.cleaned == 1
       assert snapshot.workspace_cleanup.preserved == 2
       assert snapshot.workspace_cleanup.ttl_ms == 60_000
@@ -761,13 +770,7 @@ defmodule SymphonyElixir.CoreTest do
     issue_id = "issue-resume"
     ref = make_ref()
     orchestrator_name = Module.concat(__MODULE__, :ContinuationOrchestrator)
-    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
-
-    on_exit(fn ->
-      if Process.alive?(pid) do
-        Process.exit(pid, :normal)
-      end
-    end)
+    pid = start_memory_orchestrator!(orchestrator_name)
 
     initial_state = :sys.get_state(pid)
 
@@ -803,13 +806,7 @@ defmodule SymphonyElixir.CoreTest do
     issue_id = "issue-crash"
     ref = make_ref()
     orchestrator_name = Module.concat(__MODULE__, :CrashRetryOrchestrator)
-    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
-
-    on_exit(fn ->
-      if Process.alive?(pid) do
-        Process.exit(pid, :normal)
-      end
-    end)
+    pid = start_memory_orchestrator!(orchestrator_name)
 
     initial_state = :sys.get_state(pid)
 
@@ -845,13 +842,7 @@ defmodule SymphonyElixir.CoreTest do
     issue_id = "issue-crash-initial"
     ref = make_ref()
     orchestrator_name = Module.concat(__MODULE__, :InitialCrashRetryOrchestrator)
-    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
-
-    on_exit(fn ->
-      if Process.alive?(pid) do
-        Process.exit(pid, :normal)
-      end
-    end)
+    pid = start_memory_orchestrator!(orchestrator_name)
 
     initial_state = :sys.get_state(pid)
 
@@ -885,13 +876,7 @@ defmodule SymphonyElixir.CoreTest do
   test "stale retry timer messages do not consume newer retry entries" do
     issue_id = "issue-stale-retry"
     orchestrator_name = Module.concat(__MODULE__, :StaleRetryOrchestrator)
-    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
-
-    on_exit(fn ->
-      if Process.alive?(pid) do
-        Process.exit(pid, :normal)
-      end
-    end)
+    pid = start_memory_orchestrator!(orchestrator_name)
 
     initial_state = :sys.get_state(pid)
     current_retry_token = make_ref()
@@ -1043,13 +1028,7 @@ defmodule SymphonyElixir.CoreTest do
     issue_id = "issue-retry-dispatch-crash"
     ref = make_ref()
     orchestrator_name = Module.concat(__MODULE__, :RetryDispatchCrashOrchestrator)
-    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
-
-    on_exit(fn ->
-      if Process.alive?(pid) do
-        Process.exit(pid, :normal)
-      end
-    end)
+    pid = start_memory_orchestrator!(orchestrator_name)
 
     initial_state = :sys.get_state(pid)
 
@@ -1236,6 +1215,25 @@ defmodule SymphonyElixir.CoreTest do
   defp assert_due_in_range(due_at_ms, earliest_ms, latest_ms, min_delay_ms, max_delay_ms) do
     assert due_at_ms >= earliest_ms + min_delay_ms
     assert due_at_ms <= latest_ms + max_delay_ms
+  end
+
+  defp start_memory_orchestrator!(orchestrator_name) do
+    previous_memory_issues = Application.get_env(:symphony_elixir, :memory_tracker_issues)
+
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "memory")
+    Application.put_env(:symphony_elixir, :memory_tracker_issues, [])
+
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+
+      restore_app_env(:memory_tracker_issues, previous_memory_issues)
+    end)
+
+    pid
   end
 
   defp restore_app_env(key, nil), do: Application.delete_env(:symphony_elixir, key)

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -1539,7 +1539,7 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
     assert get_in(payload, ["error", "message"]) =~ "no linked GitHub pull request was found"
     assert_received {:workpad_recorded, body}
     assert body =~ "## Codex Workpad"
-    assert body =~ "In Review transition rejected"
+    assert body =~ "Review readiness transition rejected"
     refute_received {:linear_mutation_allowed, _, _}
   end
 

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -376,6 +376,8 @@ defmodule SymphonyElixir.ExtensionsTest do
     Process.put({FakeLinearClient, :graphql_result}, fn query, variables ->
       cond do
         String.contains?(query, "commentCreate") ->
+          assert variables.body =~ "## Symphony Control"
+          assert variables.body =~ "state: claimed"
           Process.put(:claim_body, variables.body)
 
           {:ok,
@@ -420,6 +422,288 @@ defmodule SymphonyElixir.ExtensionsTest do
              Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
 
     assert is_binary(owner)
+  end
+
+  test "linear adapter creates a fresh control claim when a released control comment exists" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+    released_at = DateTime.add(DateTime.utc_now(), -60, :second)
+    claim_created_at = DateTime.add(released_at, 60, :second)
+
+    control_released =
+      signed_control_release_body(
+        "control-1",
+        "previous-worker",
+        "previous-token",
+        released_at
+      )
+
+    Process.put({FakeLinearClient, :graphql_result}, fn query, variables ->
+      cond do
+        String.contains?(query, "commentCreate") ->
+          assert variables.body =~ "## Symphony Control"
+          assert variables.body =~ "state: claimed"
+          Process.put(:claim_body, variables.body)
+
+          {:ok, %{"data" => %{"commentCreate" => %{"success" => true, "comment" => %{"id" => "control-2"}}}}}
+
+        String.contains?(query, "SymphonyIssueClaimComments") ->
+          nodes =
+            case Process.get(:claim_body) do
+              nil ->
+                [%{"id" => "control-1", "body" => control_released, "createdAt" => DateTime.to_iso8601(released_at)}]
+
+              claim_body ->
+                [
+                  %{"id" => "control-1", "body" => control_released, "createdAt" => DateTime.to_iso8601(released_at)},
+                  %{"id" => "control-2", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claim_created_at)}
+                ]
+            end
+
+          claim_comments(nodes)
+      end
+    end)
+
+    assert {:ok, %{id: "control-2", owner: owner}} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+
+    assert is_binary(owner)
+  end
+
+  test "linear adapter releases by deleting the active control comment" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+
+    claimed_at = DateTime.add(DateTime.utc_now(), -60, :second)
+    expires_at = DateTime.add(claimed_at, 4, :hour)
+    claim_body = signed_control_claim_body("ALB-CLAIM", "worker", "token", claimed_at, expires_at)
+
+    Process.put({FakeLinearClient, :graphql_results}, [
+      claim_comments([%{"id" => "control-1", "body" => claim_body, "createdAt" => "2026-05-02T00:00:00Z"}]),
+      fn query, variables ->
+        assert String.contains?(query, "commentDelete")
+        assert variables.commentId == "control-1"
+
+        {:ok, %{"data" => %{"commentDelete" => %{"success" => true}}}}
+      end
+    ])
+
+    assert :ok = Adapter.release_issue_claim("issue-claim", %{id: "control-1", owner: "worker", token: "token"})
+  end
+
+  test "linear adapter falls back to updating release state when deleting a control comment fails" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+
+    claimed_at = DateTime.add(DateTime.utc_now(), -60, :second)
+    expires_at = DateTime.add(claimed_at, 4, :hour)
+    claim_body = signed_control_claim_body("ALB-CLAIM", "worker", "token", claimed_at, expires_at)
+
+    Process.put({FakeLinearClient, :graphql_results}, [
+      claim_comments([%{"id" => "control-1", "body" => claim_body, "createdAt" => "2026-05-02T00:00:00Z"}]),
+      {:ok, %{"data" => %{"commentDelete" => %{"success" => false}}}},
+      fn query, variables ->
+        assert String.contains?(query, "commentUpdate")
+        assert variables.commentId == "control-1"
+        assert variables.body =~ "## Symphony Control"
+        assert variables.body =~ "state: released"
+        assert variables.body =~ "claim_id: control-1"
+        assert variables.body =~ "owner: worker"
+        assert variables.body =~ "token: token"
+
+        {:ok, %{"data" => %{"commentUpdate" => %{"success" => true, "comment" => %{"id" => "control-1"}}}}}
+      end
+    ])
+
+    assert :ok = Adapter.release_issue_claim("issue-claim", %{id: "control-1", owner: "worker", token: "token"})
+  end
+
+  test "linear adapter falls back to updating release state when deleting a control comment errors" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+
+    claimed_at = DateTime.add(DateTime.utc_now(), -60, :second)
+    expires_at = DateTime.add(claimed_at, 4, :hour)
+
+    for {claim_id, delete_result} <- [
+          {"control-delete-timeout", {:error, :delete_timeout}},
+          {"control-delete-unexpected", :unexpected}
+        ] do
+      claim_body = signed_control_claim_body("ALB-CLAIM", "worker", "token", claimed_at, expires_at)
+
+      Process.put({FakeLinearClient, :graphql_results}, [
+        claim_comments([%{"id" => claim_id, "body" => claim_body, "createdAt" => "2026-05-02T00:00:00Z"}]),
+        delete_result,
+        fn query, variables ->
+          assert String.contains?(query, "commentUpdate")
+          assert variables.commentId == claim_id
+          assert variables.body =~ "state: released"
+          assert variables.body =~ "claim_id: #{claim_id}"
+
+          {:ok, %{"data" => %{"commentUpdate" => %{"success" => true}}}}
+        end
+      ])
+
+      assert :ok = Adapter.release_issue_claim("issue-claim", %{id: claim_id, owner: "worker", token: "token"})
+    end
+  end
+
+  test "linear adapter updates an existing control comment when releasing a legacy visible claim" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+
+    claimed_at = DateTime.add(DateTime.utc_now(), -60, :second)
+    expires_at = DateTime.add(claimed_at, 8, :hour)
+    released_at = DateTime.add(claimed_at, 10, :second)
+    claim_body = signed_claim_body("ALB-CLAIM", "worker", "token", claimed_at, expires_at)
+    other_release = signed_release_body("other-claim", "other-worker", "other-token", released_at)
+
+    control_without_state =
+      [
+        "## Symphony Control",
+        "",
+        "version: v1",
+        "note: previous experimental control record"
+      ]
+      |> Enum.join("\n")
+
+    Process.put({FakeLinearClient, :graphql_results}, [
+      claim_comments([
+        %{"id" => "claim-legacy", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)},
+        %{"id" => "release-other", "body" => other_release, "createdAt" => DateTime.to_iso8601(released_at)},
+        %{"id" => "control-invalid-date", "body" => control_without_state, "createdAt" => "not-a-date"},
+        %{"id" => "control-later", "body" => control_without_state, "createdAt" => "2026-05-02T00:00:00Z"}
+      ]),
+      fn query, variables ->
+        assert String.contains?(query, "commentUpdate")
+        assert variables.commentId == "control-invalid-date"
+        assert variables.body =~ "## Symphony Control"
+        assert variables.body =~ "state: released"
+        assert variables.body =~ "claim_id: claim-legacy"
+        assert variables.body =~ "owner: worker"
+        assert variables.body =~ "token: token"
+
+        {:ok, %{"data" => %{"commentUpdate" => %{"success" => true}}}}
+      end
+    ])
+
+    assert :ok = Adapter.release_issue_claim("issue-claim", %{id: "claim-legacy", owner: "worker", token: "token"})
+  end
+
+  test "linear adapter maps control update failures while releasing legacy visible claims" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+
+    claimed_at = DateTime.add(DateTime.utc_now(), -60, :second)
+    expires_at = DateTime.add(claimed_at, 4, :hour)
+    claim_body = signed_claim_body("ALB-CLAIM", "worker", "token", claimed_at, expires_at)
+    control_body = "## Symphony Control\nstate: stale"
+
+    Process.put({FakeLinearClient, :graphql_results}, [
+      claim_comments([
+        %{"id" => "claim-legacy", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)},
+        %{"id" => "control-update-false", "body" => control_body, "createdAt" => "2026-05-02T00:00:00Z"}
+      ]),
+      {:ok, %{"data" => %{"commentUpdate" => %{"success" => false}}}}
+    ])
+
+    assert {:error, :claim_release_failed} =
+             Adapter.release_issue_claim("issue-claim", %{id: "claim-legacy", owner: "worker", token: "token"})
+
+    Process.put({FakeLinearClient, :graphql_results}, [
+      claim_comments([
+        %{"id" => "claim-legacy", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)},
+        %{"id" => "control-update-error", "body" => control_body, "createdAt" => "2026-05-02T00:00:00Z"}
+      ]),
+      {:error, :update_timeout}
+    ])
+
+    assert {:error, :update_timeout} =
+             Adapter.release_issue_claim("issue-claim", %{id: "claim-legacy", owner: "worker", token: "token"})
+
+    Process.put({FakeLinearClient, :graphql_results}, [
+      claim_comments([
+        %{"id" => "claim-legacy", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)},
+        %{"id" => "control-update-unexpected", "body" => control_body, "createdAt" => "2026-05-02T00:00:00Z"}
+      ]),
+      :unexpected
+    ])
+
+    assert {:error, :claim_release_failed} =
+             Adapter.release_issue_claim("issue-claim", %{id: "claim-legacy", owner: "worker", token: "token"})
+  end
+
+  test "linear adapter verifies only the oldest surviving control claim after concurrent creates" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+
+    competitor_at = DateTime.add(DateTime.utc_now(), -1, :second)
+    own_at = DateTime.utc_now()
+
+    competitor_body =
+      signed_control_claim_body("ALB-CLAIM", "other-worker", "other-token", competitor_at, DateTime.add(competitor_at, 4, :hour))
+
+    Process.put({FakeLinearClient, :graphql_result}, fn query, variables ->
+      cond do
+        String.contains?(query, "commentCreate") ->
+          assert variables.body =~ "## Symphony Control"
+          assert variables.body =~ "state: claimed"
+          Process.put(:own_claim_body, variables.body)
+
+          {:ok, %{"data" => %{"commentCreate" => %{"success" => true, "comment" => %{"id" => "control-own"}}}}}
+
+        String.contains?(query, "commentDelete") ->
+          assert variables.commentId == "control-own"
+          {:ok, %{"data" => %{"commentDelete" => %{"success" => true}}}}
+
+        String.contains?(query, "SymphonyIssueClaimComments") ->
+          nodes =
+            if own_claim_body = Process.get(:own_claim_body) do
+              [
+                %{"id" => "control-other", "body" => competitor_body, "createdAt" => DateTime.to_iso8601(competitor_at)},
+                %{"id" => "control-own", "body" => own_claim_body, "createdAt" => DateTime.to_iso8601(own_at)}
+              ]
+            else
+              []
+            end
+
+          claim_comments(nodes)
+      end
+    end)
+
+    assert {:error, {:issue_claimed, %{id: "control-other", owner: "other-worker", token: "other-token"}}} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
+  end
+
+  test "linear adapter orders control claims by Linear createdAt instead of body claimed_at" do
+    Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
+
+    created_first = DateTime.add(DateTime.utc_now(), -60, :second)
+    created_second = DateTime.add(created_first, 10, :second)
+    body_later_than_second = DateTime.add(created_second, 2, :minute)
+    body_earlier_than_first = DateTime.add(created_first, -2, :minute)
+
+    created_first_body =
+      signed_control_claim_body(
+        "ALB-CLAIM",
+        "created-first",
+        "token-first",
+        body_later_than_second,
+        DateTime.add(body_later_than_second, 4, :hour)
+      )
+
+    created_second_body =
+      signed_control_claim_body(
+        "ALB-CLAIM",
+        "created-second",
+        "token-second",
+        body_earlier_than_first,
+        DateTime.add(created_second, 4, :hour)
+      )
+
+    Process.put(
+      {FakeLinearClient, :graphql_result},
+      claim_comments([
+        %{"id" => "control-created-first", "body" => created_first_body, "createdAt" => DateTime.to_iso8601(created_first)},
+        %{"id" => "control-created-second", "body" => created_second_body, "createdAt" => DateTime.to_iso8601(created_second)}
+      ])
+    )
+
+    assert {:error, {:issue_claimed, %{id: "control-created-first", owner: "created-first", token: "token-first"}}} =
+             Adapter.acquire_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
   end
 
   test "linear adapter rejects dispatch when another unexpired lease is older" do
@@ -479,10 +763,12 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     Process.put({FakeLinearClient, :graphql_results}, [
       claim_comments([%{"id" => "claim-stale", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}]),
+      claim_comments([%{"id" => "claim-stale", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}]),
       fn query, variables ->
         assert String.contains?(query, "commentCreate")
         assert variables.issueId == "issue-claim"
-        assert variables.body =~ "## Symphony Claim Release"
+        assert variables.body =~ "## Symphony Control"
+        assert variables.body =~ "state: released"
         assert variables.body =~ "claim_id: claim-stale"
         assert variables.body =~ "owner: #{owner}"
         assert variables.body =~ "token: stale-token"
@@ -552,8 +838,11 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     Process.put({FakeLinearClient, :graphql_results}, [
       claim_comments([%{"id" => "claim-missing-tasklist", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}]),
+      claim_comments([%{"id" => "claim-missing-tasklist", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}]),
       fn query, variables ->
         assert String.contains?(query, "commentCreate")
+        assert variables.body =~ "## Symphony Control"
+        assert variables.body =~ "state: released"
         assert variables.body =~ "claim_id: claim-missing-tasklist"
 
         {:ok, %{"data" => %{"commentCreate" => %{"success" => true}}}}
@@ -567,8 +856,11 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     Process.put({FakeLinearClient, :graphql_results}, [
       claim_comments([%{"id" => "claim-tasklist-error", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}]),
+      claim_comments([%{"id" => "claim-tasklist-error", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}]),
       fn query, variables ->
         assert String.contains?(query, "commentCreate")
+        assert variables.body =~ "## Symphony Control"
+        assert variables.body =~ "state: released"
         assert variables.body =~ "claim_id: claim-tasklist-error"
 
         {:ok, %{"data" => %{"commentCreate" => %{"success" => true}}}}
@@ -583,8 +875,11 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     Process.put({FakeLinearClient, :graphql_results}, [
       claim_comments([%{"id" => "claim-missing-pid", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}]),
+      claim_comments([%{"id" => "claim-missing-pid", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}]),
       fn query, variables ->
         assert String.contains?(query, "commentCreate")
+        assert variables.body =~ "## Symphony Control"
+        assert variables.body =~ "state: released"
         assert variables.body =~ "claim_id: claim-missing-pid"
         assert variables.body =~ "token: missing-pid-token"
 
@@ -630,6 +925,7 @@ defmodule SymphonyElixir.ExtensionsTest do
     claim_body = signed_claim_body("ALB-CLAIM", owner, "stale-token", claimed_at, expires_at)
 
     Process.put({FakeLinearClient, :graphql_results}, [
+      claim_comments([%{"id" => "claim-stale", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}]),
       claim_comments([%{"id" => "claim-stale", "body" => claim_body, "createdAt" => DateTime.to_iso8601(claimed_at)}]),
       {:ok, %{"data" => %{"commentCreate" => %{"success" => false}}}}
     ])
@@ -809,11 +1105,10 @@ defmodule SymphonyElixir.ExtensionsTest do
        }},
       {:error, :linear_timeout},
       fn query, variables ->
-        assert String.contains?(query, "commentCreate")
-        assert variables.body =~ "## Symphony Claim Release"
-        assert variables.body =~ "token:"
+        assert String.contains?(query, "SymphonyIssueClaimComments")
+        assert variables.issueId == "issue-claim"
 
-        {:ok, %{"data" => %{"commentCreate" => %{"success" => true}}}}
+        empty_claim_comments()
       end
     ])
 
@@ -838,20 +1133,30 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert {:error, :recovery_timeout} =
              Adapter.recover_stale_issue_claim(%Issue{id: "issue-claim", identifier: "ALB-CLAIM"})
 
-    Process.put(
-      {FakeLinearClient, :graphql_result},
+    visible_claimed_at = DateTime.add(DateTime.utc_now(), -60, :second)
+    visible_expires_at = DateTime.add(visible_claimed_at, 4, :hour)
+    visible_claim = signed_claim_body("ALB-CLAIM", "worker", "token", visible_claimed_at, visible_expires_at)
+
+    Process.put({FakeLinearClient, :graphql_results}, [
+      claim_comments([%{"id" => "claim-1", "body" => visible_claim, "createdAt" => DateTime.to_iso8601(visible_claimed_at)}]),
       {:ok, %{"data" => %{"commentCreate" => %{"success" => false}}}}
-    )
+    ])
 
     assert {:error, :claim_release_failed} =
              Adapter.release_issue_claim("issue-claim", %{id: "claim-1", owner: "worker", token: "token"})
 
-    Process.put({FakeLinearClient, :graphql_result}, {:error, :release_timeout})
+    Process.put({FakeLinearClient, :graphql_results}, [
+      claim_comments([%{"id" => "claim-1", "body" => visible_claim, "createdAt" => DateTime.to_iso8601(visible_claimed_at)}]),
+      {:error, :release_timeout}
+    ])
 
     assert {:error, :release_timeout} =
              Adapter.release_issue_claim("issue-claim", %{id: "claim-1", owner: "worker", token: "token"})
 
-    Process.put({FakeLinearClient, :graphql_result}, :unexpected)
+    Process.put({FakeLinearClient, :graphql_results}, [
+      claim_comments([%{"id" => "claim-1", "body" => visible_claim, "createdAt" => DateTime.to_iso8601(visible_claimed_at)}]),
+      :unexpected
+    ])
 
     assert {:error, :claim_release_failed} =
              Adapter.release_issue_claim("issue-claim", %{id: "claim-1", owner: "worker", token: "token"})
@@ -4188,8 +4493,16 @@ defmodule SymphonyElixir.ExtensionsTest do
     Adapter.claim_body_for_test(identifier, owner, token, claimed_at, expires_at)
   end
 
+  defp signed_control_claim_body(identifier, owner, token, claimed_at, expires_at) do
+    Adapter.control_claim_body_for_test(identifier, owner, token, claimed_at, expires_at)
+  end
+
   defp signed_release_body(claim_id, owner, token, released_at) do
     Adapter.release_body_for_test(claim_id, owner, token, released_at)
+  end
+
+  defp signed_control_release_body(claim_id, owner, token, released_at) do
+    Adapter.control_release_body_for_test(claim_id, owner, token, released_at)
   end
 
   defp test_hostname do

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -1573,8 +1573,11 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
     Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
 
+    test_pid = self()
+
     Application.put_env(:symphony_elixir, :orchestrator_status_fake_linear,
       fetch_candidate_issues: fn ->
+        send(test_pid, :startup_poll_started)
         Process.sleep(100)
         {:ok, []}
       end
@@ -1589,18 +1592,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       end
     end)
 
-    assert %{polling: %{checking?: true}} =
-             wait_for_snapshot(
-               pid,
-               fn
-                 %{polling: %{checking?: true}} ->
-                   true
-
-                 _ ->
-                   false
-               end,
-               500
-             )
+    assert_receive :startup_poll_started, 500
 
     assert %{
              polling: %{

--- a/elixir/test/symphony_elixir/review_readiness_test.exs
+++ b/elixir/test/symphony_elixir/review_readiness_test.exs
@@ -3,6 +3,66 @@ defmodule SymphonyElixir.Codex.ReviewReadinessTest do
 
   alias SymphonyElixir.Codex.ReviewReadiness
 
+  test "configured guarded states control which Linear transitions require review readiness" do
+    write_workflow_file!(Workflow.workflow_file_path(),
+      codex_review_readiness_guarded_states: ["Agent Review"]
+    )
+
+    parent = self()
+    linear_client = review_state_linear_client(parent)
+
+    github_client = fn url, _opts ->
+      send(parent, {:github_called, url})
+      {:error, :unexpected_github_call}
+    end
+
+    assert {:error, {:review_readiness_rejected, payload}} =
+             ReviewReadiness.authorize_linear_graphql(
+               state_transition_mutation(),
+               %{"issueId" => "issue-1", "stateId" => "state-agent-review"},
+               linear_client,
+               github_client
+             )
+
+    assert payload["error"]["message"] =~ "Linear review readiness transition rejected"
+    assert payload["error"]["message"] =~ "no linked GitHub pull request"
+    assert_receive {:linear_context_requested, "issue-1"}
+    assert_receive {:linear_workpad_created, body}
+    assert body =~ "Review readiness transition rejected"
+    refute_receive {:github_called, _url}
+
+    assert :ok =
+             ReviewReadiness.authorize_linear_graphql(
+               state_transition_mutation(),
+               %{"issueId" => "issue-1", "stateId" => "state-in-review"},
+               linear_client,
+               github_client
+             )
+
+    assert_receive {:linear_context_requested, "issue-1"}
+    refute_receive {:linear_workpad_created, _body}
+    refute_receive {:github_called, _url}
+  end
+
+  test "default review readiness guard remains In Review for compatibility" do
+    parent = self()
+
+    assert {:error, {:review_readiness_rejected, _payload}} =
+             ReviewReadiness.authorize_linear_graphql(
+               state_transition_mutation(),
+               %{"issueId" => "issue-1", "stateId" => "state-in-review"},
+               review_state_linear_client(parent),
+               fn url, _opts ->
+                 send(parent, {:github_called, url})
+                 {:error, :unexpected_github_call}
+               end
+             )
+
+    assert_receive {:linear_context_requested, "issue-1"}
+    assert_receive {:linear_workpad_created, _body}
+    refute_receive {:github_called, _url}
+  end
+
   test "github_get uses GitHub CLI auth token when env tokens are absent" do
     previous_github_token = System.get_env("GITHUB_TOKEN")
     previous_gh_token = System.get_env("GH_TOKEN")
@@ -130,6 +190,61 @@ defmodule SymphonyElixir.Codex.ReviewReadinessTest do
 
       File.chmod!(path, 0o755)
     end
+  end
+
+  defp state_transition_mutation do
+    """
+    mutation UpdateIssue($issueId: String!, $stateId: String!) {
+      issueUpdate(id: $issueId, input: {stateId: $stateId}) {
+        success
+      }
+    }
+    """
+  end
+
+  defp review_state_linear_client(parent) do
+    fn
+      query, %{"issueId" => issue_id, "body" => body}, _opts when is_binary(query) ->
+        if String.contains?(query, "commentCreate") do
+          send(parent, {:linear_workpad_created, body})
+          {:ok, %{"data" => %{"commentCreate" => %{"success" => true}}}}
+        else
+          {:error, {:unexpected_linear_query, query, issue_id}}
+        end
+
+      query, %{"issueId" => issue_id}, _opts when is_binary(query) ->
+        if String.contains?(query, "SymphonyReviewReadinessContext") do
+          send(parent, {:linear_context_requested, issue_id})
+          {:ok, review_state_issue_context(issue_id)}
+        else
+          {:error, {:unexpected_linear_query, query}}
+        end
+
+      query, variables, _opts ->
+        {:error, {:unexpected_linear_query, query, variables}}
+    end
+  end
+
+  defp review_state_issue_context(issue_id) do
+    %{
+      "data" => %{
+        "issue" => %{
+          "id" => issue_id,
+          "identifier" => "ALB-1",
+          "description" => nil,
+          "team" => %{
+            "states" => %{
+              "nodes" => [
+                %{"id" => "state-agent-review", "name" => "Agent Review"},
+                %{"id" => "state-in-review", "name" => "In Review"}
+              ]
+            }
+          },
+          "attachments" => %{"nodes" => []},
+          "comments" => %{"nodes" => []}
+        }
+      }
+    }
   end
 
   defp capture_http_request! do

--- a/elixir/test/symphony_elixir/windows_lifecycle_scripts_test.exs
+++ b/elixir/test/symphony_elixir/windows_lifecycle_scripts_test.exs
@@ -23,6 +23,7 @@ defmodule SymphonyElixir.WindowsLifecycleScriptsTest do
   test "Windows lifecycle scripts parse in PowerShell" do
     for script <- [
           "start-windows-native.ps1",
+          "start-agent-flywheel.ps1",
           "stop-windows-native.ps1",
           "install-windows-native-service.ps1",
           "cleanup-windows-native.ps1"
@@ -37,6 +38,60 @@ defmodule SymphonyElixir.WindowsLifecycleScriptsTest do
                  "-Command",
                  command
                ])
+    end
+  end
+
+  test "agent flywheel start script is all-or-nothing by default with explicit partial mode" do
+    script = File.read!(script_path("start-agent-flywheel.ps1"))
+
+    assert script =~ "[switch]$AllowPartial"
+    assert script =~ "Wait-AgentFlywheelInstance"
+    assert script =~ "Assert-AgentFlywheelPreflight"
+    assert script =~ "Test-AgentFlywheelProcessAlive"
+    assert script =~ "Test-AgentFlywheelPortAvailable"
+    assert script =~ "Get-NetTCPConnection"
+    assert script =~ "Invoke-AgentFlywheelStop -Name \"worker\""
+    assert script =~ "Worker cleanup:"
+    assert script =~ "Reviewer cleanup:"
+    assert script =~ "Failure phase:"
+    assert script =~ "Failure reason:"
+    assert script =~ "Partial startup: worker instance is still running; reviewer failed."
+    assert script =~ "LINEAR_API_KEY"
+  end
+
+  test "agent flywheel failure reason prefers reviewer stderr log" do
+    script = script_path("start-agent-flywheel.ps1")
+
+    logs_root =
+      Path.join(System.tmp_dir!(), "symphony-flywheel-logs-#{System.unique_integer([:positive])}")
+
+    command = """
+    $script = Get-Content -Raw -LiteralPath #{shell_quote(script)}
+    $entrypoint = $script.IndexOf('# Entry point.')
+    if ($entrypoint -lt 0) { throw 'flywheel script entrypoint marker not found' }
+    $helpers = $script.Substring(0, $entrypoint)
+    . ([scriptblock]::Create($helpers))
+
+    New-Item -ItemType Directory -Force -Path #{shell_quote(logs_root)} | Out-Null
+    Set-Content -LiteralPath (Join-Path #{shell_quote(logs_root)} 'symphony.stderr.log') -Value @('first', 'reviewer failed because port is occupied')
+
+    $reason = Get-AgentFlywheelFailureReason 'reviewer' #{shell_quote(logs_root)} 'fallback reason'
+    if ($reason -ne 'reviewer stderr: reviewer failed because port is occupied') {
+      throw "unexpected reason: $reason"
+    }
+    """
+
+    try do
+      assert {"", 0} =
+               run_powershell!([
+                 "-NoProfile",
+                 "-ExecutionPolicy",
+                 "Bypass",
+                 "-Command",
+                 command
+               ])
+    after
+      File.rm_rf(logs_root)
     end
   end
 

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -1189,6 +1189,22 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert Config.settings!().worker.max_concurrent_agents_per_host == 2
   end
 
+  test "config supports review readiness guarded states" do
+    assert Config.settings!().codex.review_readiness_guarded_states == ["In Review"]
+    assert Config.review_readiness_guarded_state?("In Review")
+    refute Config.review_readiness_guarded_state?("Agent Review")
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      codex_review_readiness_guarded_states: ["Agent Review", "Human Review", ""]
+    )
+
+    assert Config.settings!().codex.review_readiness_guarded_states == ["Agent Review", "Human Review"]
+    assert Config.review_readiness_guarded_state?(" agent review ")
+    assert Config.review_readiness_guarded_state?("Human Review")
+    refute Config.review_readiness_guarded_state?("In Review")
+    refute Config.review_readiness_guarded_state?(:not_a_state)
+  end
+
   test "schema helpers cover custom type and state limit validation" do
     assert StringOrMap.type() == :map
     assert StringOrMap.embed_as(:json) == :self
@@ -1478,8 +1494,9 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
     assert {:ok, workflow} = Workflow.load(path)
     assert {:ok, settings} = Schema.parse(workflow.config)
-    assert settings.tracker.dispatch_states == ["Todo"]
+    assert settings.tracker.dispatch_states == ["Ready for Agent", "Rework"]
     assert settings.codex.review_readiness_required_checks == ["make-all", "validate-pr-description", "windows-native-test"]
+    assert settings.codex.review_readiness_guarded_states == ["Agent Review"]
 
     assert workflow.prompt =~ "## Codex Workpad"
     assert workflow.prompt =~ "capability/preflight evidence"
@@ -1504,13 +1521,32 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
         identifier: "ALB-1",
         title: "Render configured repository",
         description: "Template should not hard-code the Symphony repository.",
-        state: "Todo",
+        state: "Ready for Agent",
         url: "https://linear.example/ALB-1",
         labels: []
       })
 
     assert prompt =~ "https://github.com/YOUR_GITHUB_OWNER/YOUR_REPO/pull/<number>"
     assert prompt =~ "project `YOUR_LINEAR_PROJECT_NAME`"
+  end
+
+  test "optimization reviewer Windows workflow example parses as review-only queue" do
+    path = Path.expand(Path.join([__DIR__, "..", "..", "WORKFLOW.optimization.reviewer.windows.example.md"]))
+
+    assert {:ok, workflow} = Workflow.load(path)
+    assert {:ok, settings} = Schema.parse(workflow.config)
+    assert settings.tracker.dispatch_states == ["Agent Review"]
+    assert settings.tracker.active_states == ["Agent Review"]
+    assert settings.tracker.terminal_states == ["Human Review", "Rework", "Needs Human Context", "Blocked", "Done", "Canceled", "Cancelled", "Duplicate"]
+    assert settings.codex.review_readiness_guarded_states == ["Agent Review"]
+
+    assert workflow.prompt =~ "temporary verification edits inside the reviewer workspace"
+    assert workflow.prompt =~ "Do not push reviewer edits"
+    assert workflow.prompt =~ "Standards Review"
+    assert workflow.prompt =~ "Spec Review"
+    assert workflow.prompt =~ "`Human Review`"
+    assert workflow.prompt =~ "`Rework`"
+    assert workflow.prompt =~ "`Needs Human Context`"
   end
 
   test "workflow prompt is used when building base prompt" do


### PR DESCRIPTION
#### Context

Automates the repo's Linear -> worker -> reviewer flywheel with explicit agent-ready states, portable docs, safer claim comments, and Windows two-instance startup.

#### TL;DR

*Add worker/reviewer flywheel templates, state guards, Linear control claims, and launcher.*

#### Summary

- Added configurable review-readiness guarded states for Agent Review.
- Reworked Linear durable claims to use transient Symphony Control comments.
- Added all-or-nothing Windows launcher for worker and reviewer instances.
- Documented portable issue states, worker duties, and review policy.

#### Alternatives

- Keep Todo/In Review as queues: rejected because it mixes human and agent work.
- Use one mutable Linear comment as a lock: rejected because Linear has no CAS.
- Keep separate claim/release comments: rejected because it creates Linear noise.

#### Test Plan

- [x] `make -C elixir all` (`cd elixir; make all` on Windows): 591 tests, 0 failures, coverage 95.42%, Dialyzer 0.
- [x] `mise exec -- mix test test/symphony_elixir/core_test.exs`: 52 tests, 0 failures, 1 skipped.
- [x] Real Linear smoke `ALB-71`: Ready for Agent -> In Progress -> Agent Review -> Human Review with one Workpad comment.